### PR TITLE
Fix type of projectile-keymap-prefix

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -85,7 +85,7 @@ Otherwise consider the current directory the project root."
 (defcustom projectile-keymap-prefix (kbd "C-c p")
   "Projectile keymap prefix."
   :group 'projectile
-  :type 'sexp)
+  :type 'string)
 
 (defcustom projectile-cache-file
   (expand-file-name "projectile.cache" user-emacs-directory)


### PR DESCRIPTION
This variable is a string actually.
