### PR TITLE
git cannot run submodule if the .git folder is not at the project root

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -776,9 +776,12 @@ Files are returned as relative paths to the project root."
      (t projectile-generic-command))))
 
 (defun projectile-get-sub-projects-command ()
-  (let ((vcs (projectile-project-vcs)))
+  (let ((vcs (projectile-project-vcs))
+        (project-root (projectile-project-root)))
     (cond
-     ((eq vcs 'git) projectile-git-submodule-command)
+     ((and (eq vcs 'git)
+           (projectile-file-exists-p (expand-file-name ".git" project-root)))
+        projectile-git-submodule-command)
      (t ""))))
 
 (defun projectile-get-all-sub-projects (project &optional known-projects)


### PR DESCRIPTION
I have a grails project that must defines a project under a child folder of the git repository root.
- repo root
  - .git
  - grails-project-root
    - .projectile
  - ... other top level folders ...

`projectile-project-vcs` correctly locates the git repository at 

`repo root`

 via `projectile-locate-dominating-file` prompting `projectile-get-sub-projects-command` to return the git submodule command string to be run at 

`grails-project-root`.

When you try and do this in git, it fails and returns

> You need to run this command from the toplevel of the working tree.

This request alleviates this by making sure that the `.git` folder is in
`projectile-project-root` before returning the submodule string.
