### PR TITLE
allow projectile-project-root to find the root for symlinked files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Added new `projectile-commander` methods ?v and ?R which run
   `projectile-vc-dir` and `projectile-regenerate-tags`, respectively.
+* Projectile is now able to find the project pertaining to a symlink
+  pointing to a version-controlled file.
 
 ## 0.10.0 (12/09/2013)
 

--- a/projectile.el
+++ b/projectile.el
@@ -346,7 +346,9 @@ The cache is created both in memory and on the hard drive."
 The current directory is assumed to be the project's root otherwise."
   (let ((project-root
          (or (->> projectile-project-root-files
-               (--map (locate-dominating-file default-directory it))
+               (--map (locate-dominating-file (file-truename
+                                               (or buffer-file-name default-directory))
+                                              it))
                (-remove #'null)
                (car)
                (projectile-file-truename))


### PR DESCRIPTION
This covers the case where you have a git repo `~/configs` (for dotfiles etc.), and the subdir `emacs` of that repo is symlinked to `~/.emacs.d`

projectile-project-root in a buffer visiting `~/.emacs.d/init.el` will find the root at `~/configs`.

Also includes an unrelated docstring fix.
