### PR TITLE
Helm projectile action needs a name to work on .el files

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -57,8 +57,8 @@
     (help-message . helm-generic-file-help-message)
     (mode-line . helm-generic-file-mode-line-string)
     (type . file)
-    (action . (lambda (candidate)
-                (find-file (projectile-expand-root candidate)))))
+    (action . (("Find File" . (lambda (candidate)
+                                (find-file (projectile-expand-root candidate)))))))
   "Helm source definition.")
 
 (defvar helm-source-projectile-buffers-list
@@ -100,8 +100,8 @@
     (help-message . helm-generic-file-help-message)
     (mode-line . helm-generic-file-mode-line-string)
     (type . file)
-    (action . (lambda (candidate)
-                (find-file (projectile-expand-root candidate)))))
+    (action . (("Find File" . (lambda (candidate)
+                                (find-file (projectile-expand-root candidate)))))))
   "Helm source definition.")
 
 ;;;###autoload


### PR DESCRIPTION
When operating on .el files, Helm recklessly appends an action to the
list of actions, which seems to expect the extended format for actions,
otherwise hitting RET on an emacs lisp file in helm-projectile causes
Emacs to complain. This change gives the default action the name "Find
File", and fixes this problem.
