### PR TITLE
don't treat Makefile as an indicator of the project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+* The presence of a `Makefile` is no longer taken as an indicator
+  of the project root by default, since recursive make is unfortunately
+  a common occurrence (affects `projectile-project-root-files`).
 * Added new `projectile-commander` methods ?v and ?R which run
   `projectile-vc-dir` and `projectile-regenerate-tags`, respectively.
 

--- a/projectile.el
+++ b/projectile.el
@@ -138,7 +138,6 @@ Otherwise consider the current directory the project root."
     "build.gradle"       ; Gradle project file
     "Gemfile"            ; Bundler file
     "requirements.txt"   ; Pip file
-    "Makefile"           ; Make project file
     )
   "A list of files considered to mark the root of a project."
   :group 'projectile


### PR DESCRIPTION
Sadly, despite recursive make well-known to be harmful, it is still in common
use, which means that the presence of Makefile in a directory cannot reliably
indicate that that directory is the root of a project.  Therefore it is safer
not to include this in projectile-project-root-files by default.
