### PR TITLE
Make projectile-find-file-dwim handle relative path

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1236,6 +1236,9 @@ With a prefix ARG invalidates the cache first."
   (let* ((file (if (region-active-p)
                    (buffer-substring (region-beginning) (region-end))
                  (or (thing-at-point 'filename) "")))
+         (file (if (string-match "\\.?\\./" file)
+                   (file-relative-name (file-truename file) (projectile-project-root))
+                 file))
          (files (if file
                     (-filter (lambda (project-file)
                                (string-match file project-file))


### PR DESCRIPTION
It should be able to handle relative paths that point to file in a
project. For example, we have file custom/setup-a.el, and file
personal/setup-b.el contains ../custom/setup-a.el,
projectile-find-file-dwim should be able to jump to it.