### PR TITLE
Add Helm interface to switch project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@
 
 ### New features
 
+* Add Helm interface to switch project. For more details checkout the file
+  README.md.
 * Make the mode line format customizable with `projectile-mode-line`
 * Add support for `cargo.toml` projects
 * Try to use projectile to find files in compilation buffers
 * Support `helm` as a completion system
-* New `defcustom` `projectile-globally-ignored-buffers` allows you ignore buffers by name
+* New `defcustom` `projectile-globally-ignored-buffers` allows you ignore
+  buffers by name
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -512,11 +512,11 @@ brevity and clarity:
 
 ### Helm Integration
 
-Projectile can be integrated with
-[Helm](https://github.com/emacs-helm/helm) via
-`helm-c-source-projectile` source (available in `helm-projectile.el`). There is also an example function
-for calling Helm with the Projectile file source. You can call it like
-this:
+Projectile can be integrated with [Helm](https://github.com/emacs-helm/helm) via
+`helm-source-projectile-projects`, `helm-source-projectile-files-list`,
+`helm-source-projectile-buffers-list` and `helm-source-projectile-recentf-list`
+sources (available in `helm-projectile.el`). There is also an example function
+for calling Helm with the Projectile file source. You can call it like this:
 
 ```
 M-x helm-projectile
@@ -527,6 +527,17 @@ or even better - bind it to a keybinding like this:
 ```el
 (global-set-key (kbd "C-c h") 'helm-projectile)
 ```
+
+For those who prefer helm to ido, the command `helm-projectile-switch-project`
+can be used to replace `projectile-switch-project` to switch project. Please
+note that this is different from simply setting `projectile-completion-system`
+to `helm`, which just enables projectile to use the Helm completion to complete
+a project name. The benefit of using `helm-projectile-switch-project` is that on
+any selected project we can fire many actions, not limited to just the "switch
+to project" action, as in the case of using helm completion by setting
+`projectile-completion-system` to `helm`. Currently only three actions have been
+provided, these are "Switch to project", "Open Dired in project's directory" and
+"Switch to Eshell", but we will definitely add more in the future.
 
 Obviously you need to have Helm installed for this to work :-)
 


### PR DESCRIPTION
Hi Bozhidar Batsov,

I've just added a new feature to allow switching project using helm interface.
Please note that this is different from simply setting
`projectile-completion-system` to `helm` which only enables projectile to use
the Helm Completion to complete a project name. This commit added new command
`helm-projectile-switch-project`, and bind to "H" in projectile command map by
default. The new command uses helm interface instead of ido to switch project.
The benefit of this approach is that on any selected project we can fire many
actions, not limited to just one action of "switch to project", as in the case
of using helm completion by simply setting `projectile-completion-system` to
`helm`. Currently there are only three actions, namely "Switch to project",
"Open Dired in project's directory" and "Switch to Eshell", but will definitely
add more in the future.

Could you please consider including my patch?
