### PR TITLE
Fix helm-projectile-find-dir

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -407,10 +407,12 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
 
 (defvar helm-source-projectile-directories-list
   `((name . "Projectile Directories")
-    (candidates . (lambda ()
-                    (if projectile-find-dir-includes-top-level
-                        (append '("./") (projectile-current-project-dirs))
-                      (projectile-current-project-dirs))))
+    (init . (lambda ()
+              (helm-projectile-init-buffer-with-files (projectile-project-root)
+                                                      (if projectile-find-dir-includes-top-level
+                                                          (append '("./") (projectile-current-project-dirs))
+                                                        (projectile-current-project-dirs)))))
+    (candidates-in-buffer)
     (keymap . ,(let ((map (make-sparse-keymap)))
                  (set-keymap-parent map helm-map)
                  (helm-projectile-define-key map


### PR DESCRIPTION
The command is fixed to populate a list of directory at init time, not
when we want to get a list of candidates. Otherwise, the command usually
presents an empty list.
