### PR TITLE
Fix perspective switching behavior

### DIFF
--- a/persp-projectile.el
+++ b/persp-projectile.el
@@ -56,7 +56,8 @@ project, this advice creates a new perspective for that project."
   `(defadvice ,func-name (before projectile-create-perspective-after-switching-projects activate)
      "Create a dedicated perspective for current project's window after switching projects."
      (let ((project-name (projectile-project-name)))
-           (persp-switch project-name))))
+       (when (projectile-project-p)
+         (persp-switch project-name)))))
 
 (projectile-persp-bridge projectile-dired)
 (projectile-persp-bridge projectile-find-file)


### PR DESCRIPTION
Perspective should only be changed if user is actually in a project directory.