### PR TITLE
[Fix #545] Retrieve sub-projects correctly and efficiently

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -841,7 +841,8 @@ Running \"git submodule\" any of those submodule returns this result:
 -da63813a86d46f17abf0a9303de1149ca7cee60a ../ruby-tmbundle
 
 So, each of those modules is point to itself! We must only check to avoid
-looping at a single point."
+looping at a single point. Thankfully, wich the command git submodule --quiet foreach 'echo $name',
+we can avoid such case."
   (let* ((default-directory project)
          ;; search for sub-projects under current project `project'
          (submodules (mapcar
@@ -849,19 +850,14 @@ looping at a single point."
                         (file-name-as-directory (expand-file-name s default-directory)))
                       (projectile-files-via-ext-command (projectile-get-sub-projects-command)))))
 
-    ;; check if there are more submodules to be processed
-    ;; if not, returns found submodules since we reach the base case of recursion.
-    ;; or, if the current project already in the sub-project list;
-    ;; we are simply getting into a loop, so better terminate it here and returns nil
-    ;; because we already processed it..
     (cond
-     ((null submodules) known-projects)
-     ((member project known-projects) submodules)
+     ((null submodules)
+      nil)
      (t
-      (-flatten
-       ;; recursively get sub-projects of each sub-project
-       (mapcar (lambda (s)
-                 (projectile-get-all-sub-projects s (nconc known-projects submodules))) submodules))))))
+      (nconc submodules (-flatten
+                         ;; recursively get sub-projects of each sub-project
+                         (mapcar (lambda (s)
+                                   (projectile-get-all-sub-projects s submodules)) submodules)))))))
 
 (defun projectile-get-sub-projects-files ()
   "Get files from sub-projects recursively."


### PR DESCRIPTION
Initially, the function `projectile-get-all-sub-projects` check for cycles
in sub-projects and terminate it early. Unfortunately, this approach
ignores further sub-projects down the source tree. Since using the
command "git submodule --quiet foreach 'echo $name'", it does not output
sub-project cycles like ../../bundle/html-bundle anymore, we can safely
ignore this check. We now expect external commands to return submodule
properly.

Also fix a bug that caused duplicate sub-projects. When there's no more
submodule, simply return nil. For example, this is all the sub-projects of my `yasnippet` 
test project:

``` text
sub-project: /home/xtuudoo/Downloads/yasnippet/
sub-project: /home/xtuudoo/Downloads/yasnippet/snippets/
sub-project: /home/xtuudoo/Downloads/yasnippet/yasmate/
sub-project: /home/xtuudoo/Downloads/yasnippet/yasmate/bundles/html-tmbundle/
sub-project: /home/xtuudoo/Downloads/yasnippet/yasmate/bundles/objc-tmbundle/
sub-project: /home/xtuudoo/Downloads/yasnippet/yasmate/bundles/rails-tmbundle/
sub-project: /home/xtuudoo/Downloads/yasnippet/yasmate/bundles/ruby-tmbundle/
sub-project: /home/xtuudoo/Downloads/yasnippet/yasnippet/
sub-project: /home/xtuudoo/Downloads/yasnippet/yasnippet/snippets/
sub-project: /home/xtuudoo/Downloads/yasnippet/yasnippet/yasmate/
sub-project: /home/xtuudoo/Downloads/yasnippet/yasnippet/yasmate/bundles/html-tmbundle/
sub-project: /home/xtuudoo/Downloads/yasnippet/yasnippet/yasmate/bundles/objc-tmbundle/
sub-project: /home/xtuudoo/Downloads/yasnippet/yasnippet/yasmate/bundles/rails-tmbundle/
sub-project: /home/xtuudoo/Downloads/yasnippet/yasnippet/yasmate/bundles/ruby-tmbundle/
```

The above text is the output of the call `(message "sub-project: %s" project)` each time `projectile-get-all-sub-projects`. As you can see, those are all sub-projects and there's no duplicate. Here is output in list format run within `IELM`:

``` lisp
'("/home/xtuudoo/Downloads/yasnippet/snippets/" "/home/xtuudoo/Downloads/yasnippet/yasmate/" "/home/xtuudoo/Downloads/yasnippet/yasnippet/" "/home/xtuudoo/Downloads/yasnippet/yasmate/bundles/html-tmbundle/" "/home/xtuudoo/Downloads/yasnippet/yasmate/bundles/objc-tmbundle/" "/home/xtuudoo/Downloads/yasnippet/yasmate/bundles/rails-tmbundle/" "/home/xtuudoo/Downloads/yasnippet/yasmate/bundles/ruby-tmbundle/" "/home/xtuudoo/Downloads/yasnippet/yasnippet/snippets/" "/home/xtuudoo/Downloads/yasnippet/yasnippet/yasmate/" "/home/xtuudoo/Downloads/yasnippet/yasnippet/yasmate/bundles/html-tmbundle/" "/home/xtuudoo/Downloads/yasnippet/yasnippet/yasmate/bundles/objc-tmbundle/" "/home/xtuudoo/Downloads/yasnippet/yasnippet/yasmate/bundles/rails-tmbundle/" "/home/xtuudoo/Downloads/yasnippet/yasnippet/yasmate/bundles/ruby-tmbundle/")
```
