### PR TITLE
[Bug fix] Use correct filter function

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -231,11 +231,11 @@ It is there because Helm requires it."
   "Get all current Dired buffers."
   (mapcar (lambda (b)
             (with-current-buffer b (buffer-name)))
-          (filter (lambda (b)
-                    (with-current-buffer b
-                      (and (eq major-mode 'dired-mode)
-                           (buffer-name))))
-                  (buffer-list))))
+          (-filter (lambda (b)
+                     (with-current-buffer b
+                       (and (eq major-mode 'dired-mode)
+                            (buffer-name))))
+                   (buffer-list))))
 
 (defun helm-projectile-dired-files-new-action (candidate)
   "Create a Dired buffer from chosen files.


### PR DESCRIPTION
It's supposed to be -filter, not filter in the function
helm-projectile-all-dired-buffers.
