### PR TITLE
Make projectile-replace work with lexical binding

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1165,8 +1165,7 @@ With a prefix argument ARG prompts you for a directory on which to run the repla
                         (read-directory-name "Replace in directory: ")
                       (projectile-project-root)))
          (files (projectile-files-with-string old-text directory)))
-    ;; 'files is intentional - the function expects a form to evaluate
-    (tags-query-replace old-text new-text nil 'files)))
+    (tags-query-replace old-text new-text nil (cons 'list files))))
 
 (defun projectile-symbol-at-point ()
   "Get the symbol at point and strip its properties."


### PR DESCRIPTION
The previous version actually only worked because of dynamic binding and broke when projectile switched.  This should fix it (and it seems cleaner anyway).
