### PR TITLE
Show full path within project for files.

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -119,11 +119,12 @@
 (defun helm-projectile ()
   "Use projectile with Helm instead of ido."
   (interactive)
-  (helm :sources '(helm-source-projectile-files-list
-                   helm-source-projectile-buffers-list
-                   helm-source-projectile-recentf-list)
-        :buffer "*helm projectile*"
-        :prompt (projectile-prepend-project-name "pattern: ")))
+  (let ((helm-ff-transformer-show-only-basename nil))
+    (helm :sources '(helm-source-projectile-files-list
+                     helm-source-projectile-buffers-list
+                     helm-source-projectile-recentf-list)
+          :buffer "*helm projectile*"
+          :prompt (projectile-prepend-project-name "pattern: "))))
 
 ;;;###autoload
 (eval-after-load 'projectile


### PR DESCRIPTION
In large code bases, file name collisions exist sometimes (true
story).  In such case showing just file base name is not useful as you
don't know which of the identical names you are interested in.  So how
about showing full path within project?

P.S.
On unrelated note, I think the buffer and recentf sources are
preferable and should come above the full project list.
`helm-for-files' seems to agree with this. 
