### PR TITLE
Use `magit-status` instead of `magit-status-internal`

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1906,12 +1906,12 @@ to run the replacement."
 (defun projectile-vc (&optional project-root)
   "Open `vc-dir' at the root of the project.
 
-For git projects `magit-status-internal' is used if available."
+For git projects `magit-status' is used if available."
   (interactive)
   (or project-root (setq project-root (projectile-project-root)))
   (if (and (eq (projectile-project-vcs project-root) 'git)
-           (fboundp 'magit-status-internal))
-      (magit-status-internal project-root)
+           (fboundp 'magit-status))
+      (magit-status project-root)
     (vc-dir project-root)))
 
 ;;;###autoload


### PR DESCRIPTION
If magit package is not yet loaded, `projectile` cannot find `magit-status-internal` because that function is not auto-loaded. `magit-status-internal` is now an alias for `magit-status`,  so `magit-status` should be used instead.