### PR TITLE
Add projectile-find-implementation-or-test-other-window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ for git projects.
 * Modified `projectile-ack` to append to `ack-and-a-half-arguments`
   instead of overriding them.
 * [#229] Fix `projectile-find-file-in-directory`'s behavior for project directories
+* `projectile-toggle-between-implementation-or-test` shows
+  understandable error if current buffer is not visiting a file.
 
 ## 0.10.0 (12/09/2013)
 

--- a/projectile.el
+++ b/projectile.el
@@ -861,6 +861,7 @@ With a prefix ARG invalidates the cache first."
 
 (defun projectile-find-implementation-or-test (file-name)
   "Given a FILE-NAME return the matching implementation or test filename."
+  (unless file-name (error "The current buffer is not visiting a file"))
   (if (projectile-test-file-p file-name)
       ;; find the matching impl file
       (let ((impl-file (projectile-find-matching-file file-name)))


### PR DESCRIPTION
Enhances existing functionality by extracting
`projectile-find-implementation-or-test` from
`projectile-toggle-between-implementation-and-test`, so it can be used
both to toggle, or to open in other window.

Adds a corresponding key binding at `C-c p 4 t`.
