### PR TITLE
Improve TRAMP performance

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -19,7 +19,7 @@
 
 (defun project-root-in (directory)
   (let ((default-directory (f-expand directory)))
-    (setq projectile--project-root nil)
+    (setq projectile-project-root-cache (make-hash-table :test 'equal))
     (projectile-project-root)))
 
 (provide 'test-helper)


### PR DESCRIPTION
**DON'T MERGE THIS YET**

The idea is to make a mini code review here. See #234 for more explanations.

Basically, delay projectile directory walking until absolutely necessary when over TRAMP. Performance over TRAMP is now instantaneous when you open files & friends, yet projectile still works if you press key combos like <kbd>C-c p f</kbd>.

I tried not to tie the implementation to TRAMP, that way people can tweak it for any conditions they can think of.

Things to be discussed:
- Variable names? Maybe `projectile-lazy-when`, `projectile-is-lazy-p` would be better names?
- What can go wrong here?
