### PR TITLE
Don't forcefully insert symbol at point for searching

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -676,7 +676,7 @@ If it is nil, or ack/ack-grep not found then use default grep command."
      :sources 'helm-source-grep
      :input (if (region-active-p)
                 (buffer-substring-no-properties (region-beginning) (region-end))
-              (thing-at-point 'symbol))
+              "")
      :buffer (format "*helm %s*" (if use-ack-p
                                      "ack"
                                    "grep"))
@@ -737,8 +737,7 @@ If it is nil, or ack/ack-grep not found then use default grep command."
     (error "ag not available"))
   (if (require 'helm-ag nil  'noerror)
       (if (projectile-project-p)
-          (let* ((helm-ag-insert-at-point 'symbol)
-                 (grep-find-ignored-files (-union projectile-globally-ignored-files grep-find-ignored-files))
+          (let* ((grep-find-ignored-files (-union projectile-globally-ignored-files grep-find-ignored-files))
                  (grep-find-ignored-directories (-union projectile-globally-ignored-directories grep-find-ignored-directories))
                  (ignored (mapconcat (lambda (i)
                                        (concat "--ignore " i))


### PR DESCRIPTION
Currently, helm-projectile-grep/ack/ag inserts symbol at point by
default. It could be annoying and we should let users do it manually by
simply pressing `M-n`.