### PR TITLE
projectile-find-other-file sort candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ to behave like `helm-find-files`, such as multifile selection and opening or del
 
 ### Changes
 
+* get-other-files returns more accurate results for files with the same name placed under different directories
 * Collect search tool (`grep`, `ag`, `ack`) keybindings under a common keymap prefix (`C-c p s`)
 * Remove `defcustom` `projectile-remember-window-configs` in favor of
   `persp-projectile.el`.

--- a/projectile.el
+++ b/projectile.el
@@ -1202,6 +1202,9 @@ Returns a list of possible files for users to choose.
 
 With FLEX-MATCHING, match any file that contains the base name of current file"
   (let* ((file-ext-list (cdr (assoc (file-name-extension current-file) projectile-other-file-alist)))
+         (fulldirname  (if (file-name-directory current-file)
+                           (file-name-directory current-file) "./"))
+         (dirname  (file-name-nondirectory (directory-file-name fulldirname)))
          (filename (file-name-base current-file))
          (file-list (mapcar (lambda (ext)
                               (if flex-matching
@@ -1223,7 +1226,13 @@ With FLEX-MATCHING, match any file that contains the base name of current file"
                                                         (unless (equal (file-name-extension project-file) nil)
                                                           (concat  "\." (file-name-extension project-file))))))
                                 candidates))
-                     file-list))))
+                     file-list)))
+         (candidates
+          (-sort (lambda (file _)
+                   (let ((candidate-dirname (file-name-nondirectory (directory-file-name (file-name-directory file)))))
+                     (unless (equal fulldirname (file-name-directory file))
+                     (equal dirname candidate-dirname))))
+                 candidates)))
     candidates))
 
 (defun projectile-select-files (project-files &optional arg)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -531,9 +531,13 @@
                        "src/Makefile"
                        "src/test.vert"
                        "src/test.frag"
+                       "src/same_name.c"
+                       "src/some_module/same_name.c"
+                       "include1/same_name.h"
                        "include1/test1.h"
                        "include1/test2.h"
                        "include1/test1.hpp"
+                       "include2/some_module/same_name.h"
                        "include2/test1.h"
                        "include2/test2.h"
                        "include2/test2.hpp")))
@@ -553,6 +557,8 @@
                    (projectile-get-other-files "include1/test1.h" source-tree t)))
     (should (equal '("src/Makefile")
                    (projectile-get-other-files "Makefile.lock" source-tree)))
+    (should (equal '("src/some_module/same_name.c" "src/same_name.c")
+                   (projectile-get-other-files "include2/some_module/same_name.h" source-tree)))
     ))
 
 


### PR DESCRIPTION
In projects where there are multiple file names with the same
header/source combinations we can still provide more accurate results by
sorting the candidates list to put the other-file under the same
directory name as this file to the top of the list.

So now if we have a directory tree like this:
```
|-src-
     |
     moduleA-
            |
            filename.c
     moduleB-
            |
            filename.c
|-include-
         |
         moduleA-
                |
                filename.h
          moduleB-
                 |
                 filename.h
```

`projectile-find-other-file` will always return the proper other file and there is no need to check the return list and choose which one it is that you actually wanted.

I tested this in the projects I am working on and it seems to work perfectly.

Note: In the sorting of the list the `other-file` is not used and as such there is a warning when you byte compile. So I suppose there is gotta be a better function to accomplish this. Any hints are more than welcome. 

