### PR TITLE
Clear projectile--project-root cache properly

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2082,6 +2082,7 @@ With a prefix ARG invokes `projectile-commander' instead of
         (unless (projectile-restore-window-config (projectile-project-name))
           (funcall switch-project-action)
           (delete-other-windows))
+      (setq projectile--project-root nil)
       (funcall switch-project-action))
     (run-hooks 'projectile-switch-project-hook)))
 


### PR DESCRIPTION
projectile--project-root needs to be cleared when invoking
projectile-switch-project-by-name, otherwise
projectile-switch-project would wronly switch to the current
project i.e. not switch at all.
