### PR TITLE
Don't require helm-config

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -40,7 +40,6 @@
 ;;; Code:
 
 (require 'projectile)
-(require 'helm-config)
 (require 'helm-locate)
 (require 'helm-buffers)
 (require 'helm-files)


### PR DESCRIPTION
It's entirely redundant here, and we should not force a given set of preferences upon the user.