### PR TITLE
add html and js to projectile-other-file-alist

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1104,6 +1104,10 @@ https://github.com/d11wtq/grizzl")))
     ("vert" . ("frag"))
     ("frag" . ("vert"))
 
+    ;; usefull for some web mvc-ish programming
+    ("js" . ("html"))
+    ("html" . ("js"))
+    
     ;; handle files with no extension
     (nil . ("lock" "gpg"))
     ("lock" . (""))


### PR DESCRIPTION
I've added this, to great delight - Thank you! - to my emacs.d for when I'm writing meteor.js code.
No idea if this comes in handy for other frameworks' naming conventions.
Just throwing it out there.