### PR TITLE
Change arg to be optional in projectile-find-dir

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -702,7 +702,7 @@ With a prefix ARG invalidates the cache first."
     (find-file (expand-file-name file (projectile-project-root)))
     (run-hooks 'projectile-find-file-hook)))
 
-(defun projectile-find-dir (arg)
+(defun projectile-find-dir (&optional arg)
   "Jump to a project's directory using completion.
 
 With a prefix ARG invalidates the cache first."


### PR DESCRIPTION
For consistency with projectile-find-file.  This is necessary so that projectile-find-dir can be used as value of projectile-switch-project-action.
