### PR TITLE
[Fix #588] Set default-directory before switching a project

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2160,7 +2160,8 @@ With a prefix ARG invokes `projectile-commander' instead of
 Invokes the command referenced by `projectile-switch-project-action' on switch.
 With a prefix ARG invokes `projectile-commander' instead of
 `projectile-switch-project-action.'"
-  (let* ((switch-project-action (if arg
+  (let* ((default-directory project-to-switch)
+         (switch-project-action (if arg
                                     'projectile-commander
                                   projectile-switch-project-action)))
     (funcall switch-project-action)


### PR DESCRIPTION
Add back `default-directory` which was removed in previous patch [see #588].
