### PR TITLE
[Fix #657] Remove `file-truename` calls from `projectile-project-root`

### DIFF
--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -230,13 +230,13 @@
          "projectA/src/framework/lib/"
          "projectA/src/framework.conf"
          "projectA/src/html/index.html")
-      (should (equal "projectA/src/"
+      (should (equal (expand-file-name "projectA/src/")
                      (projectile-root-top-down "projectA/src/framework/lib"
                                                '("framework.conf" ".git"))))
-      (should (equal "projectA/src/"
+      (should (equal (expand-file-name "projectA/src/")
                      (projectile-root-top-down "projectA/src/framework/lib"
                                                '(".git" "framework.conf"))))
-      (should (equal "projectA/src/html/"
+      (should (equal (expand-file-name "projectA/src/html/")
                      (projectile-root-top-down "projectA/src/html/"
                                                '(".svn")))))))
 
@@ -252,11 +252,11 @@
          "projectA/src/framework/framework.conf"
          "projectA/src/html/index.html"
          ".projectile")
-      (should (equal "projectA/"
+      (should (equal (expand-file-name "projectA/")
                      (projectile-root-top-down-recurring
                       "projectA/src/html/"
                       '("something" ".svn" ".git"))))
-      (should (equal "projectA/"
+      (should (equal (expand-file-name "projectA/")
                      (projectile-root-top-down-recurring
                       "projectA/src/html/"
                       '(".git"))))
@@ -276,16 +276,16 @@
          "projectA/src/framework/framework.conf"
          "projectA/src/html/index.html"
          "projectA/.projectile")
-      (should (equal "projectA/"
+      (should (equal (expand-file-name "projectA/")
                      (projectile-root-bottom-up "projectA/src/framework/lib"
                                                 '(".git" ".svn"))))
-      (should (equal "projectA/"
+      (should (equal (expand-file-name "projectA/")
                      (projectile-root-bottom-up "projectA/src/html"
                                                 '(".git" ".svn"))))
-      (should (equal "projectA/src/html/"
+      (should (equal (expand-file-name "projectA/src/html/")
                      (projectile-root-bottom-up "projectA/src/html"
                                                 '(".svn" ".git"))))
-      (should (equal "projectA/"
+      (should (equal (expand-file-name "projectA/")
                      (projectile-root-bottom-up "projectA/src/html"
                                                 '(".projectile" "index.html")))))))
 


### PR DESCRIPTION
I have no  global picture so feel free to close if it's nonsense.

`file-truename` is very slow on remotes because it has to check if each subdir is a simlink.  I think inner `file-truename` is not needed because you don't care what you use as key in your cache as long that key stays the same, right?  Outer `file-truename` is not needed either. It's the task of the  cacher to store the truename. Also, if you pass a truename to the `root-function` you need not truename it afterwards because guaranties to produce truename if it gets truename. 