### PR TITLE
Fix helm-projectile-vc

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -71,8 +71,10 @@
   "A Helm action for jumping to project root using `vc-dir' or Magit.
 DIR is a directory to be switched"
   (let ((projectile-require-project-root nil))
-    (with-helm-default-directory (expand-file-name dir (projectile-project-root))
-        (projectile-vc))))
+    (cond
+     ((and (eq (projectile-project-vcs dir) 'git) (fboundp 'magit-status))
+      (magit-status dir))
+     (t (vc-dir dir)))))
 
 (defun helm-projectile-compile-project (dir)
   "A Helm action for compile a project.

--- a/projectile.el
+++ b/projectile.el
@@ -1447,9 +1447,12 @@ With a prefix ARG invalidates the cache first."
 Expands wildcards using `file-expand-wildcards' before checking."
   (file-expand-wildcards (projectile-expand-root file)))
 
-(defun projectile-project-vcs ()
-  "Determine the VCS used by the project if any."
-  (let ((project-root (projectile-project-root)))
+(defun projectile-project-vcs (&optional dir)
+  "Determine the VCS used by the project if any.
+DIR is the targeted directory.  If nil, use `projectile-project-root'."
+  (let ((project-root (if dir
+                          dir
+                        (projectile-project-root))))
     (cond
      ((projectile-file-exists-p (expand-file-name ".git" project-root)) 'git)
      ((projectile-file-exists-p (expand-file-name ".hg" project-root)) 'hg)


### PR DESCRIPTION
Currently we cannot switch to a project using vc-dir or magit-status
because helm-projectile-vc cannot pass the selected project directory
into projectile-vc, even if it expanded correctly and pass to
with-helm-default-directory. This fix makes it simpler to switch to
VC status.

The change to projectile-project-vc also makes it much faster to switch
project because it does not need to compute project root when explicitly
supplied. Otherwise, there's a brief unnecessary delay.
