### PR TITLE
Add a new command to pull up git status and switch to a file from the list of changes.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1066,14 +1066,15 @@ https://github.com/d11wtq/grizzl")))
 
 (defun projectile-git-changed ()
   "Return a list of files that are added, copied, modified, or unmerged according to git."
-  (let ((git-command "git diff --name-only --diff-filter=ACMU"))
-    (split-string (replace-regexp-in-string "\n$" "" (shell-command-to-string (format "(cd %s && %s)" (projectile-project-root) git-command))) "\n")))
+  (let ((default-directory (projectile-project-root)))
+    (split-string (shell-command-to-string "git diff --name-only --diff-filter=ACMU"))))
 
 (defun projectile-git-status ()
   "Return a list of files with their git status, only for files in `projectile-git-changed'."
   (let* ((file-list (mapconcat 'identity (projectile-git-changed) " "))
-         (command (format "git -c color.status=false status --short -- %s" file-list)))
-    (split-string (replace-regexp-in-string "\n$" "" (shell-command-to-string (format "(cd %s && %s)" (projectile-project-root) command))) "\n")))
+         (git-command (format "git -c color.status=false status --short -- %s" file-list))
+         (default-directory (projectile-project-root)))
+    (split-string (shell-command-to-string git-command) "\n" t)))
 
 (defun projectile-process-current-project-files (action)
   "Process the current project's files using ACTION."


### PR DESCRIPTION
@bbatsov I find myself wanting to just see a list of modified files and switch to one of them as soon as I open up a project, so I added this command.

![Screenshot](https://www.evernote.com/shard/s2/sh/cfa1d2e3-5cde-42d5-b83e-25e65918b4c1/c15ed7353276d9135412a833f8780f50/res/80f260b4-90bc-4a96-b6ba-4481232168eb/skitch.png)

There's a little extra complication because I wanted to see whether the file was modified, added, etc (the ` M` or `??`). But it gets the job done (`projectile-git-changed` gets the list of files that we want, essentially filtering out deleted files, and `projectile-git-status` gets the status strings for each file).

But I could use your advice on what's going on with `completing-read` here. It seems that when you press enter without typing anything, it passes in an empty string instead of the first item in the list.