### PR TITLE
Add prefix file name search together with suffices

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -146,7 +146,8 @@ Otherwise consider the current directory the project root."
     ".fslckout"
     ".bzr"
     "_darcs"
-    "venv")
+    "venv"
+    "build")
   "A list of directories globally ignored by projectile."
   :group 'projectile
   :type '(repeat string))
@@ -724,6 +725,11 @@ With a prefix ARG invalidates the cache first."
                                           (projectile-current-project-test-files))))
     (find-file (expand-file-name file (projectile-project-root)))))
 
+(defcustom projectile-test-files-prefixes '("test_")
+  "Some common prefixes of test files."
+  :group 'projectile
+  :type '(repeat string))
+
 (defcustom projectile-test-files-suffices '("_test" "_spec" "Test" "-test")
   "Some common suffices of test files."
   :group 'projectile
@@ -735,9 +741,12 @@ With a prefix ARG invalidates the cache first."
 
 (defun projectile-test-file-p (file)
   "Check if FILE is a test file."
-  (-any? (lambda (suffix)
-           (s-ends-with? suffix (file-name-sans-extension file)))
-         projectile-test-files-suffices))
+  (or (-any? (lambda (prefix)
+               (s-starts-with? prefix (file-name-nondirectory file)))
+              projectile-test-files-prefixes)
+      (-any? (lambda (suffix)
+               (s-ends-with? suffix (file-name-sans-extension file)))
+              projectile-test-files-suffices)))
 
 (defun projectile-current-project-test-files ()
   "Return a list of test files for the current project."
@@ -815,32 +824,42 @@ With a prefix ARG invalidates the cache first."
           (find-file (projectile-expand-root test-file))
         (error "No matching test file found")))))
 
+(defun projectile-test-prefix (project-type)
+  "Find test files prefix based on PROJECT-TYPE."
+  (cond
+   ((member project-type '(django python)) "test_")))
+
 (defun projectile-test-suffix (project-type)
   "Find test files suffix based on PROJECT-TYPE."
   (cond
    ((member project-type '(rails-rspec ruby-rspec)) "_spec")
    ((member project-type '(rails-test ruby-test lein)) "_test")
-   ((member project-type '(maven symfony)) "Test")
-   (t (error "Project type not supported!"))))
+   ((member project-type '(maven symfony)) "Test")))
 
 (defun projectile-find-matching-test (file)
   "Compute the name of the test matching FILE."
   (let ((basename (file-name-nondirectory (file-name-sans-extension file)))
         (extension (file-name-extension file))
-        (test-suffix (projectile-test-suffix (projectile-project-type))))
+        (test-affix (or (projectile-test-prefix (projectile-project-type))
+                        (projectile-test-suffix (projectile-project-type))
+                        (error "Project type not supported!"))))
       (-first (lambda (current-file)
-                (s-equals? (file-name-nondirectory (file-name-sans-extension current-file))
-                           (concat basename test-suffix)))
+                (let ((current-file-basename (file-name-nondirectory (file-name-sans-extension current-file))))
+                  (or (s-equals? current-file-basename (concat test-affix basename))
+                      (s-equals? current-file-basename (concat basename test-affix)))))
               (projectile-current-project-files))))
 
 (defun projectile-find-matching-file (test-file)
   "Compute the name of a file matching TEST-FILE."
   (let ((basename (file-name-nondirectory (file-name-sans-extension test-file)))
         (extension (file-name-extension test-file))
-        (test-suffix (projectile-test-suffix (projectile-project-type))))
+        (test-affix (or (projectile-test-prefix (projectile-project-type))
+                        (projectile-test-suffix (projectile-project-type))
+                        (error "Project type not supported!"))))
     (-first (lambda (current-file)
-              (s-equals? (concat (file-name-nondirectory (file-name-sans-extension current-file)) test-suffix)
-                         basename))
+              (let ((current-file-basename (file-name-nondirectory (file-name-sans-extension current-file))))
+                (or (s-equals? (concat test-affix current-file-basename) basename)
+                    (s-equals? (concat current-file-basename test-affix) basename))))
             (projectile-current-project-files))))
 
 (defun projectile-grep ()


### PR DESCRIPTION
Toggle between test and implementation now work for django and python project.
Ignore 'build' directory as very parasite for search in python projects.
