### PR TITLE
Refactor cache predicates for `file-exists-p'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Refactor `projectile-file-exists-(local|remote)-cache-expire`.
 * Replace Helm equivalent commands in `projectile-commander` when using Helm.
 * Add replacement commands projectile-grep, projectile-ack and projectile-ag with its Helm version.
 * Add virtual directory manager that allows to create/update (add or delete files) a Dired buffer based on Projectile files.

--- a/README.md
+++ b/README.md
@@ -165,24 +165,24 @@ periods of time when opening files and browsing directories.
 The most common example would be interfacing with remote systems using
 TRAMP/ssh. By default all remote file existence checks are cached
 
-To disable remote file exists cache that use this snippet of code:
+To disable the file exists cache then use this snippet of code:
 
 ```el
-(setq projectile-file-exists-remote-cache-expire nil)
+(setq projectile-file-exists-cache-predicates nil)
 ```
 
 To change the remote file exists cache expire to 10 minutes use this snippet
 of code:
 
 ```el
-(setq projectile-file-exists-remote-cache-expire (* 10 60))
+(setq projectile-file-exists-cache-predicates `((file-remote-p ,(* 10 60))))
 ```
 
-You can also enable the cache for local file systems, that is normally not
+You can also enable the cache unconditionnaly for any file systems, that is normally not
 needed but possible:
 
 ```el
-(setq projectile-file-exists-local-cache-expire (* 5 60))
+(setq projectile-file-exists-cache-predicates `(((lambda (f) t) ,(* 5 60))))
 ```
 
 #### Using Projectile everywhere

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -317,8 +317,7 @@
   (with-sandbox
    (f-mkdir "project" "dirA" "dirB")
    (f-touch "project/fileA")
-   (let ((projectile-file-exists-local-cache-expire nil)
-         (projectile-file-exists-remote-cache-expire nil))
+   (let ((projectile-file-exists-cache-predicates nil))
      (should (projectile-file-exists-p "project/fileA"))
      (should (projectile-file-exists-p "project/dirA/dirB"))
      (should-not (projectile-file-exists-p "project/dirA/fileB"))
@@ -332,10 +331,8 @@
   (with-sandbox
    (f-mkdir "dirA" "dirB")
    (f-touch "fileA")
-   (let* ((initial-time (current-time))
-          (projectile-file-exists-local-cache-expire 100)
-          (projectile-file-exists-remote-cache-expire nil))
-
+   (let ((initial-time (current-time))
+         (projectile-file-exists-cache-predicates '(((lambda (f) t) 100))))
      (noflet ((run-with-timer (&rest args) 'nooptimer))
        (noflet ((current-time () initial-time))
          (should (projectile-file-exists-p "fileA"))


### PR DESCRIPTION
**DON'T MERGE THIS YET**

When done, it'll fix #521

@thomasf: can you review and green-light this commit?

If ok, I'll apply the same for `projectile-project-root`