### PR TITLE
Make projectile test file prefix/suffix functions "customizable"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ for git projects.
 * New functions `projectile-find-implementation-or-test` and
   `projectile-find-implementation-or-test-other-window`, the later is
   bound to `C-c p 4 t`.
+* New defcustoms `projectile-test-prefix-function` and `projectile-test-suffix-function`
+  allow users to customize how projectile identifies test files by project type.
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -925,13 +925,29 @@ With a prefix ARG invalidates the cache first."
   (find-file
    (projectile-find-implementation-or-test (buffer-file-name))))
 
+(defun projectile-test-affix (project-type)
+  "Find test files affix based on PROJECT-TYPE."
+  (or (funcall projectile-test-prefix-function project-type)
+      (funcall projectile-test-suffix-function project-type)
+      (error "Project type not supported!")))
+
+(defcustom projectile-test-prefix-function 'projectile-test-prefix
+  "Function to find test files prefix based on PROJECT-TYPE."
+  :group 'projectile
+  :type 'function)
+
+(defcustom projectile-test-suffix-function 'projectile-test-suffix
+  "Function to find test files suffix based on PROJECT-TYPE."
+  :group 'projectile
+  :type 'function)
+
 (defun projectile-test-prefix (project-type)
-  "Find test files prefix based on PROJECT-TYPE."
+  "Find default test files prefix based on PROJECT-TYPE."
   (cond
    ((member project-type '(django python)) "test_")))
 
 (defun projectile-test-suffix (project-type)
-  "Find test files suffix based on PROJECT-TYPE."
+  "Find default test files suffix based on PROJECT-TYPE."
   (cond
    ((member project-type '(rails-rspec ruby-rspec)) "_spec")
    ((member project-type '(rails-test ruby-test lein)) "_test")
@@ -941,9 +957,7 @@ With a prefix ARG invalidates the cache first."
   "Compute the name of the test matching FILE."
   (let ((basename (file-name-nondirectory (file-name-sans-extension file)))
         (extension (file-name-extension file))
-        (test-affix (or (projectile-test-prefix (projectile-project-type))
-                        (projectile-test-suffix (projectile-project-type))
-                        (error "Project type not supported!"))))
+        (test-affix (projectile-test-affix (projectile-project-type))))
       (-first (lambda (current-file)
                 (let ((current-file-basename (file-name-nondirectory (file-name-sans-extension current-file))))
                   (or (s-equals? current-file-basename (concat test-affix basename))
@@ -954,9 +968,7 @@ With a prefix ARG invalidates the cache first."
   "Compute the name of a file matching TEST-FILE."
   (let ((basename (file-name-nondirectory (file-name-sans-extension test-file)))
         (extension (file-name-extension test-file))
-        (test-affix (or (projectile-test-prefix (projectile-project-type))
-                        (projectile-test-suffix (projectile-project-type))
-                        (error "Project type not supported!"))))
+        (test-affix (projectile-test-affix (projectile-project-type))))
     (-first (lambda (current-file)
               (let ((current-file-basename (file-name-nondirectory (file-name-sans-extension current-file))))
                 (or (s-equals? (concat test-affix current-file-basename) basename)


### PR DESCRIPTION
Hi!
I've been playing with `projectile` for a few days now and it's been a huge boost to my workflow. 
I have however hit a snag with the test-file -> implementation-file toggling feature, namely that my projects' `unittest` test files use the `*_test.py` naming convention, rather than the `test_*.py` convention currently supported by `projectile`.
It would be great if the functions supplying prefixes/suffixes for test files were customizable; here's one implementation of that. I've deliberately kept the existing prefix/suffix functions as they are (so as not to mess up users who've worked around this already by overriding them), just wrapped them with `customize` aliases.

Here's an example of user then customizing `projectile` to their test setup:

``` lisp
(defun default-projectile-prefix-unless-django (project-type)
  (when (not (eq project-type 'django))
    (projectile-test-prefix project-type)))

(defun default-projectile-suffix-unless-django (project-type)
  (if (eq project-type 'django)
      "_test"
    (projectile-test-suffix project-type)))


(custom-set-variables
 '(projectile-test-prefix-function 'default-projectile-prefix-unless-django)
 '(projectile-test-suffix-function 'default-projectile-suffix-unless-django))
```

I've run the `cask` tests as well as `checkdoc` and things look good.
