### PR TITLE
Display which projects were cleaned up

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2252,10 +2252,20 @@ This command will first prompt for the directory the file is in."
   :group 'projectile
   :type 'hook)
 
+(defun projectile-keep-project-p (project)
+  "Determine wether we should cleanup this project or not.
+
+It handles the case of remote files as well. See `projectile-cleanup-known-projects'."
+  ;; Taken from from `recentf-keep-default-predicate'
+  (cond
+   ((file-remote-p project nil t) (file-readable-p project))
+   ((file-remote-p project))
+   ((file-readable-p project))))
+
 (defun projectile-cleanup-known-projects ()
   "Remove known projects that don't exist anymore."
   (interactive)
-  (let* ((separated-projects (-separate #'projectile-file-exists-p projectile-known-projects))
+  (let* ((separated-projects (-separate #'projectile-keep-project-p projectile-known-projects))
          (projects-kept (car separated-projects))
          (projects-removed (cadr separated-projects)))
     (setq projectile-known-projects projects-kept)


### PR DESCRIPTION
Hello,

This improves `projectile-cleanup-known-projects`.

I added an additional `ignore-errors` in there, so it'd not stop on old dead TRAMP invalid hosts and continue cleaning up. I'm not completely sure about this, because it means that if you refuse to log in your host it'll remove the remote projects... but at the same time you're supposed to log in in order for projectile to check the path is still valid.

@thomasf: what's your take on the `ignore-errors` part?
