### PR TITLE
Compilation find file fix

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2178,10 +2178,11 @@ fallback to the original function."
            (and (projectile-project-p)
                 (let ((root (projectile-project-root))
                       (dirs (cons "" (projectile-current-project-dirs))))
-                  (->> dirs
-                    (--map (f-join root it filename))
-                    (-filter #'file-exists-p)
-                    (-first-item))))
+                  (-when-let (full-filename (->> dirs
+                                              (--map (f-join root it filename))
+                                              (-filter #'file-exists-p)
+                                              (-first-item)))
+                    (find-file-noselect full-filename))))
            ;; Fall back to the old function `compilation-find-file'
            ad-do-it))))
 


### PR DESCRIPTION
How to reproduce:

In GNU Emacs 24.4.1 on OS X installed by Macports with projectile from git, create a maven Java project with test failures that output a Java stacktrace, run M-x compile RET mvn install RET to compile and run the tests.

You'll get a _compilation_ buffer that has the filenames and line numbers highlighted in the Java stacktrace, but don't list a path to the filename.  Select one of the highlighted filename/line items in the stacktrace.

Expected result:

Jumps right to file and line in project.

Observed result:

Error message in mini-buffer: "No buffer named /full/path/to/java/file/here.java"

Patch:

The compilation-find-file defadvice seems to return a buffer (returned by find-file-noselect run on the filename) in some cases, and in other cases, returns a filename string directly.  This patch fixes it to return a buffer in both scenarios.

Disclaimer:

I'm an elisp newbie, so if I just have a bogus setup, let me know :)
