### PR TITLE
helm-projectile.el: rewrite `helm-projectile-define-key' to allow defini...

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -60,12 +60,21 @@
   (with-current-buffer (helm-candidate-buffer)
     (expand-file-name candidate helm-projectile-current-project-root)))
 
-(defmacro helm-projectile-define-key (map key fun)
-  (declare (indent 1))
-  `(define-key ,map ,key
-     (lambda ()
-       (interactive)
-       (helm-quit-and-execute-action ,fun))))
+(defmacro helm-projectile-define-key (keymap key def &rest bindings)
+  "In KEYMAP, define key sequence KEY1 as DEF1, KEY2 as DEF2 ..."
+  (declare (indent defun))
+  (let ((ret '(progn)))
+    (while key
+      (add-to-list
+       'ret
+       `(define-key ,keymap ,key
+          (lambda ()
+            (interactive)
+            (helm-quit-and-execute-action ,def)))
+       'append)
+      (setq key (pop bindings)
+            def (pop bindings)))
+    ret))
 
 (defun helm-projectile-vc (dir)
   "A Helm action for jumping to project root using `vc-dir' or Magit.
@@ -90,14 +99,11 @@ DIR is the project root."
                       projectile-known-projects)))
     (keymap . ,(let ((map (make-sparse-keymap)))
                  (set-keymap-parent map helm-map)
-                 (helm-projectile-define-key map (kbd "C-d") 'dired)
                  (helm-projectile-define-key map
-                   (kbd "M-g") 'helm-projectile-vc)
-                 (helm-projectile-define-key map
-                   (kbd "M-e") 'helm-projectile-switch-to-eshell)
-                 (helm-projectile-define-key map
-                   (kbd "C-s") 'helm-find-files-grep)
-                 (helm-projectile-define-key map
+                   (kbd "C-d") 'dired
+                   (kbd "M-g") 'helm-projectile-vc
+                   (kbd "M-e") 'helm-projectile-switch-to-eshell
+                   (kbd "C-s") 'helm-find-files-grep
                    (kbd "C-c") 'helm-projectile-compile-project)
                  map))
     (action . (("Switch to project" .
@@ -124,9 +130,10 @@ DIR is the project root."
   (let ((map (copy-keymap helm-find-files-map)))
     (define-key map (kbd "<left>") 'helm-previous-source)
     (define-key map (kbd "<right>") 'helm-next-source)
-    (helm-projectile-define-key map (kbd "M-e") 'helm-projectile-switch-to-eshell)
-    (helm-projectile-define-key map (kbd "M-.") 'helm-projectile-ff-etags-select-action)
-    (helm-projectile-define-key map (kbd "M-!") 'helm-projectile-find-files-eshell-command-on-file-action)
+    (helm-projectile-define-key map
+      (kbd "M-e") 'helm-projectile-switch-to-eshell
+      (kbd "M-.") 'helm-projectile-ff-etags-select-action
+      (kbd "M-!") 'helm-projectile-find-files-eshell-command-on-file-action)
     map))
 
 (define-key helm-etags-map (kbd "C-c p f") (lambda ()
@@ -244,9 +251,10 @@ DIR is the project root."
                 (projectile-current-project-dirs))))
     (keymap . ,(let ((map (make-sparse-keymap)))
                  (set-keymap-parent map helm-map)
-                 (helm-projectile-define-key map (kbd "C-c o") 'helm-projectile-dired-find-dir-other-window)
-                 (helm-projectile-define-key map (kbd "M-e") 'helm-projectile-switch-to-eshell)
-                 (helm-projectile-define-key map (kbd "C-s") 'helm-find-files-grep)
+                 (helm-projectile-define-key map
+                   (kbd "C-c o") 'helm-projectile-dired-find-dir-other-window
+                   (kbd "M-e")   'helm-projectile-switch-to-eshell
+                   (kbd "C-s")   'helm-find-files-grep)
                  map))
     (action . (("Open Dired" . helm-projectile-dired-find-dir)
                ("Open Dired in other window`C-c o'" . helm-projectile-dired-find-dir)


### PR DESCRIPTION
Hi Bozhidar,

I just rewrote the macro `helm-projectile-define-key` that I had written previously, to allow defining multiple keys. I then used the enhanced macro to clean up the code where `helm-projectile-define-key` are being called repeatedly while defining multiple key bindings.

To illustrate, when previously we have to write:

```
(helm-projectile-define-key KEYMAP KEY1 DEF1)
(helm-projectile-define-key KEYMAP KEY2 DEF2)
(helm-projectile-define-key KEYMAP KEY3 DEF3)
```

Now, we can clean it up to:

```
(helm-projectile-define-key KEYMAP
   KEY1 DEF1
   KEY2 DEF2
   KEY3 DEF3)
```

Could you please merge it if you agree with my improvement?

York Zhao
