### PR TITLE
Only load cache at projectile load time

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -141,10 +141,11 @@ Otherwise consider the current directory the project root."
   "A list of pairs of commands and prerequisite lambdas to perform project compilation.")
 
 (defvar projectile-projects-cache
-  (when (file-exists-p projectile-cache-file)
+  (if (file-exists-p projectile-cache-file)
     (with-temp-buffer
       (insert-file-contents projectile-cache-file)
-      (read (buffer-string))))
+      (read (buffer-string)))
+    (make-hash-table :test 'equal))
   "A hashmap used to cache project file names to speed up related operations.")
 
 (defun projectile-version ()


### PR DESCRIPTION
Previously the cache file was loaded and evaluated everytime the major
mode was changed.  When using some other libraries, major modes change
a lot. For example, this mean that everytime I used `smex` or
`iswitchb-buffer`, I would have a long delay while the cache file was
loaded.

There's no real need to load each time a major mode changes, the only
regression would be a stale cache if the file was modified by a
separate process. I don't suspect anybody will hit that situation.
