### PR TITLE
Work with git submodules in nested folder structure.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -729,7 +729,7 @@ Files are returned as relative paths to the project root."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-git-submodule-command "git submodule --quiet foreach 'echo $name' | tr '\\n' '\\0'"
+(defcustom projectile-git-submodule-command "git submodule --quiet foreach 'echo $path' | tr '\\n' '\\0'"
   "Command used by projectile to get the files in git submodules."
   :group 'projectile
   :type 'string)


### PR DESCRIPTION
Projectile currently assumes git submodules folders match the submodule name and are contained in the root of the git repository. This change allows projectile to see submodules in a deeper folder structure. Example `.gitmodules` below.

```
[submodule "library-fork"]
    path = /frontend-src/modules/library
    url = git://github.com/fork/fork.git
```

Addresses #532 too, latest master doesn't fail for `C-c p f` but doesn't include submodule files with the example `.gitmodule` because of the silent failure.
