### PR TITLE
Modifiable mode line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ allow users to customize how projectile identifies test files by project type.
 * CVS checkouts are now automatically detected.
 * added `projectile-persp-switch-project` command to make perspective
   mode work along with projectile.
+* Changed `projectile-mode-line-lighter` to a defcustom variable to make
+  mode line indicator prefix customizable.
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -499,6 +499,12 @@ additional functions to the hook using `add-hook`:
 (add-hook 'projectile-idle-timer-hook 'my-projectile-idle-timer-function)
 ```
 
+### Mode line indicator
+
+By default the minor mode indicator of Projectile appears in the form
+"Projectile[ProjectName]". The "Projectile" prefix is configurable using the
+variable `projectile-mode-line-lighter`.
+
 ## Caveats
 
 * Traversing the project directory programmatically (instead of using

--- a/projectile.el
+++ b/projectile.el
@@ -1875,16 +1875,18 @@ is chosen."
 (easy-menu-change '("Tools") "--" nil "Search Files (Grep)...")
 
 ;;;###autoload
-(defconst projectile-mode-line-lighter " Projectile"
-  "The default lighter for `projectile-mode'.")
+(defcustom projectile-mode-line-lighter "Projectile"
+  "The default lighter for `projectile-mode'."
+  :group 'projectile
+  :type 'string)
 
-(defvar-local projectile-mode-line projectile-mode-line-lighter
+(defvar-local projectile-mode-line (format " %s" projectile-mode-line-lighter)
   "The dynamic mode line lighter variable for `projectile-mode'.")
 
 (defun projectile-update-mode-line ()
   "Report project in mode-line."
   (let* ((project-name (projectile-project-name))
-         (message (format "%s[%s]" projectile-mode-line-lighter project-name)))
+         (message (format " %s[%s]" projectile-mode-line-lighter project-name)))
     (setq projectile-mode-line message))
   (force-mode-line-update))
 


### PR DESCRIPTION
I tend to work on a smaller screen, with buffers split vertically. This leaves me little space for long strings describing mode names. Generally I use [diminish-mode](http://marmalade-repo.org/packages/diminish) to reduce string names, but this isn't the best option for projectile because I find the dynamically changing string showing the name of the project useful.  

By making `projectile-mode-line-lighter` a customizable variable, people can alter the prefixed "Projectile" as desired. I've moved the leading space out of the variable so that altering the variable doesn't require knowledge that the leading space is necessary for the mode lines to be separate, but it's questionable whether or not that's the right way to do it and I would be happy to change that if you think it's a better idea to leave the leading space under user control.
