### PR TITLE
Added open in dired mode for helm-source-projectile-files-list

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -70,7 +70,8 @@
     (help-message . helm-find-file-help-message)
     (mode-line . helm-ff-mode-line-string)
     (type . file)
-    (action . (lambda (file) (find-file file))))
+    (action . (("Find file" . (lambda (file) (find-file file)))
+               ("Open dired in file's directory" . helm-open-dired))))
   "Helm source definition.")
 
 (defvar helm-source-projectile-buffers-list


### PR DESCRIPTION
I added helm-open-dired in the action list for helm-source-projectile-files-list, so that I can open file's directory in dired mode by C-e with helm-projectile.

This is my first time making a pull request on github. Please let me know if I missed any rule that I should follow. Thanks.
