### PR TITLE
Fix `projectile-regenerate-tags` in dirs with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ buffers by name
 
 ### Bugs fixed
 
+* Fix `projectile-regenerate-tags` to work in directories that include spaces.
 * Prevent `projectile-kill-buffers` from trying to kill indirect
 buffers.
 * [#412](https://github.com/bbatsov/projectile/issues/412): Handle multiple possible targets in `projectile-toggle-between-implementation-or-test`.

--- a/projectile.el
+++ b/projectile.el
@@ -170,7 +170,7 @@ Otherwise consider the current directory the project root."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-tags-command "ctags -Re -f %s %s"
+(defcustom projectile-tags-command "ctags -Re -f \"%s\" \"%s\""
   "The command Projectile's going to use to generate a TAGS file."
   :group 'projectile
   :type 'string)


### PR DESCRIPTION
Just like it says in the title! :sparkles: