### PR TITLE
Fix `projectile-replace` directory selection with `helm-mode`

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1944,7 +1944,8 @@ to run the replacement."
                     (projectile-prepend-project-name
                      (format "Replace %s with: " old-text))))
          (directory (if arg
-                        (read-directory-name "Replace in directory: ")
+                        (file-name-as-directory
+                         (read-directory-name "Replace in directory: "))
                       (projectile-project-root)))
          (files (projectile-files-with-string old-text directory)))
     (tags-query-replace old-text new-text nil (cons 'list files))))


### PR DESCRIPTION
In the current version of projectile (0.11.0) and helm-mode (1.6.4), explicitly passing a directory into `projectile-replace` results in the following error:

    Opening input file: no such file or directory, /path/to/directorypath/to/file.el

Specifically, a `/` is missing between `/path/to/directory` and `path/to/file.el` because `helm-mode`'s directory selection strips the trailing slash before returning it. This patch makes `projectile-replace` robust against these edge cases.