### PR TITLE
Add new command "projectile-find-other-file"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+* Add command projectile-find-other-file  Switch between files with
+  the same  name but different extensions.
 * Add Helm interface to switch project. For more details checkout the file
   README.md.
 * Make the mode line format customizable with `projectile-mode-line`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ it. Some of Projectile's features:
 * jump to a file in a directory
 * jump to a project buffer
 * jump to a test in project
+* toggle between files with same names but different extensions (i.e. .h <-> .cpp)
 * toggle between code and its test
 * jump to recently visited files in the project
 * switch between projects you have worked on
@@ -298,6 +299,7 @@ Keybinding         | Description
 <kbd>C-c p 4 f</kbd> | Jump to a project's file using completion and show it in another window.
 <kbd>C-c p d</kbd> | Display a list of all directories in the project. With a prefix argument it will clear the cache first.
 <kbd>C-c p 4 d</kbd> | Switch to a project directory and show it in another window.
+<kbd>C-c p 4 a</kbd> | Switch between files with the same name but different extensions in other window.
 <kbd>C-c p T</kbd> | Display a list of all test files(specs, features, etc) in the project.
 <kbd>C-c p l</kbd> | Display a list of all files in a directory (that's not necessarily a project)
 <kbd>C-c p s g</kbd> | Run grep on the files in the project.
@@ -306,6 +308,7 @@ Keybinding         | Description
 <kbd>C-c p b</kbd> | Display a list of all project buffers currently open.
 <kbd>C-c p 4 b</kbd> | Switch to a project buffer and show it in another window.
 <kbd>C-c p 4 C-o</kbd> | Display a project buffer in another window without selecting it.
+<kbd>C-c p a</kbd> | Switch between files with the same name but different extensions.
 <kbd>C-c p o</kbd> | Runs `multi-occur` on all project buffers currently open.
 <kbd>C-c p r</kbd> | Runs interactive query-replace on all files in the projects.
 <kbd>C-c p i</kbd> | Invalidates the project cache (if existing).


### PR DESCRIPTION
This command is used for switching between files with the same name but
with different extensions in the current project. It would be useful for
switching between header files and source files in C/C++, and possibly
test files with the same names.
