### PR TITLE
Update projectile.el

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -668,7 +668,8 @@ With a prefix ARG invalidates the cache first."
         (search-regexp (if (and transient-mark-mode mark-active)
                            (buffer-substring (region-beginning) (region-end))
                          (read-string (projectile-prepend-project-name "Grep for: ")
-                                      (substring-no-properties (thing-at-point 'symbol))))))
+                                      (substring-no-properties (or (thing-at-point 'symbol)
+                                                                   ""))))))
     (dolist (root-dir roots)
       (require 'grep)
       ;; paths for find-grep should relative and without trailing /


### PR DESCRIPTION
fixed `projectile-grep` when point is on whitespace, should fix #120
