### PR TITLE
Add -R argument to default projectile-bzr-command

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -382,7 +382,7 @@ Files are returned as relative paths to the project root."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-bzr-command "bzr ls --versioned -0"
+(defcustom projectile-bzr-command "bzr ls -R --versioned -0"
   "Command used by projectile to get the files in a bazaar project."
   :group 'projectile
   :type 'string)


### PR DESCRIPTION
Fixes issue #164 by making the default projectile-bzr-command use the -R flag to recurse into directories.
