### PR TITLE
Fix generation of command for tag generation

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -170,7 +170,7 @@ Otherwise consider the current directory the project root."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-tags-command "ctags -Re -f \"%s\" \"%s\""
+(defcustom projectile-tags-command "ctags -Re -f \"%s\" %s"
   "The command Projectile's going to use to generate a TAGS file."
   :group 'projectile
   :type 'string)
@@ -1734,7 +1734,7 @@ regular expression."
 
 (defun projectile-tags-exclude-patterns ()
   "Return a string with exclude patterns for ctags."
-  (mapconcat (lambda (pattern) (format "--exclude=%s"
+  (mapconcat (lambda (pattern) (format "--exclude=\"%s\""
                                        (directory-file-name pattern)))
              (projectile-ignored-directories-rel) " "))
 

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -210,7 +210,7 @@
 (ert-deftest projectile-test-tags-exclude-items ()
   (noflet ((projectile-ignored-directories-rel () (list ".git/" ".hg/")))
     (should (equal (projectile-tags-exclude-patterns)
-                   "--exclude=.git --exclude=.hg"))))
+                   "--exclude=\".git\" --exclude=\".hg\""))))
 
 (ert-deftest projectile-test-maybe-invalidate ()
   (noflet ((projectile-invalidate-cache (arg) t))


### PR DESCRIPTION
Previously, command line that was being generated was this:
ctags -Re -f TAGS "--exclude=<pattern> .... "
Due to the inclusion of quotes, the exclude pattern is completely
ignored by ctags.

This commit fixes this issue and generates the command line as follows:
ctags -Re -f TAGS --exclude="<pattern>" ...
This does not break the exclude option while still works with spaces in
filenames.