### PR TITLE
Autoload projectile-kill-buffers

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1933,6 +1933,7 @@ to run the replacement."
   "Get the symbol at point and strip its properties."
   (substring-no-properties (or (thing-at-point 'symbol) "")))
 
+;;;###autoload
 (defun projectile-kill-buffers ()
   "Kill all project buffers."
   (interactive)


### PR DESCRIPTION
I don't really use `projectile-mode`, but I find this command extremely useful, and it works perfectly well without `projectile-mode` enabled. It therefore makes sense to have it autoloaded. (It's likely that there are a number of such functions, and I'd encourage you to autoload them all.)
