### PR TITLE
Allow wildcards in projectile-project-root-files

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -615,7 +615,7 @@ Returns a project root directory path or nil if not found."
   (projectile-locate-dominating-file
    dir
    (lambda (dir)
-     (--first (projectile-file-exists-p (expand-file-name it dir))
+     (--first (file-expand-wildcards (expand-file-name it dir))
               (or list projectile-project-root-files (list))))))
 
 (defun projectile-root-top-down-recurring (dir &optional list)


### PR DESCRIPTION
So after we got haskell project identification working which is enough if the project is under version control, it would be nice if projects without vcs are recognized as well. :)

To do so, we have to allow wildcards when searching for project-root-files as well.

What do you thing about replacing `projectile-file-exits-p` with `file-expand-wildcards` again?
