### PR TITLE
run projectile-switch-project-hook prior to calling switch action

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2210,10 +2210,13 @@ With a prefix ARG invokes `projectile-commander' instead of
                                   projectile-switch-project-action)))
     (if projectile-remember-window-configs
         (unless (projectile-restore-window-config (projectile-project-name))
+	  (run-hooks 'projectile-switch-project-hook)
           (funcall switch-project-action)
           (delete-other-windows))
-      (funcall switch-project-action))
-    (run-hooks 'projectile-switch-project-hook)))
+        (progn 
+          (run-hooks 'projectile-switch-project-hook)
+          (funcall switch-project-action)))
+    ))
 
 
 (defun projectile-find-file-in-directory (&optional directory)


### PR DESCRIPTION
The `projectile-switch-project-hook` is useful for loading project specific settings. Those will be delayed because of a blocking switch project action. So, in some cases, like mode settings, those won't be set in time until after the mode is activated on the buffer following a find-file action. I'm not that familiar with the projectile code-base, so I'm hoping that the ordering of this hook can be alternated with the action, without much fuss.
