### PR TITLE
Use print0 for find in generic/SVN commands

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -226,12 +226,12 @@ The current directory is assumed to be the project's root otherwise."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-svn-command "find . -type f"
+(defcustom projectile-svn-command "find . -type f -print0"
   "Command used by projectile to get the files in a svn project."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-generic-command "find . -type f"
+(defcustom projectile-generic-command "find . -type f -print0"
   "Command used by projectile to get the files in a generic project."
   :group 'projectile
   :type 'string)


### PR DESCRIPTION
A command's output is split by '\0' - this means the `find` command
needs the `-print0` flag to work properly.
