### PR TITLE
vc-git-grep fails due to inclusion of directory `..`

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -924,7 +924,7 @@ With a prefix ARG invalidates the cache first."
       (require 'grep)
       ;; in git projects users have the option to use `vc-git-grep' instead of `rgrep'
       (if (and (eq (projectile-project-vcs) 'git) projectile-use-git-grep)
-          (vc-git-grep search-regexp "* .*" root-dir)
+          (vc-git-grep search-regexp "'*'" root-dir)
         ;; paths for find-grep should relative and without trailing /
         (let ((grep-find-ignored-directories (-union (-map (lambda (dir) (s-chop-suffix "/" (file-relative-name dir root-dir)))
                                                            (cdr (projectile-ignored-directories))) grep-find-ignored-directories))


### PR DESCRIPTION
After enabling `(setq projectile-use-git-grep t)`, I tried using project grep and encountered the following error:

```
-*- mode: grep; default-directory: "~/.home-config/" -*-
Grep started at Thu Dec 26 18:38:38

git --no-pager grep -n -e projectile-global-mode -- * .*
fatal: '..' is outside repository

Grep exited abnormally with code 128 at Thu Dec 26 18:38:38
```

Changing line 928 of projectile.el to `(vc-git-grep search-regexp "*" root-dir)` fixes this, but no longer searches hidden files in the project. However, `'*'` as the parameter does work.

I'm not sure if this is an oddity in git grep or the shell (bash in my case).
