### PR TITLE
Support parent project root files which overrides current directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## master (unreleased)
 
 ### New features
-
+* added new defcustoms `projectile-project-root-files-top-down-recurring`,
+  `projectile-project-root-files-bottom-up` and
+  `projectile-project-root-files-functions`.
 * Added new command `projectile-save-project-buffers`.
 * Added new command `projectile-cleanup-known-projects`.
 * Added new commands `projectile-display-buffer`

--- a/Cask
+++ b/Cask
@@ -4,5 +4,6 @@
 (package-file "projectile.el")
 
 (development
+ (depends-on "f")
  (depends-on "noflet")
  (depends-on "ack-and-a-half"))

--- a/README.md
+++ b/README.md
@@ -361,6 +361,20 @@ If both directories to keep and ignore are specified, the directories
 to keep first apply, restricting what files are considered. The paths
 and patterns to ignore are then applied to that set.
 
+### Customizing project root files
+
+You can set the values of `projectile-project-root-files`,
+`projectile-project-root-files-top-down-recurring`,
+`projectile-project-root-files-bottom-up` and
+`projectile-project-root-files-functions` to customize how project roots are
+identified.
+
+To customize project root files settings:
+
+```
+M-x customize-group RET projectile RET
+```
+
 ### Helm Integration
 
 Projectile can be integrated with

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+sandbox/

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -14,27 +14,33 @@
 (load (expand-file-name "test-helper.el" testsuite-dir) nil :no-message)
 
 (ert-deftest projectile-test-project-get-name ()
-  (should (equal (projectile-project-name) "project")))
+  (noflet ((projectile-project-name () "project"))
+          (should (equal (projectile-project-name) "project"))))
 
 (ert-deftest projectile-test-prepend-project-name ()
-  (should (equal (projectile-prepend-project-name "Test") "[project] Test")))
+  (noflet ((projectile-project-name () "project"))
+          (should (equal (projectile-prepend-project-name "Test") "[project] Test"))))
 
 (ert-deftest projectile-test-expand-root ()
-  (should (equal (projectile-expand-root "foo") "/path/to/project/foo"))
-  (should (equal (projectile-expand-root "foo/bar") "/path/to/project/foo/bar"))
-  (should (equal (projectile-expand-root "./foo/bar") "/path/to/project/foo/bar")))
+  (noflet ((projectile-project-root () "/path/to/project"))
+          (should (equal (projectile-expand-root "foo") "/path/to/project/foo"))
+          (should (equal (projectile-expand-root "foo/bar") "/path/to/project/foo/bar"))
+          (should (equal (projectile-expand-root "./foo/bar") "/path/to/project/foo/bar"))))
 
 (ert-deftest projectile-test-ignored-directory-p ()
   (noflet ((projectile-ignored-directories () '("/path/to/project/tmp")))
           (should (projectile-ignored-directory-p "/path/to/project/tmp"))
           (should-not (projectile-ignored-directory-p "/path/to/project/log"))))
+
 (ert-deftest projectile-test-ignored-file-p ()
   (noflet ((projectile-ignored-files () '("/path/to/project/TAGS")))
           (should (projectile-ignored-file-p "/path/to/project/TAGS"))
           (should-not (projectile-ignored-file-p "/path/to/project/foo.el"))))
 
 (ert-deftest projectile-test-ignored-files ()
-  (noflet ((projectile-project-ignored-files () '("foo.js" "bar.rb")))
+  (noflet ((projectile-project-root () "/path/to/project")
+           (projectile-project-name () "project")
+           (projectile-project-ignored-files () '("foo.js" "bar.rb")))
           (let ((expected '("/path/to/project/TAGS"
                             "/path/to/project/foo.js"
                             "/path/to/project/bar.rb"))
@@ -67,18 +73,20 @@
                     (should-not (projectile-project-ignored-directories))))))
 
 (ert-deftest projectile-test-project-ignored ()
-  (let* ((file-names '("log" "tmp" "compiled"))
-         (files (mapcar 'projectile-expand-root file-names)))
-    (noflet ((projectile-paths-to-ignore () (list "log" "tmp" "compiled"))
-             (file-expand-wildcards (pattern ignored)
-                                    (cond
-                                     ((string-equal pattern "log")
-                                      "/path/to/project/log")
-                                     ((string-equal pattern "tmp")
-                                      "/path/to/project/tmp")
-                                     ((string-equal pattern "compiled")
-                                      "/path/to/project/compiled"))))
-            (should (equal (projectile-project-ignored) files)))))
+  (noflet ((projectile-project-root () "/path/to/project")
+           (projectile-project-name () "project"))
+          (let* ((file-names '("log" "tmp" "compiled"))
+                 (files (mapcar 'projectile-expand-root file-names)))
+                (noflet ((projectile-paths-to-ignore () (list "log" "tmp" "compiled"))
+                         (file-expand-wildcards (pattern ignored)
+                                                (cond
+                                                 ((string-equal pattern "log")
+                                                  "/path/to/project/log")
+                                                 ((string-equal pattern "tmp")
+                                                  "/path/to/project/tmp")
+                                                 ((string-equal pattern "compiled")
+                                                  "/path/to/project/compiled"))))
+                        (should (equal (projectile-project-ignored) files))))))
 
 
 (ert-deftest projectile-test-parse-dirconfig-file ()
@@ -169,3 +177,137 @@
     (should (projectile-maybe-invalidate-cache t))
     (noflet ((file-newer-than-file-p (a b) t))
       (should (projectile-maybe-invalidate-cache nil)))))
+
+(ert-deftest projectile-test-root-top-down ()
+  (with-sandbox
+   (f-mkdir "projectA" ".svn")
+   (f-mkdir "projectA" "src" ".svn")
+   (f-mkdir "projectA" "src" "html" ".svn")
+   (f-mkdir "projectA" ".git")
+   (f-mkdir "projectA" "src" "html")
+   (f-mkdir "projectA" "src" "framework" "lib")
+   (f-touch "projectA/src/framework.conf")
+   (f-touch "projectA/src/html/index.html")
+   (should (equal "projectA/src/"
+                  (projectile-root-top-down "projectA/src/framework/lib"
+                                            '("framework.conf" ".git"))))
+   (should (equal "projectA/src/"
+                  (projectile-root-top-down "projectA/src/framework/lib"
+                                            '(".git" "framework.conf"))))
+   (should (equal "projectA/src/html/"
+                  (projectile-root-top-down "projectA/src/html/"
+                                            '(".svn"))))))
+
+(ert-deftest projectile-test-root-top-down-recurring ()
+  (with-sandbox
+   (f-mkdir "projectA" ".svn")
+   (f-mkdir "projectA" "src" ".svn")
+   (f-mkdir "projectA" "src" "html" ".svn")
+   (f-mkdir "projectA" ".git")
+   (f-mkdir "projectA" "src" "html")
+   (f-mkdir "projectA" "src" "framework" "lib")
+   (f-touch "projectA/src/framework/framework.conf")
+   (f-touch "projectA/src/html/index.html")
+   (f-touch ".projectile")
+   (should (equal "projectA/"
+                  (projectile-root-top-down-recurring "projectA/src/html/"
+                                                      '("something" ".svn" ".git"))))
+   (should (equal "projectA/"
+                  (projectile-root-top-down-recurring "projectA/src/html/"
+                                                      '(".git"))))
+   (should-not (projectile-root-top-down-recurring "projectA/src/html/"
+                                                   '("elusivefile")))))
+
+(ert-deftest projectile-test-root-bottom-up ()
+  (with-sandbox
+   (f-mkdir "projectA" ".svn")
+   (f-mkdir "projectA" "src" ".svn")
+   (f-mkdir "projectA" "src" "html" ".svn")
+   (f-mkdir "projectA" ".git")
+   (f-mkdir "projectA" "src" "html")
+   (f-mkdir "projectA" "src" "framework" "lib")
+   (f-touch "projectA/src/framework/framework.conf")
+   (f-touch "projectA/src/html/index.html")
+   (f-touch "projectA/.projectile")
+   (should (equal "projectA/"
+                  (projectile-root-bottom-up "projectA/src/framework/lib"
+                                             '(".git" ".svn"))))
+   (should (equal "projectA/"
+                  (projectile-root-bottom-up "projectA/src/html"
+                                             '(".git" ".svn"))))
+   (should (equal "projectA/src/html/"
+                  (projectile-root-bottom-up "projectA/src/html"
+                                             '(".svn" ".git"))))
+   (should (equal "projectA/"
+                  (projectile-root-bottom-up "projectA/src/html"
+                                             '(".projectile" "index.html"))))))
+
+(ert-deftest projectile-test-project-root ()
+  (with-sandbox
+   (f-mkdir "projectA" "src" ".svn")
+   (f-mkdir "projectA" "src" "html" ".svn")
+   (f-mkdir "projectA" "src" "html")
+   (f-mkdir "projectA" "src" "framework" "lib")
+   (f-mkdir "projectA" "build" "framework" "lib")
+   (f-mkdir "projectA" "requirements" "a" "b" "c" "d" "e" "f" "g")
+   (f-touch "projectA/src/framework/framework.conf")
+   (f-touch "projectA/requirements/a/b/c/requirements.txt")
+   (f-touch "projectA/src/html/index.html")
+   (f-touch "projectA/.projectile")
+   (f-touch "override")
+   (let ((projectile-project-root-files-bottom-up '("somefile" ".projectile"))
+         (projectile-project-root-files '("otherfile" "framework.conf" "requirements.txt"))
+         (projectile-project-root-files-top-down-recurring '(".svn" ".foo"))
+         (projectile-project-root-files-functions '(projectile-root-bottom-up
+                                                    projectile-root-top-down
+                                                    projectile-root-top-down-recurring)))
+     (should (f-same? "projectA"
+                      (project-root-in "projectA/requirements/a/b/c/d/e/f/g")))
+     (should (f-same? "projectA"
+                      (project-root-in "projectA/src/framework/lib")))
+     (should (f-same? "projectA"
+                      (project-root-in "projectA/src/html")))
+     
+     (setq projectile-project-root-files-functions '(projectile-root-top-down
+                                                     projectile-root-top-down-recurring
+                                                     projectile-root-bottom-up))
+     (should (f-same? "projectA/requirements/a/b/c"
+                      (project-root-in "projectA/requirements/a/b/c/d/e/f/g")))
+     (should (f-same? "projectA/src/framework"
+                      (project-root-in "projectA/src/framework/lib")))
+     (should (f-same? "projectA/src"
+                      (project-root-in "projectA/src/html"))))
+   
+   (let ((projectile-project-root-files-bottom-up '("somefile" ".projectile"))
+         (projectile-project-root-files '("otherfile" "noframework.conf"))
+         (projectile-project-root-files-top-down-recurring '(".svn" ".foo"))
+         (projectile-project-root-files-functions '(projectile-root-top-down-recurring
+                                                    projectile-root-bottom-up
+                                                    projectile-root-top-down)))
+     (should (f-same? "projectA/src"
+                      (project-root-in "projectA/src/framework/lib")))
+     (should (f-same? "projectA/src"
+                      (project-root-in "projectA/src/html")))
+     (should (f-same? "projectA/"
+                      (project-root-in "projectA/build/framework/lib"))))
+
+   (let ((projectile-project-root-files-bottom-up '("somefile" "override"))
+         (projectile-project-root-files '("otherfile" "anotherfile"))
+         (projectile-project-root-files-top-down-recurring '("someotherfile" "yetanotherfile"))
+         (projectile-project-root-files-functions '(projectile-root-bottom-up
+                                                    projectile-root-top-down
+                                                    projectile-root-top-down-recurring)))
+     (should (f-same? default-directory
+                      (project-root-in "projectA/src/framework/lib")))
+     (should (f-same? default-directory
+                      (project-root-in "projectA/src/html"))))
+   (let ((projectile-project-root-files-bottom-up '("somecoolfile"))
+         (projectile-project-root-files nil)
+         (projectile-project-root-files-top-down-recurring '(".svn"))
+         (projectile-project-root-files-functions '(projectile-root-bottom-up
+                                                    projectile-root-top-down
+                                                    projectile-root-top-down-recurring)))
+     (should (f-same? "projectA/src/"
+                      (project-root-in "projectA/src/")))
+     (should (f-same? "projectA/src/"
+                      (project-root-in "projectA/src/html"))))))

--- a/test/run-tests
+++ b/test/run-tests
@@ -17,6 +17,5 @@
 
 ;; setup test environment
 ;; and run tests
-(noflet ((projectile-project-root () "/path/to/project")
-         (projectile-project-name () "project"))
-        (ert-run-tests-batch-and-exit t))
+
+(ert-run-tests-batch-and-exit t)

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,0 +1,22 @@
+(require 'f)
+
+(defvar root-test-path
+  (f-dirname (f-this-file)))
+
+(defvar root-code-path
+  (f-parent root-test-path))
+
+(defvar root-sandbox-path
+  (f-expand "sandbox" root-test-path))
+
+(defmacro with-sandbox (&rest body)
+  "Evaluate BODY in an empty temporary directory."
+  `(let ((default-directory root-sandbox-path))
+     (when (f-dir? root-sandbox-path)
+       (f-delete root-sandbox-path :force))
+     (f-mkdir root-sandbox-path)
+     ,@body))
+
+(defun project-root-in (directory)
+  (let ((default-directory (f-expand directory)))
+    (projectile-project-root)))


### PR DESCRIPTION
- greater user control.
- configurable per file name pattern
- fewer calls to `file-exists-p` (good for tramp, slow disks, very deep directory structures, etc...)

Should be easy to also implement projectile-svn-project-root as an `'ancestor-bottom` check.

related to https://github.com/bbatsov/projectile/issues/234

btw. I cannot run the tests, cask has never worked for me and vagrant also seems prohibited by other networking things on my current computer.. So I've only tested this manually.
