### PR TITLE
Simplify helm-projectile command

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -821,11 +821,8 @@ If invoked outside of a project, displays a list of known projects to jump."
   (interactive "P")
   (if (projectile-project-p)
       (projectile-maybe-invalidate-cache arg))
-  (let ((helm-ff-transformer-show-only-basename nil)
-        (src (if (projectile-project-p)
-                 helm-projectile-sources-list
-               helm-source-projectile-projects)))
-    (helm :sources src
+  (let ((helm-ff-transformer-show-only-basename nil))
+    (helm :sources helm-projectile-sources-list
           :buffer "*helm projectile*"
           :prompt (projectile-prepend-project-name (if (projectile-project-p)
                                                        "pattern: "


### PR DESCRIPTION
If invoked outside of a project, helm-projectile only shows a list of
projects. Currently, helm-projectile-sources-list includes project
roots, project buffer and project file listings, but empty when used
outside of a project effectively shows only project listing.