### PR TITLE
PHP Symfony2 project support

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -573,6 +573,7 @@ With a prefix ARG invalidates the cache first."
 
 (defvar projectile-rails-rspec '("Gemfile" "app" "lib" "db" "config" "spec"))
 (defvar projectile-rails-test '("Gemfile" "app" "lib" "db" "config" "test"))
+(defvar projectile-symfony '("composer.json" "app" "src" "vendor"))
 (defvar projectile-ruby-rspec '("Gemfile" "lib" "pkg" "spec"))
 (defvar projectile-ruby-test '("Gemfile" "lib" "pkg" "test"))
 (defvar projectile-maven '("pom.xml"))
@@ -588,6 +589,7 @@ With a prefix ARG invalidates the cache first."
      ((projectile-verify-files projectile-rails-test) 'rails-test)
      ((projectile-verify-files projectile-ruby-rspec) 'ruby-rspec)
      ((projectile-verify-files projectile-ruby-test) 'ruby-test)
+     ((projectile-verify-files projectile-symfony) 'symfony)
      ((projectile-verify-files projectile-maven) 'maven)
      ((projectile-verify-files projectile-lein) 'lein)
      ((projectile-verify-files projectile-rebar) 'rebar)
@@ -638,7 +640,7 @@ With a prefix ARG invalidates the cache first."
   (cond
    ((member project-type '(rails-rspec ruby-rspec)) "_spec")
    ((member project-type '(rails-test ruby-test lein)) "_test")
-   ((member project-type '(maven)) "Test")
+   ((member project-type '(maven symfony)) "Test")
    (t (error "Project type not supported!"))))
 
 (defun projectile-find-matching-test (file)
@@ -760,6 +762,8 @@ With a prefix ARG invalidates the cache first."
 (defvar projectile-ruby-compile-cmd "bundle exec rake")
 (defvar projectile-ruby-test-cmd "bundle rake test")
 (defvar projectile-ruby-rspec-cmd "bundle exec rspec")
+(defvar projectile-symfony-compile-cmd "app/console server:run")
+(defvar projectile-symfony-test-cmd "phpunit -c app ")
 (defvar projectile-maven-compile-cmd "mvn clean install")
 (defvar projectile-maven-test-cmd "mvn test")
 (defvar projectile-lein-compile-cmd "lein compile")
@@ -781,6 +785,7 @@ With a prefix ARG invalidates the cache first."
   (cond
    ((member project-type '(rails-rspec rails-test)) projectile-rails-compile-cmd)
    ((member project-type '(ruby-rspec ruby-test)) projectile-ruby-compile-cmd)
+   ((eq project-type 'symfony) projectile-symfony-compile-cmd)
    ((eq project-type 'lein) projectile-lein-compile-cmd)
    ((eq project-type 'make) projectile-make-compile-cmd)
    ((eq project-type 'rebar) projectile-rebar-compile-cmd)
@@ -792,6 +797,7 @@ With a prefix ARG invalidates the cache first."
   (cond
    ((member project-type '(rails-rspec ruby-rspec)) projectile-ruby-rspec-cmd)
    ((member project-type '(rails-test ruby-test)) projectile-ruby-test-cmd)
+   ((eq project-type 'symfony) projectile-symfony-test-cmd)
    ((eq project-type 'lein) projectile-lein-test-cmd)
    ((eq project-type 'make) projectile-make-test-cmd)
    ((eq project-type 'rebar) projectile-rebar-test-cmd)


### PR DESCRIPTION
It has project detection based on Symfony2 (>2.1, composer powered)  source tree, FileName.php tests are switched to FileNameTest.php in related Tests directory (it is resolved by projectile)

Check it out if I'm not omit something (I've based it on rails-test project)
