### PR TITLE
projectile-kill-buffers: Ignore indirect buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* Prevent `projectile-kill-buffers` from trying to kill indirect
+  buffers.
+
 ## 0.11.0 (05/27/2014)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -1573,14 +1573,14 @@ With a prefix argument ARG prompts you for a directory on which to run the repla
 (defun projectile-kill-buffers ()
   "Kill all project buffers."
   (interactive)
-  (let* ((buffers (projectile-project-buffer-names))
+  (let* ((buffers (projectile-project-buffers))
          (question
           (format
            "Are you sure you want to kill %d buffer(s) for '%s'? "
            (length buffers)
            (projectile-project-name))))
     (if (yes-or-no-p question)
-        (mapc 'kill-buffer buffers))))
+        (mapc 'kill-buffer (-remove 'buffer-base-buffer buffers)))))
 
 (defun projectile-save-project-buffers ()
   "Save all project buffers."


### PR DESCRIPTION
When an indirect buffer is located after its base buffer in the buffers
list, `projectile-kill-buffers` gives an error ('No buffer named ...').
This commit filters out indirect buffers, which will be killed when the
base buffer is killed.
