### PR TITLE
Add Helm action for incremental grep in selected projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Add Helm action for incremental grep in the selected projects.
 * Add command projectile-find-other-file  Switch between files with
   the same  name but different extensions.
 * Add Helm interface to switch project. For more details checkout the file

--- a/README.md
+++ b/README.md
@@ -538,10 +538,16 @@ to `helm`, which just enables projectile to use the Helm completion to complete
 a project name. The benefit of using `helm-projectile-switch-project` is that on
 any selected project we can fire many actions, not limited to just the "switch
 to project" action, as in the case of using helm completion by setting
-`projectile-completion-system` to `helm`. Currently only four actions have been
-provided, these are "Switch to project", "Open Dired in project's directory",
-"Open project root in vc-dir or magit" and "Switch to Eshell", but we will
-definitely add more in the future.
+`projectile-completion-system` to `helm`. Currently, there are five actions:
+"Switch to project", "Open Dired in project's directory", "Open project root in
+vc-dir or magit", "Switch to Eshell" and "Grep project files". We will add more
+and more actions in the future.
+
+Note that the helm grep is different from `projectile-grep` because the helm
+grep is incremental. To use it, select your projects (select multiple projects
+by pressing C-SPC), press "C-s" (or "C-u C-s" for recursive grep), and type your
+regexp. As you type the regexp in the mini buffer, the live grep results are
+displayed incrementally.
 
 Obviously you need to have Helm installed for this to work :-)
 

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -92,6 +92,8 @@
                    (kbd "M-g") 'helm-projectile-vc)
                  (helm-projectile-define-key map
                    (kbd "M-e") 'helm-projectile-switch-to-eshell)
+                 (helm-projectile-define-key map
+                   (kbd "C-s") 'helm-find-files-grep)
                  map))
     (action . (("Switch to project" .
                 (lambda (project)
@@ -100,7 +102,8 @@
                ("Open Dired in project's directory `C-d'" . dired)
                ("Open project root in vc-dir or magit `M-g'" .
                 helm-projectile-vc)
-               ("Switch to Eshell `M-e'" . helm-projectile-switch-to-eshell))))
+               ("Switch to Eshell `M-e'" . helm-projectile-switch-to-eshell)
+               ("Grep in projects `C-s C-u Recurse'" . helm-find-files-grep))))
   "Helm source for known projectile projects.")
 
 (defvar helm-source-projectile-files-list


### PR DESCRIPTION
Hi Bozhidar,

I just add a new Helm action for incremental grep:

Add a new Helm action (bound to "C-s") to do incremental grep in the selected
projects. To use it, press "C-c ph" to fire `helm-projectile`, select your
project (press "C-SPC" to select multiple projects), type "C-s" (or "C-u C-s"
for recursive grep), and then type your regexp. As you type the regexp in the
mini buffer, the live grep results will be displayed incrementally.
