### PR TITLE
Fix: use helm-buffers-match-function rather than helm-buffers-list--matc...

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -513,7 +513,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
                          (setq helm-buffer-max-len-mode (cdr result))))))
    (candidates :initform helm-buffers-list-cache)
    (matchplugin :initform nil)
-   (match :initform 'helm-buffers-list--match-fn)
+   (match :initform 'helm-buffers-match-function)
    (persistent-action :initform 'helm-buffers-list-persistent-action)
    (keymap :initform helm-buffer-map)
    (volatile :initform t)


### PR DESCRIPTION
...h-fn

Commit 6613f8 on helm-emacs/helm replaced helm-buffers-list--match-fn
with helm-buffers-match-function, breaking helm-projectile.  This commit
updates helm-projectile to use the new function.