### PR TITLE
Proposal: change projectile-mode-line to P[%s]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * `projectile-compile-project` now offers appropriate completion
   targets even when called from a subdirectory.
+* `projectile-mode-line` was changed to P[%s] to save mode-line space.
 
 ## 0.12.0 (03/29/2015)
 

--- a/projectile.el
+++ b/projectile.el
@@ -2563,7 +2563,7 @@ is chosen."
 
 ;;;###autoload
 (defcustom projectile-mode-line
-  '(:eval (format " Projectile[%s]" (projectile-project-name)))
+  '(:eval (format " P[%s]" (projectile-project-name)))
   "Mode line lighter for Projectile.
 
 The value of this variable is a mode line template as in


### PR DESCRIPTION
Projectile's mode line takes a quoter of my modeline on a left-right split.  I think `P[project-name]` is as suggestive as `Projectile[project-name]`.  I would expect most users changing it anyways, then why not change it by default?