### PR TITLE
Do not try to traverse http:// and https:// paths.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -972,6 +972,7 @@ Operates on filenames relative to the project root."
     (and (not (s-starts-with? " " (buffer-name buffer)))
          (not (projectile-ignored-buffer-p buffer))
          (s-equals? (file-remote-p default-directory) (file-remote-p project-root))
+         (not (s-matches? "^http\\(s\\)?://" default-directory))
          (s-starts-with? project-root (file-truename default-directory)))))
 
 (defun projectile-ignored-buffer-p (buffer)


### PR DESCRIPTION
fixes #473  .

Even though I suspect there might be either a function or a regexp hidden somewhere in Emacs I could not find it. This works for http/https.
