### PR TITLE
Add file listing for sub-projects to Projectile

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -719,6 +719,11 @@ Files are returned as relative paths to the project root."
   :group 'projectile
   :type 'string)
 
+(defcustom projectile-git-submodule-command "git submodule --quiet foreach 'echo $name' | tr '\\n' '\\0'"
+  "Command used by projectile to get the files in a git project."
+  :group 'projectile
+  :type 'string)
+
 (defcustom projectile-hg-command "hg locate -0 -I ."
   "Command used by projectile to get the files in a hg project."
   :group 'projectile
@@ -761,9 +766,111 @@ Files are returned as relative paths to the project root."
      ((eq vcs 'svn) projectile-svn-command)
      (t projectile-generic-command))))
 
+(defun projectile-get-sub-projects-command ()
+  (let ((vcs (projectile-project-vcs)))
+    (cond
+     ((eq vcs 'git) projectile-git-submodule-command)
+     (t ""))))
+
+(defun projectile-get-all-sub-projects (project &optional known-projects)
+  "Get all sub-projects for a given projects.
+PROJECT is base directory to start search recursively.
+KNOWN-PROJECTS is all the currently known sub-projects.  It is used for testing
+already traversed sub-projects.
+
+The function handles also the case that a project has sub-projects that
+includes themselves as modules and could create a infinite loop when traverse
+the sub-project tree.  A sub-project is a another project inside current project
+that could also be consider a project when standing on its own.  Git submodule
+is an example of a sub-project.  This function is designed to extend with
+more VCS in general, since it uses the function `projectile-get-sub-projects-command'
+to return appropriate command for a VCS to list sup-project.
+
+Now, consider a project tree like this:
+
+root/
+    sub-project1/
+    sub-project2/
+    sub-project3/
+    .... main project's files and directories....
+
+Each such sub-project can also have sub-projects.  In the normal
+case, we can walk the directory tree all they way down.  The problem is,
+sub-projects can include itself as a sub-project! To solve this problem,
+the function checks that if it encounters existing sub-projects already
+processed before (this means the function walks up the directory tree again),
+it simply ignores to avoid infinite loop.
+
+An example is `yasnippet' Git project at the time of writing this:
+
+yasnippet/
+    snippets/  -> submodule
+    yasmate/   -> submodule
+
+
+Running \"git submodule\" inside `yasnippet/' returns this result:
+
+ 16154e1462a8bbb2c5cf48e1101bd3f2c090e0fc snippets (remotes/origin/cleanup_html_tags-7-g16154e1)
+ 0543618bd34a6715918992f01161c118f136bb37 yasmate (0543618)
+
+Running \"git submodule\" inside `yasnippet/yasmate' returns this result:
+
+-993588a35d665427209936618a9e524679480e95 bundles/html-tmbundle
+-d0c1ae22d326d310edaf126acf93588b7958f682 bundles/objc-tmbundle
+-8091f39a6efd288c8793321e8822a639db3cc940 bundles/rails-tmbundle
+-da63813a86d46f17abf0a9303de1149ca7cee60a bundles/ruby-tmbundle
+
+We change into the directory of either of those directory, for example:
+
+cd bundles/ruby-tmbundle
+
+Running \"git submodule\" any of those submodule returns this result:
+
+-993588a35d665427209936618a9e524679480e95 ../html-tmbundle
+-d0c1ae22d326d310edaf126acf93588b7958f682 ../objc-tmbundle
+-8091f39a6efd288c8793321e8822a639db3cc940 ../rails-tmbundle
+-da63813a86d46f17abf0a9303de1149ca7cee60a ../ruby-tmbundle
+
+So, each of those modules is point to itself! We must only check to avoid
+looping at a single point."
+  (let* ((default-directory project)
+         ;; search for sub-projects under current project `project'
+         (submodules (mapcar
+                      (lambda (s)
+                        (expand-file-name (concat s "/") default-directory))
+                      (projectile-files-via-ext-command (projectile-get-sub-projects-command)))))
+
+    ;; check if there are more submodules to be processed
+    ;; if not, returns found submodules since we reach the base case of recursion.
+    ;; or, if the current project already in the sub-project list;
+    ;; we are simply getting into a loop, so better terminate it here and returns nil
+    ;; because we already processed it..
+    (cond
+     ((null submodules) known-projects)
+     ((member project known-projects) submodules)
+     (t
+      (-flatten
+       ;; recursively get sub-projects of each sub-project
+       (mapcar (lambda (s)
+                 (projectile-get-all-sub-projects s (nconc known-projects submodules))) submodules))))))
+
+(defun projectile-get-sub-projects-files ()
+  "Get files from sub-projects recursively."
+  (-flatten
+   (mapcar (lambda (s)
+             (let ((default-directory s))
+               (mapcar (lambda (f)
+                         (concat s f))
+                       (projectile-files-via-ext-command projectile-git-command))))
+           (projectile-get-all-sub-projects (projectile-project-root)))))
+
 (defun projectile-get-repo-files ()
-  "Get a list of the files in the project."
-  (projectile-files-via-ext-command (projectile-get-ext-command)))
+  "Get a list of the files in the project, including sub-projects."
+  (cond
+   ((eq (projectile-project-vcs) 'git)
+    (nconc (projectile-files-via-ext-command (projectile-get-ext-command))
+           (projectile-get-sub-projects-files)))
+   (t (projectile-files-via-ext-command (projectile-get-ext-command)))))
 
 (defun projectile-files-via-ext-command (command)
   "Get a list of relative file names in the project root by executing COMMAND."


### PR DESCRIPTION
Add the ability for Projectile to automatically see sub-projects in a project like Git submodule. It can handle cycle submodules (submodules that can include itself as submodules and create a loop). The scenario is described in details in function projectile-get-all-sub-projects.

 Demo (begins when START DEMO appears in minibuffer):

In the first demo, I already cloned [yasnippet](https://github.com/capitaomorte/yasnippet), and then listed its submodules. The output showed that I got 3 submodules: 
- Two from yasnippet: `snippets` and `yasmate`. The interesting thing is that inside each of `yasmate` submodules also contain submodules, and these submodules are actually pointed to itself. 
- One I added myself, that is another `yasnippet` inside the current yasnippet to further demonstrate handling of loop submodules. The nested `yasnippet` also has the problem described above.

![git-submodules-recursive](https://cloud.githubusercontent.com/assets/4818719/4598032/33b99eb6-50b4-11e4-92fb-4d5d3801624c.gif)

The next demo shows the result of this commit:
- The file listing in `helm-projectile-find-file` includes submodule files, that are `yasnippet`, `snippets` and `yasmate` in that order. In the end, you can even see that the narrow files from `yasmate` pattern comes from two submodules: One belongs to the nested `yasnippet` and one belongs to the current `yasnippet`.

![helm-projectile-find-files-submodules](https://cloud.githubusercontent.com/assets/4818719/4598034/3f23ff76-50b4-11e4-90cb-d8e44935f88d.gif)

My only remaining concern is the command to get submodule list in current project:

``` lisp
(defcustom projectile-git-submodule-command "git submodule | awk '{ print $2 }' | tr '\\n' '\\0' | sed -e 's/ //g'"
  "Command used by projectile to get the files in a git project."
  :group 'projectile
  :type 'string)
```

Aside from `git submodule` command, I will convert the remaining to Elisp for portability.
