### PR TITLE
[Fix #658] Specify project path for projectile-tags-command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changes
 
+* Specify project path for `projectile-regenerate-tags`.
 * Handle files with special characters in `projectile-get-other-files`
 * [#1260](https://github.com/bbatsov/projectile/pull/1260): ignored-*-p: Now they match against regular expressions.
 * **(Breaking)** Remove the default prefix key (`C-c p`) for Projectile. Users now have to pick one themselves.

--- a/projectile.el
+++ b/projectile.el
@@ -167,7 +167,7 @@ Otherwise consider the current directory the project root."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-tags-command "ctags -Re -f \"%s\" %s"
+(defcustom projectile-tags-command "ctags -Re -f \"%s\" %s \"%s\""
   "The command Projectile's going to use to generate a TAGS file."
   :group 'projectile
   :type 'string)
@@ -2853,7 +2853,7 @@ SEARCH-TERM is a regexp."
            (tags-exclude (projectile-tags-exclude-patterns))
            (default-directory project-root)
            (tags-file (expand-file-name projectile-tags-file-name))
-           (command (format projectile-tags-command tags-file tags-exclude))
+           (command (format projectile-tags-command tags-file tags-exclude default-directory))
            shell-output exit-code)
       (with-temp-buffer
         (setq exit-code


### PR DESCRIPTION
Otherwise it would generate empty TAGS files on some systems
