### PR TITLE
mentioned that persp-mode should be enabled to use persp-projectile

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ Install package: perspective
 Secondly, make sure `persp-projectile.el` is in your Emacs load path. Then require it in your init file.
 
 ```el
+(persp-mode)
 (require 'persp-projectile)
 ```
 


### PR DESCRIPTION
I noticed some people got error message when using persp-projectile, mainly because they didn't enable perspective mode by the time they call the function, so I think it'd be a good idea to mention that explicitly in README.
