### PR TITLE
Declare ack-and-a-half-arguments prior to use

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1036,6 +1036,7 @@ With a prefix ARG invalidates the cache first."
           (grep-compute-defaults)
           (rgrep search-regexp "* .*" root-dir))))))
 
+(defvar ack-and-a-half-arguments)
 (defun projectile-ack (regexp)
   "Run an ack search with REGEXP in the project."
   (interactive


### PR DESCRIPTION
The autoload on the ack-and-half call loads the library, unfortunately
until that has happened ack-and-a-half-arguments is not declared so this
code will fail without a require on ack-and-a-half first.

This solves it by simply declaring the variable first. I'm not quite
sure how this works if defcustom has already loaded a value for this
variable, but this shouldn't override existing values.

The other approach is to change the fboundp call to
(require 'ack-and-a-half nil 'no-error). That doesn't remove the free
variable error on ack-and-a-half-arguments though.
