### PR TITLE
projectile-follow-symlinks in projectile-file-truename

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -592,7 +592,7 @@ Returns nil if no window configuration was found"
 (defadvice delete-file (before purge-from-projectile-cache (filename &optional trash))
   (if (and projectile-enable-caching (projectile-project-p))
       (let* ((project-root (projectile-project-root))
-             (true-filename (projectile-file-truename filename))
+             (true-filename (file-truename filename))
              (relative-filename (file-relative-name true-filename project-root)))
         (if (projectile-file-cached-p relative-filename project-root)
             (projectile-purge-file-from-cache relative-filename)))))
@@ -982,7 +982,7 @@ Operates on filenames relative to the project root."
          (not (projectile-ignored-buffer-p buffer))
          (s-equals? (file-remote-p default-directory) (file-remote-p project-root))
          (not (s-matches? "^http\\(s\\)?://" default-directory))
-         (s-starts-with? project-root (projectile-file-truename default-directory)))))
+         (s-starts-with? project-root (file-truename default-directory)))))
 
 (defun projectile-ignored-buffer-p (buffer)
   "Check if BUFFER should be ignored."
@@ -2332,7 +2332,7 @@ It handles the case of remote files as well. See `projectile-cleanup-known-proje
 
 (defun projectile-ignored-projects ()
   "A list of projects that should not be save in `projectile-known-projects'."
-  (-map 'projectile-file-truename projectile-ignored-projects))
+  (-map 'file-truename projectile-ignored-projects))
 
 (defun projectile-add-known-project (project-root)
   "Add PROJECT-ROOT to the list of known projects."

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -105,8 +105,20 @@
                      (projectile-get-project-directories))))))
 
 (ert-deftest projectile-test-file-truename ()
+  (with-sandbox
+  (f-mkdir "source-tree")
+  (f-mkdir "project-symlink")
+  (f-touch "source-tree/test.txt")
+  (f-symlink "../source-tree" "project-symlink/source-tree")
   (should (equal nil (projectile-file-truename nil)))
-  (should (equal (file-truename "test") (projectile-file-truename "test"))))
+  (let ((projectile-follow-symlinks nil))
+    (should (equal (expand-file-name "./project-symlink/source-tree/test.txt")
+  		   (projectile-file-truename "./project-symlink/source-tree/test.txt"))))
+  (let ((projectile-follow-symlinks t))
+    (should (equal (file-truename "./source-tree/test.txt")
+		   (projectile-file-truename "./project-symlink/source-tree/test.txt")))
+    (should (equal (file-truename "./source-tree/test.txt")
+		   (projectile-file-truename "./source-tree/test.txt"))))))
 
 (ert-deftest projectile-test-dir-files ()
   (noflet ((projectile-project-root () "/my/root/")


### PR DESCRIPTION
I ran into this issue using clearcase -- I was trying to create a directory with soft links to the dynamically mounted vobs, and once I was in the vob, projectile couldn't resolve the project because file-truename follows symlinks :(

I tried just disabling `file-symlink-p` in .dir-locals, but then I needed symlinks resolved for `vc-mode`.

So I have been using this PR for a day or so, and I have seen no problems using it with clearcase or another project where symlinks are being followed.

Let me know if there is anything else I can do for this!
