### PR TITLE
Expand file names before processing them

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -434,7 +434,7 @@ Returns nil if no window configuration was found"
 (defun projectile-parent (path)
   "Return the parent directory of PATH.
 PATH may be a file or directory and directory paths may end with a slash."
-  (directory-file-name (file-name-directory (directory-file-name path))))
+  (directory-file-name (file-name-directory (directory-file-name (expand-file-name path)))))
 
 (defun projectile-locate-ancestor-containing (directory name)
   "Look up the directory hierarchy, starting at DIRECTORY, for a directory containing NAME.


### PR DESCRIPTION
We need to expand a file name to make it absolute and to process any special symbols before trying to process it.

Fixes an error from projectile functions, when default-directory contains a tilde, e.g. `~/`, as is the case in `*scratch*` and probably other special buffers.

The following traceback occurs when running `projectile-switch-project` from `*scratch*`, with `default-directory` being `"~/"`, on Emacs 24.4.50:

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  directory-file-name(nil)
  projectile-parent("~")
  projectile-locate-ancestor-containing("~" ".svn")
  projectile-svn-project-root("~/")
  projectile-project-root()
  projectile-dirconfig-file()
  projectile-maybe-invalidate-cache(nil)
  projectile-find-file(nil)
  #<subr call-interactively>(projectile-find-file nil nil)
  ad-Advice-call-interactively(#<subr call-interactively> projectile-find-file nil nil)
  apply(ad-Advice-call-interactively #<subr call-interactively> (projectile-find-file nil nil))
  call-interactively(projectile-find-file nil nil)
  command-execute(projectile-find-file)
```
