### PR TITLE
move .projectile earlier in projectile-project-root-files list

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -96,7 +96,7 @@ the current directory the project root."
 
 ;; variables
 (defvar projectile-project-root-files
-  '(".git" ".hg" ".bzr" "_darcs" ".projectile" "rebar.config" "pom.xml" "build.sbt" "Gemfile")
+  '(".projectile" ".git" ".hg" ".bzr" "_darcs" "rebar.config" "pom.xml" "build.sbt" "Gemfile")
   "A list of files considered to mark the root of a project.")
 
 (defvar projectile-globally-ignored-files


### PR DESCRIPTION
This allows to overwrite project root in case multiple smaller
projects are stored in one git repository. Previously, since
projectile-project-root does depth first search it will always find a
top level .git directory.
