### PR TITLE
Improve helm-projectile-fuzzy-match docstring

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -60,7 +60,8 @@
 
 ;;;###autoload
 (defcustom helm-projectile-fuzzy-match t
-  "Enable fuzzy matching for Helm Projectile commands."
+  "Enable fuzzy matching for Helm Projectile commands.
+This needs to be set before loading helm-projectile."
   :group 'helm-projectile
   :type 'boolean)
 


### PR DESCRIPTION
Document that this variable needs to be set before helm-projectile is
loaded.  (Fixes bug#634)