### PR TITLE
projectile-ag: vary prompt based on current-prefix-arg

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1437,7 +1437,7 @@ With an optional prefix argument ARG SEARCH-TERM is interpreted as a
 regular expression."
   (interactive
    (list (read-from-minibuffer
-          (projectile-prepend-project-name "Ag search for: ")
+          (projectile-prepend-project-name (format "Ag %ssearch for: " (if current-prefix-arg "regexp " "")))
           (projectile-symbol-at-point))
          current-prefix-arg))
   (if (fboundp 'ag-regexp)


### PR DESCRIPTION
Just a minor convenience: it makes the prompt remind me what kind of search I'm about to do.
