### PR TITLE
[Fix #176] Opened files added to the cache as if belonging to the root

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -298,7 +298,7 @@ The cache is created both in memory and on the hard drive."
   (interactive)
   (let* ((current-project (projectile-project-root))
          (abs-current-file (buffer-file-name (current-buffer)))
-         (current-file (file-relative-name abs-current-file)))
+         (current-file (file-relative-name abs-current-file current-project)))
     (unless (or (projectile-file-cached-p current-file current-project)
                 (projectile-ignored-directory-p (file-name-directory abs-current-file)))
       (puthash current-project


### PR DESCRIPTION
Variable 'current-file' was referring to the file basename in function
projectile-cache-current-file.

It now refers to the relative path of the file from the project root directory.

Thanks for sharing projectile.
