### PR TITLE
Add occur mode to globally ignored projectile modes.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -157,7 +157,8 @@ Otherwise consider the current directory the project root."
     "help-mode"
     "completion-list-mode"
     "Buffer-menu-mode"
-    "gnus-.*-mode")
+    "gnus-.*-mode"
+    "occur-mode")
   "A list of regular expressions for major modes ignored by projectile.
 
 If a buffer is using a given major mode, projectile will ignore


### PR DESCRIPTION
This is just a suggestion (there might be better ways of doing this):

When using multi-occur (C-c p o) multiple times with the same regex, it lists
all the matches in the opened occur buffers. Adding the occur-mode to the
ignored modes stops this.

As this is a customizable variable, it's easy for each user to achieve this, but
I think the default behavior should be to not show matches in other/already open
occur buffers.
