### PR TITLE
Stop use hardcoded virtualenv name in python commands.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -155,6 +155,7 @@ Otherwise consider the current directory the project root."
     ".fslckout"
     ".bzr"
     "_darcs"
+    ".tox"
     "build")
   "A list of directories globally ignored by projectile."
   :group 'projectile


### PR DESCRIPTION
This allow users specify virtualenv throw third party extensions,
and not depend on name conventions.
