### PR TITLE
Fix docstring typo

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2529,7 +2529,7 @@ is chosen."
 ;;;###autoload
 (defcustom projectile-mode-line
   '(:eval (format " Projectile[%s]" (projectile-project-name)))
-  "Mode line ligher for Projectile.
+  "Mode line lighter for Projectile.
 
 The value of this variable is a mode line template as in
 `mode-line-format'.  See Info Node `(elisp)Mode Line Format' for


### PR DESCRIPTION
"Lighter" was misspelled as "ligher" in the docstring for `projectile-mode-line`.