### PR TITLE
Need to require ack-and-a-half for it to work

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1033,14 +1033,13 @@ With a prefix ARG invalidates the cache first."
           (grep-compute-defaults)
           (rgrep search-regexp "* .*" root-dir))))))
 
-(defvar ack-and-a-half-arguments)
 (defun projectile-ack (regexp)
   "Run an ack search with REGEXP in the project."
   (interactive
    (list (read-from-minibuffer
           (projectile-prepend-project-name "Ack search for: ")
           (projectile-symbol-at-point))))
-  (if (fboundp 'ack-and-a-half)
+  (if (require 'ack-and-a-half nil 'noerror)
       (let* ((saved-arguments ack-and-a-half-arguments)
              (ack-and-a-half-arguments
               (append saved-arguments


### PR DESCRIPTION
I guess I didn't test this as well as I should have previously. It would
appear that defvar without a value still leaves it as void. Since the
function references the arguments before autoload brings in
ack-and-half, it's used in projectile while still void.
