### PR TITLE
Remove another unnecessary action and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,9 @@ commands:
 If you already activate helm-projectile key bindings and you don't like it, you can turn it off
 and use the normal Projectile bindings with command `helm-projectile-off`.
 
+To fully learn Helm Projectile and see what it is capable of, you should refer to this guide:
+[Exploring large projects with Projectile and Helm Projectile](http://tuhdo.github.io/helm-projectile.html).
+
 Obviously you need to have Helm installed for this to work :-)
 
 ![Helm-Projectile Screenshot](https://github.com/bbatsov/projectile/raw/master/screenshots/helm-projectile.png)

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -162,7 +162,6 @@ DIR is the project root."
    "Serial rename by copying files" 'helm-ff-serial-rename-by-copying
    "Open file with default tool" 'helm-open-file-with-default-tool
    "Find file in hex dump" 'hexl-find-file
-   "Complete at point `C-c i'" 'helm-insert-file-name-completion-at-point
    "Insert as org link `C-c @'" 'helm-files-insert-as-org-link
    "Open file externally `C-c C-x, C-u to choose'" 'helm-open-file-externally
    "Grep File(s) `C-s, C-u Recurse'" 'helm-find-files-grep


### PR DESCRIPTION
The action "Complete at point" is not needed for helm-projectile. It is
used in helm-find-files to complete partial paths, but we always get
full paths in helm-projectile.
