### PR TITLE
Ignore errors when loading a tags file.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1469,7 +1469,9 @@ regular expression."
   (when (projectile-project-p)
     (let ((tags-file (projectile-expand-root projectile-tags-file-name)))
       (when (file-exists-p tags-file)
-        (visit-tags-table tags-file t)))))
+        (with-demoted-errors 
+          "Error loading tags-file: %s"
+          (visit-tags-table tags-file t))))))
 
 (defun projectile-find-tag ()
   "Find tag in project."


### PR DESCRIPTION
When using a project / machine which uses an incompatible tags file, we get an initial failure to load the visited project file itself. (along with the error message that the TAGS file is invalid.)

While silently ignoring the tags file error is not the best thing in the world,  not loading the file we are interested in is a whole lot worse.

Without adding a lot of overhead (perhaps a defadvice on visit tags file) this is the simplest way to avoid the issue.  However, it would be nicer to handle the problem more effectively (at the very least sending a message )
