### PR TITLE
Issue 579: Add .projectile to the search of VCS roots. 

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1509,6 +1509,7 @@ PROJECT-ROOT is the targeted directory. If nil, use
    ((projectile-file-exists-p (expand-file-name ".bzr" project-root)) 'bzr)
    ((projectile-file-exists-p (expand-file-name "_darcs" project-root)) 'darcs)
    ((projectile-file-exists-p (expand-file-name ".svn" project-root)) 'svn)
+   ((projectile-locate-dominating-file project-root ".projectile") 'none)
    ((projectile-locate-dominating-file project-root ".git") 'git)
    ((projectile-locate-dominating-file project-root ".hg") 'hg)
    ((projectile-locate-dominating-file project-root ".fossil") 'fossil)


### PR DESCRIPTION
Stop searching when we come across the .projectile.
