### PR TITLE
projectile-find-tag: Use ggtags-find-tag if bound

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1464,15 +1464,16 @@ regular expression."
 (defun projectile-find-tag ()
   "Find tag in project."
   (interactive)
-  (let ((tags (if (boundp 'ggtags-mode)
+  (let ((find-tag-function (if (boundp 'ggtags-mode) 'ggtags-find-tag 'find-tag))
+        (tags (if (boundp 'ggtags-mode)
                   (projectile--tags (all-completions "" ggtags-completion-table))
                 ;; we have to manually reset the tags-completion-table every time
                 (setq tags-completion-table nil)
                 (tags-completion-table)
                 (projectile--tags tags-completion-table))))
-    (find-tag (projectile-completing-read "Find tag: "
-                                          tags
-                                          (projectile-symbol-at-point)))))
+    (funcall find-tag-function (projectile-completing-read "Find tag: "
+                                                            tags
+                                                            (projectile-symbol-at-point)))))
 
 (defun projectile--tags (completion-table)
   "Find tags using COMPLETION-TABLE."


### PR DESCRIPTION
When using ggtags and projectile, calling `projectile-find-tag` does not visit the tag after selecting from the completion list, but instead asks which tags table to visit.

This patch switches between `find-tag` and `ggtags-find-tag` dynamically.
