### PR TITLE
Optionally remember window configurations when switching projects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New features
 
+* New defcustom `projectile-remember-window-configs` will make
+  `projectile-switch-project` restore the most recent window configuration (if
+  any) of the target project.
 * New command `projectile-run-command-in-root`.
 * New defcustom `projectile-use-git-grep` will make `projectile-grep` use `git grep`
 for git projects.

--- a/README.md
+++ b/README.md
@@ -145,10 +145,18 @@ This might not be a great idea if you start Projectile in your home folder for i
 
 #### Switching projects
 
-When running `projectile-switch-project` (<kbd>C-c p s</kbd>) Projectile invokes the command specified in
-`projectile-switch-project-action` (by default it is `projectile-find-file`).
-Depending on your personal workflow and habits, you may prefer to
-alter the value of `projectile-switch-project-action`:
+When running `projectile-switch-project` (<kbd>C-c p s</kbd>) Projectile invokes
+the command specified in `projectile-switch-project-action` (by default it is
+`projectile-find-file`).
+
+When `projectile-remember-window-configs` is `t` (default is `nil`), the most
+recent window configuration of the target project is restored instead of calling
+`projectile-switch-project-action`.  If the target project has no window
+configuration in the current editing session, `projectile-switch-project-action`
+is otherwise invoked as described above.
+
+Depending on your personal workflow and habits, you
+may prefer to alter the value of `projectile-switch-project-action`:
 
 ###### `projectile-find-file`
 


### PR DESCRIPTION
This pull request allows for a project's most recent window configuration to be restored as a project switching action. More specifically, you can now set `projectile-switch-project-action` to `projectile-restore-window-configuration`, resulting in that project's latest window configuration to replace the contents of the current frame. If the target project has no recent window configuration, `projectile-switch-project-action-alternative` is called.

Note that there's no caching of window configurations, since they have no read representation as lisp objects, making them difficult to serialize.
