### PR TITLE
 Fix and refactor getting files using external tools

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -707,16 +707,13 @@ A thin wrapper around `file-truename' that handles nil."
 (defun projectile-dir-files (directory)
   "List the files in DIRECTORY and in its sub-directories.
 Files are returned as relative paths to the project root."
-  ;; check for a cache hit first if caching is enabled
-  (let ((files-list (and projectile-enable-caching
-                         (gethash directory projectile-projects-cache)))
-        (root (projectile-project-root)))
-    ;; cache disabled or cache miss
-    (or files-list
+  (or (and projectile-enable-caching
+           (gethash directory projectile-projects-cache))
+      (let ((root (projectile-project-root)))
         (if (eq projectile-indexing-method 'native)
             (projectile-dir-files-native root directory)
-          ;; use external tools to get the project files
-          (projectile-remove-ignored (projectile-dir-files-external root directory))))))
+          (projectile-remove-ignored
+           (projectile-dir-files-external root directory))))))
 
 (defun projectile-dir-files-native (root directory)
   "Get the files for ROOT under DIRECTORY using just Emacs Lisp."

--- a/projectile.el
+++ b/projectile.el
@@ -723,15 +723,6 @@ Files are returned as relative paths to the project root."
   (--map (file-relative-name it root)
          (projectile-index-directory directory (projectile-patterns-to-ignore))))
 
-(defun projectile-dir-files-external (root directory)
-  "Get the files for ROOT under DIRECTORY using external tools."
-  (let ((default-directory directory)
-        (files-list nil))
-    (setq files-list (-map (lambda (f)
-                             (file-relative-name (expand-file-name f directory) root))
-                           (projectile-get-repo-files)))
-    files-list))
-
 (defcustom projectile-git-command "git ls-files -zco --exclude-standard"
   "Command used by projectile to get the files in a git project."
   :group 'projectile
@@ -772,66 +763,40 @@ Files are returned as relative paths to the project root."
   :group 'projectile
   :type 'string)
 
-(defun projectile-get-ext-command ()
-  "Determine which external command to invoke based on the project's VCS."
+(defun projectile-dir-files-external (root directory)
+  "Get the files for ROOT under DIRECTORY using external tools."
   (let ((vcs (projectile-project-vcs)))
-    (cond
-     ((eq vcs 'git) projectile-git-command)
-     ((eq vcs 'hg) projectile-hg-command)
-     ((eq vcs 'fossil) projectile-fossil-command)
-     ((eq vcs 'bzr) projectile-bzr-command)
-     ((eq vcs 'darcs) projectile-darcs-command)
-     ((eq vcs 'svn) projectile-svn-command)
-     (t projectile-generic-command))))
+    (if (eq vcs 'git)
+        (projectile-dir-files-git root directory)
+      (let ((default-directory directory))
+        (--map (file-relative-name (expand-file-name it directory) root)
+               (split-string (shell-command-to-string
+                              (pcase vcs
+                                (`hg     projectile-hg-command)
+                                (`fossil projectile-fossil-command)
+                                (`bzr    projectile-bzr-command)
+                                (`darcs  projectile-darcs-command)
+                                (`svn    projectile-svn-command)
+                                (_       projectile-generic-command)))
+                             "\0" t))))))
 
-(defun projectile-get-sub-projects-command ()
-  (let ((vcs (projectile-project-vcs)))
-    (cond
-     ((eq vcs 'git) projectile-git-submodule-command)
-     (t ""))))
-
-(defun projectile-get-all-sub-projects (project)
-  "Get all sub-projects for a given projects.
-PROJECT is base directory to start search recursively."
-  (let* ((default-directory project)
-         ;; search for sub-projects under current project `project'
-         (submodules (mapcar
-                      (lambda (s)
-                        (file-name-as-directory (expand-file-name s default-directory)))
-                      (projectile-files-via-ext-command (projectile-get-sub-projects-command)))))
-
-    (cond
-     ((null submodules)
-      nil)
-     (t
-      (nconc submodules (-flatten
-                         ;; recursively get sub-projects of each sub-project
-                         (mapcar (lambda (s)
-                                   (projectile-get-all-sub-projects s)) submodules)))))))
-
-(defun projectile-get-sub-projects-files ()
-  "Get files from sub-projects recursively."
-  (-flatten
-   (mapcar (lambda (s)
-             (let ((default-directory s))
-               (mapcar (lambda (f)
-                         (concat s f))
-                       (projectile-files-via-ext-command projectile-git-command))))
-           (condition-case nil
-               (projectile-get-all-sub-projects (projectile-project-root))
-             (error nil)))))
-
-(defun projectile-get-repo-files ()
-  "Get a list of the files in the project, including sub-projects."
-  (cond
-   ((eq (projectile-project-vcs) 'git)
-    (nconc (projectile-files-via-ext-command (projectile-get-ext-command))
-           (projectile-get-sub-projects-files)))
-   (t (projectile-files-via-ext-command (projectile-get-ext-command)))))
-
-(defun projectile-files-via-ext-command (command)
-  "Get a list of relative file names in the project root by executing COMMAND."
-  (split-string (shell-command-to-string command) "\0" t))
+(defun projectile-dir-files-git (root &optional directory)
+  (let* ((default-directory root)
+         (modules (-map 'expand-file-name
+                        (split-string (shell-command-to-string
+                                       projectile-git-submodule-command)
+                                      "\0" t))))
+    (when directory
+      (setq modules (--filter (file-in-directory-p it directory) modules))
+      (setq default-directory directory))
+    (--map (file-relative-name (expand-file-name it directory) root)
+           (-mapcat (lambda (file)
+                      (setq file (expand-file-name file))
+                      (if (member file modules)
+                          (projectile-dir-files-git (file-name-as-directory file))
+                        (list file)))
+                    (split-string (shell-command-to-string projectile-git-command)
+                                  "\0" t)))))
 
 (defun projectile-index-directory (directory patterns)
   "Index DIRECTORY taking into account PATTERNS.

--- a/projectile.el
+++ b/projectile.el
@@ -716,12 +716,12 @@ Files are returned as relative paths to the project root."
            (projectile-dir-files-external root directory))))))
 
 (defun projectile-dir-files-native (root directory)
-  "Get the files for ROOT under DIRECTORY using just Emacs Lisp."
+  "Get the files for ROOT under DIRECTORY using just Emacs Lisp.
+Files are returned as relative paths to the project root."
   (message "Projectile is indexing %s. This may take a while."
            (propertize directory 'face 'font-lock-keyword-face))
-  ;; we need the files with paths relative to the project root
-  (-map (lambda (file) (file-relative-name file root))
-        (projectile-index-directory directory (projectile-patterns-to-ignore))))
+  (--map (file-relative-name it root)
+         (projectile-index-directory directory (projectile-patterns-to-ignore))))
 
 (defun projectile-dir-files-external (root directory)
   "Get the files for ROOT under DIRECTORY using external tools."


### PR DESCRIPTION
```
The entry point is `projectile-dir-files-external'.  When the project is
a Git repository it also returns the files in submodules.  For other
project types nothing equivalent is done, but an abstraction to do that
in the future already existed.

Unfortunately that was implemented using six additional functions.  This
lead to a lot of accidental complexity, which in turn lead to work being
done which did not need to be done.  Also it didn't quite work in the
only case where we actually made use of this; Git submodules that are
located outside the directory we are interested in where also recursed
into.

So remove all of that and just keep `projectile-dir-files-external'.
When the project is a Git repository, then that function calls out to
the new function `projectile-dir-files-git', which as the name suggests
only knows about Git.

Provided there actually is another vcs which supports the equivalent of
Git submodules, then that should implemented as a separate function.
That function might share some code with the Git variant, but that's
okay; a bit of harmless code duplication is better than a broken
abstraction.

`git submodules foreach COMMAND' calls COMMAND for every initialized
submodule.  This includes submodules which are not below the current
directory but $path is always relative to that directory.  We need to
filter out such submodules, and that's what is responsible for most
of the complications in `projectile-dir-files-git'.

On the other hand, because `git submodules foreach COMMAND' ignores
submodules that have not been initialize yet, there is no need to
explicitly deal with modules which have themselves or their superproject
as a submodule.  There is no risk of infinite recursion because for that
to happen the submodules would have had to be initialized recursively,
which would have failed eventually due to there being no space left on
the harddrive.
```