### PR TITLE
Add helm require statements

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -41,6 +41,8 @@
 
 (require 'projectile)
 (require 'helm-config)
+(require 'helm-locate)
+(require 'helm-buffers)
 
 (defun helm-c-projectile-files-list ()
   "Generates a list of files in the current project"


### PR DESCRIPTION
helm-c-buffer-map and helm-generic-files-map were undefined before on my setup (not sure why).  This seems to fix that, although I'm not sure whether it's the "right way."  
