### PR TITLE
Set default-directory before compilation command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Changes
+
+* `projectile-compile-project` now offers appropriate completion
+  targets even when called from a subdirectory.
+
 ## 0.12.0 (03/29/2015)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -2121,13 +2121,11 @@ with a prefix ARG."
   (let* ((project-root (if dir
                            dir
                          (projectile-project-root)))
+         (default-directory project-root)
          (default-cmd (projectile-compilation-command project-root))
          (compilation-cmd (if (or compilation-read-command arg)
                               (compilation-read-command default-cmd)
-                            default-cmd))
-         (default-directory (if dir
-                                dir
-                              project-root)))
+                            default-cmd)))
     (puthash project-root compilation-cmd projectile-compilation-cmd-map)
     (compilation-start compilation-cmd)))
 


### PR DESCRIPTION
Set `default-directory` before reading the compilation command so that
`completion-at-point` offers appropriate targets even when
`projectile-compile-project` is called from a subdirectory.  Also,
remove unnecessary check on DIR argument.