### PR TITLE
prevent infinite loop with new virtual dired name

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -250,6 +250,15 @@ CANDIDATE is the selected file, but choose the marked files if available."
            (not helm-projectile-virtual-dired-remote-enable))
       (message "Virtual Dired manager is disabled in remote host. Enable with %s."
                (propertize "helm-projectile-virtual-dired-remote-enable" 'face 'font-lock-keyword-face))
+    ;; When RET is hit to exit the minibuffer after typing a new dired buffer
+    ;; name as part of completing-read below, emacs goes into infinite loop with
+    ;; "[Display not ready]" message.  Apparently new names are not accepted.
+    ;; One way to prevent this infinite loop is to set
+    ;; helm--reading-passwd-or-string to non-nil which prevents
+    ;; helm-maybe-exit-minibuffer from going into infinite loop.
+    ;; This hack probably is not an acceptible solution to the problem.
+    ;; 
+    (let ((helm--reading-passwd-or-string t))
     (let ((new-name (completing-read "Select or enter a new buffer name: "
                                      (helm-projectile-all-dired-buffers)))
           (helm--reading-passwd-or-string t)
@@ -271,6 +280,7 @@ CANDIDATE is the selected file, but choose the marked files if available."
         (when (get-buffer new-name)
           (kill-buffer new-name))
         (rename-buffer new-name)))))
+        )
 
 (defun helm-projectile-dired-files-add-action (candidate)
   "Add files to a Dired buffer.


### PR DESCRIPTION
The proposed change is not meant to be checked in.
It is merely to document the problem.  

As documented in the code comment, I can't seem to exit the minibuffer when I type a new name.
First I type C-c p f then start selecting files via hitting Control-SPC on a few files on the ensuing helm buffer.
To create a new virtual dired buffer I type C-c f which asks for a dired buffer name in the mini buffer.
I type a new name, i.e., not a pre-exising dired buffer name then hit enter.
Rather than accepting the new name, emacs goes into infinite loop with "Display not ready" error message.

The hack in this request demonstrate that infinite loop is caused in part by helm-maybe-exit-minibuffer.