### PR TITLE
[FIX] Add timer to allow canceling helm-projectile-grep/ack properly, fix helm-projectile-ack file ignoring

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -665,10 +665,10 @@ If it is nil, or ack/ack-grep not found then use default grep command."
                       'identity
                       (-union (-map (lambda (path)
                                       (concat "--ignore-dir=" (file-name-nondirectory (directory-file-name path))))
-                                    (projectile-ignored-directories))
+                                    projectile-globally-ignored-directories)
                               (-map (lambda (path)
-                                      (concat "--ignore-file=is:" (file-relative-name path default-directory)))
-                                    (projectile-ignored-files))) " "))
+                                      (concat "--ignore-file=match:" (shell-quote-argument path)))
+                                    projectile-globally-ignored-files)) " "))
         (helm-ack-grep-executable (cond
                                    ((executable-find "ack") "ack")
                                    ((executable-find "ack-grep") "ack-grep")


### PR DESCRIPTION
Without a timer, helm-projectile-ack/ag prevents user to quit the commands with <kbd>C-g</kbd> in one try, thus requires multiple <kbd>C-g</kbd> pressings. A timer introduces a brief delay for Emacs to accept user input and fix multiple <kbd>C-g</kbd> pressings issue. This is also the way `helm-find-files-grep` does.

Currently helm-projectile-ack processes ignored files and directories the same as projectile-ack. This works for directories, but not work for ignoring files with wildcard matching. When user adds files with wildcard, ack will see this not as an argument to it but a search string and returns no result.

This is fixed by using "--ignore-file=match:" pattern that accepts a regex that matches files. Also, `shell-quote-argument` must be used to properly pass the file patterns with regex in it, otherwise ack also returns no result.

Also fix `projectile-vcs` to return correct type for `.projectile` projects: generic type.
