### PR TITLE
projectile-ignored-files has no effect on `find` result

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -283,11 +283,9 @@ directory is assumed to be the project root otherwise."
 
 (defun projectile-ignored-files ()
   "Return list of ignored files."
-  (mapcar
-   'projectile-expand-root
    (append
     projectile-globally-ignored-files
-    (projectile-project-ignored-files))))
+    (projectile-project-ignored-files)))
 
 (defun projectile-ignored-directories ()
   "Return list of ignored directories."


### PR DESCRIPTION
When invoke projectile-grep, find command report a warning like:

find: warning: Unix filenames usually don't contain slashes (though pathnames do).  That means that '-name "/home/sliim/projects/SLiib/TAGS/"' will probably evaluate to false all the time on this system.

Therefore these files aren't ignored..
