### PR TITLE
Fix the problem of corrupting "known project file"

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -251,7 +251,7 @@ project."
 The saved data can be restored with `projectile-unserialize'."
   (when (file-writable-p filename)
     (with-temp-file filename
-      (insert (prin1-to-string data)))))
+      (insert (let (print-length) (prin1-to-string data))))))
 
 (defun projectile-unserialize (filename)
   "Read data serialized by `projectile-serialize' from FILENAME."


### PR DESCRIPTION
At times the "known project file" (the file "projectile-bookmarks.eld") gets
damaged, i.e., the end of the list gets abbreviated with "\.\.\.". This is
caused by calling `prin1-to-string` with random current non-nil value of
`print-length`. A non-nil value of this variable determines the maximum length
of list to print before abbreviating. Therefor, by binding `print-length` to nil
temporarily while calling `prin1-to-string`, we forces no-limit printing which
addresses the problem.
