### PR TITLE
Fix for typo

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -110,7 +110,6 @@ the current directory the project root."
 (defvar projectile-ignored-file-extensions
   '("class" "o" "so" "elc" "beam" "png" "jpg" "jpeg")
   "A list of file extensions ignored by projectile.")
-  "A list of file extensions ignored by projectile.")
 
 (defvar projectile-project-compilation-commands '(("./rebar compile" . (lambda (dir)
                                                                          (file-exists-p


### PR DESCRIPTION
It seems that there was a rebase artefact in the code under the line

https://github.com/gleber/projectile/blob/improve-erlang-support/projectile.el#L113

Sorry about that!
