### PR TITLE
Fix filename prefix chop when not in project

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1013,7 +1013,7 @@ with a prefix ARG."
 This command will first prompt for the directory the file is in."
   (interactive)
   (let* ((directory (read-directory-name "Find file in directory: "))
-         (default-directory directory)
+         (default-directory (file-truename directory))
          (projectile-require-project-root nil))
     (projectile-find-file)))
 


### PR DESCRIPTION
The value returned by `read-directory-name` is begin with `~`, and the filename returned by `projectile-dir-files-external` is begin with `/home`, the filename prefix won't get properly choped.

UPDATE: I didn't get it, what's the value of this function, you can just use `ido-find-file` and it does a better work. And I'm very confused why this function returns the same result as `projectile-find-file` when invoked in a project.
