### PR TITLE
Don't show Projectile directory when not in project

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -694,8 +694,10 @@ A thin wrapper around `file-truename' that handles nil."
   (let ((project-root
          (condition-case nil
              (projectile-project-root)
-           (error default-directory))))
-    (file-name-nondirectory (directory-file-name project-root))))
+           (error nil))))
+    (if project-root
+        (file-name-nondirectory (directory-file-name project-root))
+      "-")))
 
 
 ;;; Project indexing


### PR DESCRIPTION
Currently, Projectile shows any directory it's in. This is not useful
since we don't know whether or not we are in a project directory. This
change makes it only shows project root in modeline when we are actually
in a project, so we know whether we are in a Project or not when
entering a buffer, and also save screen estate.