### PR TITLE
Fix git-grep to work in Windows.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1028,7 +1028,7 @@ With a prefix ARG invalidates the cache first."
       (require 'grep)
       ;; in git projects users have the option to use `vc-git-grep' instead of `rgrep'
       (if (and (eq (projectile-project-vcs) 'git) projectile-use-git-grep)
-          (vc-git-grep search-regexp "'*'" root-dir)
+          (vc-git-grep search-regexp "" root-dir)
         ;; paths for find-grep should relative and without trailing /
         (let ((grep-find-ignored-directories (-union (-map (lambda (dir) (s-chop-suffix "/" (file-relative-name dir root-dir)))
                                                            (cdr (projectile-ignored-directories))) grep-find-ignored-directories))


### PR DESCRIPTION
the single quotes prevented it from working on windows.  tested on windows and an ubuntu vm.
