### PR TITLE
Use built in string= and cl-remove-if-not

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -253,8 +253,8 @@ CANDIDATE is the selected file, but choose the marked files if available."
     (let ((new-name (completing-read "Select or enter a new buffer name: "
                                      (helm-projectile-all-dired-buffers)))
           (helm--reading-passwd-or-string t)
-          (files (filter (lambda (f)
-                           (not (string-empty-p f)))
+          (files (cl-remove-if-not (lambda (f)
+                           (not (string= f "")))
                          (mapcar (lambda (file)
                                    (replace-regexp-in-string (projectile-project-root) "" file))
                                  (helm-marked-candidates :with-wildcard t))))


### PR DESCRIPTION
Replace one use of string-empty-p with string= and one instance of "filter" with cl-remove-if-not to prevent "udefined function" errors for users who do not have string-empty-p and filter defined.