### PR TITLE
projectile-kill-buffers tries to reopen old TRAMP buffers

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -772,11 +772,9 @@ Operates on filenames relative to the project root."
 (defun projectile-project-buffer-p (buffer project-root)
   "Check if BUFFER is under PROJECT-ROOT."
   (with-current-buffer buffer
-    (and (s-starts-with? project-root
-                         (file-truename default-directory))
-         ;; ignore hidden buffers
-         (not (s-starts-with? " " (buffer-name buffer)))
-         (not (projectile-ignored-buffer-p buffer)))))
+    (and (not (s-starts-with? " " (buffer-name buffer)))
+         (not (projectile-ignored-buffer-p buffer))
+         (s-starts-with? project-root (file-truename default-directory)))))
 
 (defun projectile-ignored-buffer-p (buffer)
   "Check if BUFFER should be ignored."


### PR DESCRIPTION
Hello,

If I:
- open some files over TRAMP
- kill the buffer/file
- kill all the TRAMP buffers
- naviguate to another project, and open a file there
- do `C-c p k`

The minibuffer shows me that it reopens previous TRAMP connection, eventually decides it's not useful for the buffer lists and behaves properly and asks me if I want to kill the buffers for the current project... but the TRAMP part looks really useless.

Any idea what could trigger this? I assume `projectile-kill-buffers` would be pretty stupid and just iterate over the buffers and check with `projectile-project-root`? I recently discovered ido/recentf was pretty lame reguarding cache when TRAMP was involved, maybe it has something to do with it.

If you have no idea I'll probably investiguate.
