### PR TITLE
Fix crash in projectile-find-file from magit

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -193,8 +193,9 @@ The current directory is assumed to be the project's root otherwise."
       (if projectile-use-native-indexing
           (setq files-list (projectile-index-directory directory patterns))
         ;; use external tools to get the project files
-        (let ((current-dir (or (file-name-directory (buffer-file-name))
-                               default-directory)))
+        (let ((current-dir (if (buffer-file-name)
+                               (file-name-directory (buffer-file-name))
+                             default-directory)))
           ;; the shell commands need to invoked in the project's root dir
           (cd (projectile-project-root))
           (setq files-list (projectile-get-repo-files))


### PR DESCRIPTION
In a magit buffer, I can't call projectile-find-file. I get the traceback:

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  file-name-directory(nil)
  (or (file-name-directory (buffer-file-name)) default-directory)
  (let ((current-dir (or (file-name-directory (buffer-file-name)) default-directory))) (cd (projectile-project-root)) (setq files-list (projectile-get-repo-files)) (message current-dir) (cd current-dir))
  (if projectile-use-native-indexing (setq files-list (projectile-index-directory directory patterns)) (let ((current-dir (or (file-name-directory (buffer-file-name)) default-directory))) (cd (projectile-project-root)) (setq files-list (projectile-get-repo-files)) (message current-dir) (cd current-dir)))
  (if files-list nil (message "Projectile is indexing %s. This may take a while." (propertize directory (quote face) (quote font-lock-keyword-face))) (if projectile-use-native-indexing (setq files-list (projectile-index-directory directory patterns)) (let ((current-dir (or (file-name-directory (buffer-file-name)) default-directory))) (cd (projectile-project-root)) (setq files-list (projectile-get-repo-files)) (message current-dir) (cd current-dir))) (projectile-cache-project directory files-list))
  (unless files-list (message "Projectile is indexing %s. This may take a while." (propertize directory (quote face) (quote font-lock-keyword-face))) (if projectile-use-native-indexing (setq files-list (projectile-index-directory directory patterns)) (let ((current-dir (or (file-name-directory (buffer-file-name)) default-directory))) (cd (projectile-project-root)) (setq files-list (projectile-get-repo-files)) (message current-dir) (cd current-dir))) (projectile-cache-project directory files-list))
  (let ((files-list (and projectile-enable-caching (gethash directory projectile-projects-cache))) (patterns (projectile-rel-patterns))) (unless files-list (message "Projectile is indexing %s. This may take a while." (propertize directory (quote face) (quote font-lock-keyword-face))) (if projectile-use-native-indexing (setq files-list (projectile-index-directory directory patterns)) (let ((current-dir (or (file-name-directory ...) default-directory))) (cd (projectile-project-root)) (setq files-list (projectile-get-repo-files)) (message current-dir) (cd current-dir))) (projectile-cache-project directory files-list)) files-list)
  projectile-project-files("~/work/web/")
  projectile-current-project-files()
  (projectile-hashify-files (projectile-current-project-files))
  (let* ((project-files (projectile-hashify-files (projectile-current-project-files))) (file (projectile-completing-read "File file: " (projectile-hash-keys project-files)))) (find-file (gethash file project-files)))
  projectile-find-file(nil)
  call-interactively(projectile-find-file nil nil)
```

This is because of this line in projectile.el:

```
(or (file-name-directory (buffer-file-name))
                           default-directory)
```

which assumes that buffer-file-name is never nil. Fix enclosed.
