### PR TITLE
[Fix #560] [Fix #580] Add new defcustom that is used for globally ignoring files by extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ to behave like `helm-find-files`, such as multifile selection and opening or del
 * Add support for `cargo.toml` projects
 * Try to use projectile to find files in compilation buffers
 * Support `helm` as a completion system
-* New `defcustom` `projectile-globally-ignored-buffers` allows you ignore
-buffers by name
 * New command `projectile-project-info` displays basic info about the current project.
+* New `defcustom` `projectile-globally-ignored-buffers` allows you to ignore
+  buffers by name
+* New `defcustom` `projectile-globally-ignored-file-suffixes` allows
+  you to globally ignore files with particular extensions
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -258,6 +258,12 @@ pattern that would have found a project root in a subdirectory."
   :group 'projectile
   :type '(repeat string))
 
+(defcustom projectile-globally-ignored-file-suffixes
+  nil
+  "A list of file suffixes globally ignored by projectile."
+  :group 'projectile
+  :type '(repeat string))
+
 (defcustom projectile-globally-ignored-directories
   '(".idea"
     ".eunit"
@@ -852,8 +858,10 @@ Operates on filenames relative to the project root."
   (let ((ignored (append (projectile-ignored-files-rel)
                          (projectile-ignored-directories-rel))))
     (-remove (lambda (file)
-               (--any-p (string-prefix-p it file) ignored))
+               (or (--any-p (string-prefix-p it file) ignored)
+                   (--any-p (string-suffix-p it file) projectile-globally-ignored-file-suffixes)))
              files)))
+
 
 (defun projectile-buffers-with-file (buffers)
   "Return only those BUFFERS backed by files."

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -111,6 +111,19 @@
         (should (equal (projectile-project-ignored) files))))))
 
 
+(ert-deftest projectile-remove-ignored-suffixes ()
+  (noflet ((projectile-project-root () "/path/to/project")
+           (projectile-project-name () "project")
+           (projectile-ignored-files-rel () ())
+           (projectile-ignored-directories-rel () ()))
+          (let* ((file-names '("foo.c" "foo.o" "foo.so" "foo.o.gz"))
+                 (files (mapcar 'projectile-expand-root file-names)))
+            (let ((projectile-globally-ignored-file-suffixes '(".o" ".so")))
+              (should (equal (projectile-remove-ignored files)
+                             (mapcar 'projectile-expand-root
+                                     '("foo.c" "foo.o.gz"))))))))
+
+
 (ert-deftest projectile-test-parse-dirconfig-file ()
   (noflet ((file-exists-p (filename) t)
            (file-truename (filename) filename)


### PR DESCRIPTION
Add a new defcustom projectile-globally-ignored-file-extensions that is
used by projectile-remove-ignored to remove files based off of the file
suffix.