### PR TITLE
typo in function name

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -342,7 +342,7 @@ directory is assumed to be the project root otherwise."
         (define-key prefix-map (kbd "i") 'projectile-invalidate-cache)
         (define-key prefix-map (kbd "t") 'projectile-regenerate-tags)
         (define-key prefix-map (kbd "k") 'projectile-kill-buffers)
-        (define-key prefix-map (kdb "d") 'projectile-dired)
+        (define-key prefix-map (kbd "d") 'projectile-dired)
 
         (define-key map projectile-keymap-prefix prefix-map))
       map)


### PR DESCRIPTION
cause of this typo loading fails with `Symbol's function definition is void: kdb`
