### PR TITLE
Allow setting projectile root as a file local variable.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -207,7 +207,8 @@ pattern that would have found a project root in a subdirectory."
   :type '(repeat string))
 
 (defcustom projectile-project-root-files-functions
-  '(projectile-root-bottom-up
+  '(projectile-root-file-local
+    projectile-root-bottom-up
     projectile-root-top-down
     projectile-root-top-down-recurring)
   "A list of functions for finding project roots."
@@ -589,6 +590,14 @@ which we're looking."
                                      (directory-file-name file))))
              (setq file nil))))
     (if root (file-name-as-directory root))))
+
+(defvar projectile-custom-root nil
+  "Defines a custom Projectile project root. This is intended to
+  be used as a file local variable.")
+
+(defun projectile-root-file-local (dir)
+  projectile-custom-root
+  )
 
 (defun projectile-root-bottom-up (dir &optional list)
   "Identify a project root in DIR by looking at `projectile-project-root-files-bottom-up'.


### PR DESCRIPTION
This is useful, for example, if you keep your OrgMode files in one git repo but associate them with other projects in other directories. It just saves you having to switch to a different project all the time.

This is my first time contributing to a big elisp project so I have no idea if this is following the proper conventions. Any feedback is appreciated! Also I have no idea if anyone else would find this functionality useful, but I just implemented it for myself in my .emacs.d and decided to push it up here too in case it was useful for others.