### PR TITLE
Nested extensions in helm-projectile-find-other-files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master (unreleased)
+* Add support for nested extensions (e.g. spec.js) to projectile-find-other-file
 
 ## 0.12.0 (03/29/2015)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ it. Some of Projectile's features:
 * jump to a project buffer
 * jump to a test in project
 * toggle between files with same names but different extensions (e.g. `.h` <-> `.c/.cpp`, `Gemfile` <-> `Gemfile.lock`)
-* toggle between code and its test
+* toggle between code and its test (e.g. `main.service.js` <-> `main.service.spec.js`)
 * jump to recently visited files in the project
 * switch between projects you have worked on
 * kill all project buffers

--- a/projectile.el
+++ b/projectile.el
@@ -1207,10 +1207,16 @@ Other file extensions can be customized with the variable `projectile-other-file
     (error "No other file found")))
 
 (defun file-name-sans-extensions (file-name)
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
   "Return FILE-NAME sans any extensions.
 The extensions, in a filename, are what follows the first '.', with the exception of a leading '.'"
   (setq file-name (file-name-nondirectory file-name))
   (substring file-name 0 (string-match "\\..*" file-name 1)))
+<<<<<<< HEAD
+<<<<<<< HEAD
 
 (defun file-name-extensions (file-name)
   "Return FILE-NAME's extensions.
@@ -1228,13 +1234,97 @@ If no associated other-file-extensions for the complete (nested) extension are f
         (-if-let (associated-extensions (cdr (assoc current-extensions projectile-other-file-alist)))
             (throw 'break associated-extensions))
         (setq current-extensions (file-name-extensions current-extensions))))))
+=======
+	"Return FILENAME sans any extensions.
+=======
+  "Return FILE-NAME sans any extensions.
+>>>>>>> 3d1f745... FILENAME -> FILE-NAME; hope this also fixes indentation
+The extensions, in a filename, are what follows the first '.', with the exception of a leading '.'"
+  (setq file-name (file-name-nondirectory file-name))
+	(substring file-name 0 (string-match "\\..*" file-name 1)))
+=======
+>>>>>>> b283c93... Indentation fix
+
+(defun file-name-extensions (file-name)
+  "Return FILE-NAME's extensions.
+The extensions, in a filename, are what follows the first '.', with the exception of a leading '.'"
+  ;;would it make sense to return nil instead of an empty string if no extensions are found?
+  (setq file-name (file-name-nondirectory file-name))
+  (substring file-name (-if-let (extensions-start (string-match "\\..*" file-name 1)) (1+ extensions-start) (length file-name))))
+
+(defun projectile-associated-file-name-extensions (file-name)
+  "Return projectile-other-file-extensions associated to FILE-NAME's extensions.
+If no associated other-file-extensions for the complete (nested) extension are found, remove subextensions from FILENAME's extensions until a match is found."  
+<<<<<<< HEAD
+=======
+	"Return FILENAME sans any extensions.
+=======
+  "Return FILE-NAME sans any extensions.
+>>>>>>> 3d1f745... FILENAME -> FILE-NAME; hope this also fixes indentation
+The extensions, in a filename, are what follows the first '.', with the exception of a leading '.'"
+  (setq file-name (file-name-nondirectory file-name))
+	(substring file-name 0 (string-match "\\..*" file-name 1)))
+=======
+>>>>>>> b283c93... Indentation fix
+
+(defun file-name-extensions (file-name)
+  "Return FILE-NAME's extensions.
+The extensions, in a filename, are what follows the first '.', with the exception of a leading '.'"
+  ;;would it make sense to return nil instead of an empty string if no extensions are found?
+  (setq file-name (file-name-nondirectory file-name))
+  (substring file-name (-if-let (extensions-start (string-match "\\..*" file-name 1)) (1+ extensions-start) (length file-name))))
+
+(defun projectile-associated-file-name-extensions (file-name)
+  "Return projectile-other-file-extensions associated to FILE-NAME's extensions.
+If no associated other-file-extensions for the complete (nested) extension are found, remove subextensions from FILENAME's extensions until a match is found."  
+<<<<<<< HEAD
+>>>>>>> c5f84be... Nested extensions in projectile-get-other-files
+	(let ((current-extensions (file-name-extensions (file-name-nondirectory file-name))))
+		(catch 'break
+			(while (not (string= "" current-extensions))
+				(-if-let (associated-extensions (cdr (assoc current-extensions projectile-other-file-alist)))
+						(throw 'break associated-extensions))
+				(setq current-extensions (file-name-extensions current-extensions))))))
+<<<<<<< HEAD
+>>>>>>> c5f84be... Nested extensions in projectile-get-other-files
+=======
+=======
+>>>>>>> b283c93... Indentation fix
+  (let ((current-extensions (file-name-extensions (file-name-nondirectory file-name))))
+    (catch 'break
+      (while (not (string= "" current-extensions))
+        (-if-let (associated-extensions (cdr (assoc current-extensions projectile-other-file-alist)))
+            (throw 'break associated-extensions))
+        (setq current-extensions (file-name-extensions current-extensions))))))
+<<<<<<< HEAD
+>>>>>>> b283c93... Indentation fix
+=======
+>>>>>>> c5f84be... Nested extensions in projectile-get-other-files
+=======
+>>>>>>> b283c93... Indentation fix
 
 (defun projectile-get-other-files (current-file project-file-list &optional flex-matching)
   "Narrow to files with the same names but different extensions.
 Returns a list of possible files for users to choose.
 
 With FLEX-MATCHING, match any file that contains the base name of current file"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
   (let* ((file-ext-list (projectile-associated-file-name-extensions current-file))
+=======
+	(let* ((file-ext-list	(projectile-associated-file-name-extensions current-file))
+>>>>>>> c5f84be... Nested extensions in projectile-get-other-files
+=======
+  (let* ((file-ext-list (projectile-associated-file-name-extensions current-file))
+>>>>>>> b283c93... Indentation fix
+=======
+	(let* ((file-ext-list	(projectile-associated-file-name-extensions current-file))
+>>>>>>> c5f84be... Nested extensions in projectile-get-other-files
+=======
+  (let* ((file-ext-list (projectile-associated-file-name-extensions current-file))
+>>>>>>> b283c93... Indentation fix
          (fulldirname  (if (file-name-directory current-file)
                            (file-name-directory current-file) "./"))
          (dirname  (file-name-nondirectory (directory-file-name fulldirname)))

--- a/projectile.el
+++ b/projectile.el
@@ -1206,16 +1206,39 @@ Other file extensions can be customized with the variable `projectile-other-file
         (find-file-other-window (expand-file-name (projectile-completing-read "Switch to: " other-files) (projectile-project-root))))
     (error "No other file found")))
 
+(defun file-name-sans-extensions (file-name)
+  "Return FILE-NAME sans any extensions.
+The extensions, in a filename, are what follows the first '.', with the exception of a leading '.'"
+  (setq file-name (file-name-nondirectory file-name))
+  (substring file-name 0 (string-match "\\..*" file-name 1)))
+
+(defun file-name-extensions (file-name)
+  "Return FILE-NAME's extensions.
+The extensions, in a filename, are what follows the first '.', with the exception of a leading '.'"
+  ;;would it make sense to return nil instead of an empty string if no extensions are found?
+  (setq file-name (file-name-nondirectory file-name))
+  (substring file-name (-if-let (extensions-start (string-match "\\..*" file-name 1)) (1+ extensions-start) (length file-name))))
+
+(defun projectile-associated-file-name-extensions (file-name)
+  "Return projectile-other-file-extensions associated to FILE-NAME's extensions.
+If no associated other-file-extensions for the complete (nested) extension are found, remove subextensions from FILENAME's extensions until a match is found."  
+  (let ((current-extensions (file-name-extensions (file-name-nondirectory file-name))))
+    (catch 'break
+      (while (not (string= "" current-extensions))
+        (-if-let (associated-extensions (cdr (assoc current-extensions projectile-other-file-alist)))
+            (throw 'break associated-extensions))
+        (setq current-extensions (file-name-extensions current-extensions))))))
+
 (defun projectile-get-other-files (current-file project-file-list &optional flex-matching)
   "Narrow to files with the same names but different extensions.
 Returns a list of possible files for users to choose.
 
 With FLEX-MATCHING, match any file that contains the base name of current file"
-  (let* ((file-ext-list (cdr (assoc (file-name-extension current-file) projectile-other-file-alist)))
+  (let* ((file-ext-list (projectile-associated-file-name-extensions current-file))
          (fulldirname  (if (file-name-directory current-file)
                            (file-name-directory current-file) "./"))
          (dirname  (file-name-nondirectory (directory-file-name fulldirname)))
-         (filename (file-name-base current-file))
+         (filename (file-name-sans-extensions current-file))
          (file-list (mapcar (lambda (ext)
                               (if flex-matching
                                   (concat ".*" filename ".*" "\." ext "\\'")

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -523,6 +523,10 @@
                                        (nil . ("lock" "gpg"))
                                        ("lock" . (""))
                                        ("gpg" . (""))
+
+                                       ;; handle files with nested extensions
+                                       ("service.js" . ("service.spec.js"))
+                                       ("js" . ("js"))
                                        ))
         (source-tree '("src/test1.c"
                        "src/test2.c"
@@ -540,7 +544,15 @@
                        "include2/some_module/same_name.h"
                        "include2/test1.h"
                        "include2/test2.h"
-                       "include2/test2.hpp")))
+                       "include2/test2.hpp"
+
+                       "src/test1.service.js"
+                       "src/test2.service.spec.js"
+                       "include1/test1.service.spec.js"
+                       "include2/test1.service.spec.js"
+                       "include1/test2.js"
+                       "include2/test2.js")))
+    
     (should (equal '("include1/test1.h" "include2/test1.h")
                    (projectile-get-other-files "src/test1.c" source-tree)))
     (should (equal '("include1/test1.h" "include2/test1.h" "include1/test1.hpp")
@@ -559,6 +571,12 @@
                    (projectile-get-other-files "Makefile.lock" source-tree)))
     (should (equal '("src/some_module/same_name.c" "src/same_name.c")
                    (projectile-get-other-files "include2/some_module/same_name.h" source-tree)))
+    ;; nested extensions
+    (should (equal '("include1/test1.service.spec.js" "include2/test1.service.spec.js")
+                   (projectile-get-other-files "src/test1.service.js" source-tree)))
+    ;; fallback to outer extensions if no rule for nested extension defined
+    (should (equal '("include1/test2.js" "include2/test2.js")
+                   (projectile-get-other-files "src/test2.service.spec.js" source-tree)))
     ))
 
 


### PR DESCRIPTION
This commit resolves #454 by employing custom functions for file-name base and extensions that respect nested extensions. 
If the complete nested extension is not associated to any other-file-extensions, the extension is stripped of nesting until other-file-extensions are found (e.g. if no other-file extensions for "service.spec.js" are specified use the other-file extensions specified for "spec.js" are grabbed and so on).