### PR TITLE
Performance optimization and eliminate boilerplate code

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -79,10 +79,7 @@
   "A Helm action for jumping to project root using `vc-dir' or Magit.
 DIR is a directory to be switched"
   (let ((projectile-require-project-root nil))
-    (cond
-     ((and (eq (projectile-project-vcs dir) 'git) (fboundp 'magit-status))
-      (magit-status dir))
-     (t (vc-dir dir)))))
+    (projectile-vc dir)))
 
 (defun helm-projectile-compile-project (dir)
   "A Helm action for compile a project.

--- a/projectile.el
+++ b/projectile.el
@@ -1955,15 +1955,17 @@ to run the replacement."
   (interactive)
   (dired (projectile-project-root)))
 
-(defun projectile-vc ()
+(defun projectile-vc (&optional project-root)
   "Open `vc-dir' at the root of the project.
 
 For git projects `magit-status' is used if available."
   (interactive)
+  (or project-root (setq project-root (projectile-project-root)))
   (cond
-   ((and (eq (projectile-project-vcs) 'git) (fboundp 'magit-status))
-    (magit-status (projectile-project-root)))
-   (t (vc-dir (projectile-project-root)))))
+   ((and (eq (projectile-project-vcs project-root) 'git)
+         (fboundp 'magit-status))
+    (magit-status project-root))
+   (t (vc-dir project-root))))
 
 (defun projectile-recentf ()
   "Show a list of recently visited files in a project."


### PR DESCRIPTION
Hi Bozhidar,

I added a few improvements:
1. Optimized the macro `helm-source-projectile-projects` for the sake of performance. This is because "list" in Emacs Lisp is singly-linked list, frequently adding to the end of a list using `add-to-list` can be slow. For this reason, it's better to add to the front of a list, and just do a one-time reverse after adding all the items.
2. Minor cleanup on `projectile-project-vcs`
3. Added the optional parameter `project-root` for function `projectile-vc` to allow being called from `helm-projectile-vc`, to eliminate boilerplate code.

Thanks,

York Zhao
