### PR TITLE
Add support for running a list of functions when idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New features
 
+* New variable `projectile-enable-idle-timer` turns on an idle timer
+  which runs the hook `projectile-idle-timer-hook` every
+  `projectile-idle-timer-seconds` seconds when non-nil.
 * New defcustom `projectile-remember-window-configs` will make
   `projectile-switch-project` restore the most recent window configuration (if
   any) of the target project.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,25 @@ Obviously you need to have Helm installed for this to work :-)
 
 ![Helm-Projectile Screenshot](https://github.com/bbatsov/projectile/raw/master/screenshots/helm-projectile.png)
 
+### Idle Timer
+
+Projectile can be configured to run the hook
+`projectile-idle-timer-hook` every time Emacs is in a project and has
+been idle for `projectile-idle-timer-seconds` seconds (default is 30
+seconds).  To enable this feature, run:
+
+```
+M-x customize-group RET projectile RET
+```
+
+and set `projectile-enable-idle-timer` to non-nil.  By default,
+`projectile-idle-timer-hook` runs `projectile-regenerate-tags`.  Add
+additional functions to the hook using `add-hook`:
+
+```lisp
+(add-hook 'projectile-idle-timer-hook 'my-projectile-idle-timer-function)
+```
+
 ## Caveats
 
 * Traversing the project directory programmatically (instead of using

--- a/projectile.el
+++ b/projectile.el
@@ -207,7 +207,41 @@ Any function that does not take arguments will do."
 If no configuration exists, just run `projectile-switch-project-action' as usual."
   :group 'projectile
   :type 'boolean)
+
+;;; Idle Timer
+(defvar projectile-idle-timer nil
+  "The timer object created when `project-enable-idle-timer' is non-nil.")
 
+(defcustom projectile-idle-timer-seconds 30
+  "The idle period to use when `projectile-enable-idle-timer' is non-nil."
+  :group 'projectile
+  :type 'number)
+
+(defcustom projectile-idle-timer-hook '(projectile-regenerate-tags)
+  "The hook run when `projectile-enable-idle-timer' is non-nil."
+  :group 'projectile
+  :type '(repeat symbol))
+
+(defcustom projectile-enable-idle-timer nil
+  "Enables idle timer hook `projectile-idle-timer-functions'.
+
+When `projectile-enable-idle-timer' is non-nil, the hook
+`projectile-idle-timer-hook' is run each time Emacs has been idle
+for `projectile-idle-timer-seconds' seconds and we're in a
+project."
+  :group 'projectile
+  :set (lambda (symbol value)
+	 (set symbol value)
+	 (when projectile-idle-timer
+	   (cancel-timer projectile-idle-timer))
+	 (setq projectile-idle-timer nil)
+	 (when projectile-enable-idle-timer
+	   (setq projectile-idle-timer (run-with-idle-timer
+					projectile-idle-timer-seconds t
+					(lambda ()
+					  (when (projectile-project-p)
+					    (run-hooks 'projectile-idle-timer-hook)))))))
+  :type 'boolean)
 
 ;;; Serialization
 (defun projectile-serialize (data filename)


### PR DESCRIPTION
When `projectile-enable-idle-timer` is non-nil, a timer is created and
stored in `projectile-idle-timer` which runs repeatedly every
`projectile-idle-timer-seconds` seconds.  When the timer runs, it calls
`run-hooks` on a new hook variable, `projectile-idle-timer-hook`, which
defaults to `'(projectile-idle-regenerate-tags)`.  New functions can be
added to the hook using `add-hook` as usual.  Note that the creation of
the idle timer is done using the `:set` keyword in the `defcustom` call
that defines `projectile-enable-idle-timer`.

See issue #248.
