### PR TITLE
Define helm source for projects list

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -126,8 +126,11 @@
 (defvar helm-source-projectile-projects-list
   `((name . "Projects")
     (candidates . projectile-known-projects)
-    (action . projectile-switch-project-by-name)
-    (type . file)))
+    (persistent-action . dired)
+    (action ("Switch to project" . projectile-switch-project-by-name)
+	    ("Projectile commander" . ,(lambda (p)
+					 (projectile-switch-project-by-name p t)))
+ 	    ("Dired" . dired))))
 
 (defcustom helm-projectile-sources-list
   '(helm-source-projectile-files-list


### PR DESCRIPTION
The patch adds new helm source for list of known projects. Unfortunately I was not lucky to find helm developer documentation, so the patch is really basic. I guessed the meaning of helm keys. 
