### PR TITLE
Update fuzzy-matching source where it is possible

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -374,6 +374,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
                 (helm-exit-minibuffer))
                ((> (length files) 1) files)
                (t  project-files))))
+    :fuzzy-match t
     :coerce 'helm-projectile-coerce-file
     :action-transformer 'helm-find-files-action-transformer
     :keymap (let ((map (copy-keymap helm-find-files-map)))
@@ -389,6 +390,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
   (helm-build-in-buffer-source "Projectile files"
     :data (lambda ()
             (projectile-current-project-files))
+    :fuzzy-match t
     :coerce 'helm-projectile-coerce-file
     :keymap (let ((map (copy-keymap helm-find-files-map)))
               (helm-projectile-define-key map
@@ -463,6 +465,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
             (if projectile-find-dir-includes-top-level
                 (append '("./") (projectile-current-project-dirs))
               (projectile-current-project-dirs)))
+    :fuzzy-match t
     :coerce 'helm-projectile-coerce-file
     :action-transformer 'helm-find-files-action-transformer
     :keymap (let ((map (make-sparse-keymap)))
@@ -517,6 +520,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
   (helm-build-in-buffer-source "Projectile recent files"
     :data (lambda ()
             (projectile-recentf-files))
+    :fuzzy-match t
     :coerce 'helm-projectile-coerce-file
     :keymap helm-projectile-find-file-map
     :help-message 'helm-ff-help-message


### PR DESCRIPTION
These sources are updated with fuzzy-matching:
- helm-source-projectile-files-list: it works nicely with large source
  tree like the Linux kernel.
- helm-source-projectile-files-dwim-list
- helm-source-projectile-directories-list
- helm-source-projectile-recentf-list

The current Helm implementation allows both fuzzy matching and regular Helm
matching with regex, depend on patterns entered. So if someone doesn't
like fuzzy matching, he can always use old matching instead.

helm-source-projectile-files-in-all-projects-list is not applicable
because there could be too many files for fuzzy matching.
