### PR TITLE
Add Cargo.toml as a project root file

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -172,6 +172,7 @@ and `projectile-buffers-with-file-or-process'."
     "Gruntfile.js"       ; Grunt project file
     "bower.json"         ; Bower project file
     "composer.json"      ; Composer project file
+    "Cargo.toml"         ; Cargo project file
     )
   "A list of files considered to mark the root of a project."
   :group 'projectile


### PR DESCRIPTION
Cargo.toml is the project file for Cargo, the package manager for Rust. http://crates.io/
