### PR TITLE
Automatically integrate helm into projectile

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -110,7 +110,7 @@
 
 ;;;###autoload
 (eval-after-load 'projectile
-    (define-key projectile-mode-map (kbd "C-c p h") 'helm-projectile))
+    '(define-key projectile-mode-map (kbd "C-c p h") 'helm-projectile))
 
 (provide 'helm-projectile)
 ;;; helm-projectile.el ends here


### PR DESCRIPTION
Currently one needs to explicitly `(require 'helm-projectile)` or call the function with `M-x` to make this keybinding available, which is not exactly convenient.

Add `helm-projectile` to the Projectile key map automatically after Projectile was loaded to make things work more nicely.
