### PR TITLE
[Fix #542] Ignore all errors when getting files in sub-projects

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -873,7 +873,7 @@ looping at a single point."
                        (projectile-files-via-ext-command projectile-git-command))))
            (condition-case nil
                (projectile-get-all-sub-projects (projectile-project-root))
-             nil))))
+             (error nil)))))
 
 (defun projectile-get-repo-files ()
   "Get a list of the files in the project, including sub-projects."


### PR DESCRIPTION
To ensure projectile-current-project-files is still functional, we
should just consider getting sub-project files optional bonus. If
Projectile fails to get any sub-project files, just ignore it.
