### PR TITLE
Regenerate tags function excludes directories listed in .projectile file

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -615,6 +615,7 @@ project-root for every file."
     (call-interactively projectile-ack-function)))
 
 (defun projectile-tags-exclude-patterns ()
+  "Return a string with exclude patterns for ctags."
   (mapconcat (lambda (pattern) (format "--exclude=%s" pattern))
 	     (projectile-project-ignored-directories) " "))
 


### PR DESCRIPTION
Paths in .projectile file that start with / are passed to ctags through "--exclude" option. Thus tags are not generated for these directories.
