### PR TITLE
Add two other-window commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+* Added new commands `projectile-display-buffer`
+  and`projectile-find-dir-other-window`.
 * Added new interacive function `projectile-project-buffers-other-buffer`
   which runs new `projectile-project-buffers-non-visible` function, the former
   is bound to `C-c p ESC`.

--- a/README.md
+++ b/README.md
@@ -262,12 +262,14 @@ Keybinding         | Description
 <kbd>C-c p f</kbd> | Display a list of all files in the project. With a prefix argument it will clear the cache first.
 <kbd>C-c p 4 f</kbd> | Jump to a project's file using completion and show it in another window.
 <kbd>C-c p d</kbd> | Display a list of all directories in the project. With a prefix argument it will clear the cache first.
+<kbd>C-c p 4 d</kbd> | Switch to a project directory and show it in another window.
 <kbd>C-c p T</kbd> | Display a list of all test files(specs, features, etc) in the project.
 <kbd>C-c p l</kbd> | Display a list of all files in a directory (that's not necessarily a project)
 <kbd>C-c p g</kbd> | Run grep on the files in the project.
 <kbd>C-c p v</kbd> | Run `vc-dir` on the root directory of the project.
 <kbd>C-c p b</kbd> | Display a list of all project buffers currently open.
 <kbd>C-c p 4 b</kbd> | Switch to a project buffer and show it in another window.
+<kbd>C-c p 4 C-o</kbd> | Display a project buffer in another window without selecting it.
 <kbd>C-c p o</kbd> | Runs `multi-occur` on all project buffers currently open.
 <kbd>C-c p r</kbd> | Runs interactive query-replace on all files in the projects.
 <kbd>C-c p i</kbd> | Invalidates the project cache (if existing).

--- a/projectile.el
+++ b/projectile.el
@@ -640,6 +640,14 @@ Operates on filenames relative to the project root."
     "Switch to buffer: "
     (projectile-project-buffer-names))))
 
+(defun projectile-display-buffer ()
+  "Display a project buffer in another window without selecting it."
+  (interactive)
+  (display-buffer
+   (projectile-completing-read
+    "Display buffer: "
+    (projectile-project-buffer-names))))
+
 (defun projectile-project-buffers-other-buffer ()
   "Switch to the most recently selected buffer project buffer.
 Only buffers not visible in windows are returned."
@@ -845,13 +853,27 @@ With a prefix ARG invalidates the cache first."
   (interactive "P")
   (when arg
     (projectile-invalidate-cache nil))
-  (let ((dir (projectile-completing-read
-              "Find dir: "
-              (if projectile-find-dir-includes-top-level
-                  (append '("./") (projectile-current-project-dirs))
-                (projectile-current-project-dirs)))))
+  (let ((dir (projectile-complete-dir)))
     (dired (expand-file-name dir (projectile-project-root)))
     (run-hooks 'projectile-find-dir-hook)))
+
+(defun projectile-find-dir-other-window (&optional arg)
+  "Jump to a project's directory in other window using completion.
+
+With a prefix ARG invalidates the cache first."
+  (interactive "P")
+  (when arg
+    (projectile-invalidate-cache nil))
+  (let ((dir (projectile-complete-dir)))
+    (dired-other-window (expand-file-name dir (projectile-project-root)))
+    (run-hooks 'projectile-find-dir-hook)))
+
+(defun projectile-complete-dir ()
+  (projectile-completing-read
+   "Find dir: "
+   (if projectile-find-dir-includes-top-level
+       (append '("./") (projectile-current-project-dirs))
+     (projectile-current-project-dirs))))
 
 (defun projectile-find-test-file (&optional arg)
   "Jump to a project's test file using completion.
@@ -1563,6 +1585,7 @@ is chosen."
   (let ((map (make-sparse-keymap)))
     (let ((prefix-map (make-sparse-keymap)))
       (define-key prefix-map (kbd "4 b") 'projectile-switch-to-buffer-other-window)
+      (define-key prefix-map (kbd "4 C-o") 'projectile-display-buffer)
       (define-key prefix-map (kbd "4 f") 'projectile-find-file-other-window)
       (define-key prefix-map (kbd "4 t") 'projectile-find-implementation-or-test-other-window)
       (define-key prefix-map (kbd "a") 'projectile-ack)
@@ -1570,6 +1593,7 @@ is chosen."
       (define-key prefix-map (kbd "b") 'projectile-switch-to-buffer)
       (define-key prefix-map (kbd "c") 'projectile-compile-project)
       (define-key prefix-map (kbd "d") 'projectile-find-dir)
+      (define-key prefix-map (kbd "4 d") 'projectile-find-dir-other-window)
       (define-key prefix-map (kbd "D") 'projectile-dired)
       (define-key prefix-map (kbd "e") 'projectile-recentf)
       (define-key prefix-map (kbd "f") 'projectile-find-file)


### PR DESCRIPTION
These are projectile analogs for `display-buffer` and
`dired-other-window`, with projectile bindings that mirror the bindings
in the `C-x 4` keymap.
