### PR TITLE
Remove the uniqueness enforcement for `ivy-read'

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1119,8 +1119,7 @@ https://github.com/emacs-helm/helm")))
 https://github.com/d11wtq/grizzl")))
      ((eq projectile-completion-system 'ivy)
       (if (fboundp 'ivy-read)
-          (ivy-read prompt (cl-delete-duplicates choices
-                                                 :test #'equal) initial-input)
+          (ivy-read prompt choices initial-input)
         (user-error "Please install ivy from \
 https://github.com/abo-abo/swiper")))
      (t (funcall projectile-completion-system prompt choices)))))


### PR DESCRIPTION
* projectile.el (projectile-completing-read): Update.
`cl-delete-duplicates' for thousands of candidates is just too slow.
Anyway, the choices are supposed to be unique in the first place.