### PR TITLE
Add "sbt compile" and "sbt test" to default compile and test commands of a sbt project.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -926,6 +926,7 @@ With a prefix argument ARG prompts you for a directory on which to run the repla
 (defvar projectile-sbt-test-cmd "sbt test")
 (defvar projectile-make-compile-cmd "make")
 (defvar projectile-make-test-cmd "make test")
+
 (defvar projectile-compilation-cmd-map
   (make-hash-table :test 'equal)
   "A mapping between projects and the last compilation command used on them.")


### PR DESCRIPTION
There seems to be no default compile and test commands for a sbt project. So I added them. And I've tested this on my sbt project.
