### PR TITLE
Allow to disable fuzzy matching in Helm Projectile

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,12 +621,15 @@ If you want to use these commands, you have to activate it to replace the normal
 commands:
 
 ```lisp
+;; (setq helm-projectile-fuzzy-match nil)
 (require 'helm-projectile)
 (helm-projectile-on)
 ```
 
 If you already activate helm-projectile key bindings and you don't like it, you can turn it off
-and use the normal Projectile bindings with command `helm-projectile-off`.
+and use the normal Projectile bindings with command `helm-projectile-off`. Similarly, if you want to
+disable fuzzy matching in Helm Projectile (it is enabled by default), you must set `helm-projectile-fuzzy-match`
+to nil before loading `helm-projectile`.
 
 To fully learn Helm Projectile and see what it is capable of, you should refer to this guide:
 [Exploring large projects with Projectile and Helm Projectile](http://tuhdo.github.io/helm-projectile.html).

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -58,6 +58,12 @@
 
 (defvar helm-projectile-current-project-root)
 
+;;;###autoload
+(defcustom helm-projectile-fuzzy-match t
+  "Enable fuzzy matching for Helm Projectile commands."
+  :group 'helm-projectile
+  :type 'boolean)
+
 (defun helm-projectile-coerce-file (candidate)
   (with-current-buffer (helm-candidate-buffer)
     (expand-file-name candidate (projectile-project-root))))
@@ -164,7 +170,7 @@ It is there because Helm requires it."
                 (cons (abbreviate-file-name (projectile-project-root))
                       (projectile-relevant-known-projects))
               projectile-known-projects))
-    :fuzzy-match t
+    :fuzzy-match helm-projectile-fuzzy-match
     :keymap (let ((map (make-sparse-keymap)))
               (set-keymap-parent map helm-map)
               (helm-projectile-define-key map
@@ -376,7 +382,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
                 (helm-exit-minibuffer))
                ((> (length files) 1) files)
                (t  project-files))))
-    :fuzzy-match t
+    :fuzzy-match helm-projectile-fuzzy-match
     :coerce 'helm-projectile-coerce-file
     :action-transformer 'helm-find-files-action-transformer
     :keymap (let ((map (copy-keymap helm-find-files-map)))
@@ -392,7 +398,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
   (helm-build-in-buffer-source "Projectile files"
     :data (lambda ()
             (projectile-current-project-files))
-    :fuzzy-match t
+    :fuzzy-match helm-projectile-fuzzy-match
     :coerce 'helm-projectile-coerce-file
     :keymap (let ((map (copy-keymap helm-find-files-map)))
               (helm-projectile-define-key map
@@ -467,7 +473,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
             (if projectile-find-dir-includes-top-level
                 (append '("./") (projectile-current-project-dirs))
               (projectile-current-project-dirs)))
-    :fuzzy-match t
+    :fuzzy-match helm-projectile-fuzzy-match
     :coerce 'helm-projectile-coerce-file
     :action-transformer 'helm-find-files-action-transformer
     :keymap (let ((map (make-sparse-keymap)))
@@ -522,7 +528,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
   (helm-build-in-buffer-source "Projectile recent files"
     :data (lambda ()
             (projectile-recentf-files))
-    :fuzzy-match t
+    :fuzzy-match helm-projectile-fuzzy-match
     :coerce 'helm-projectile-coerce-file
     :keymap helm-projectile-find-file-map
     :help-message 'helm-ff-help-message


### PR DESCRIPTION
To disable it, simply set helm-projectile-fuzzy-match to nil before
loading helm-projectile.