### PR TITLE
Require grep in order for grep ignore variables to exist.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -200,6 +200,7 @@
                            (buffer-substring (region-beginning) (region-end))
                          (read-string "Search for: " (thing-at-point 'symbol))))
         (root-dir (projectile-get-project-root)))
+    (require 'grep)
     (let ((grep-find-ignored-directories (append projectile-ignored-directories grep-find-ignored-directories))
           (grep-find-ignored-files (append projectile-ignored-files grep-find-ignored-files)))
       (grep-compute-defaults)


### PR DESCRIPTION
Found a bug in the code from the previous pull request. 

If `rgrep` has not been called prior to invoking `projectile-grep`, the `grep-find-ignored-*` variables are not defined due to autoloading of grep. I therefor added an explicit require of grep inside `projectile-grep`.

I'm pretty new to autoloads and elisp in general. Can you see a better solution?
