### PR TITLE
Properly remove initial buffer

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -497,7 +497,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
 (defclass helm-source-projectile-buffer (helm-source-sync helm-type-buffer)
   ((init :initform (lambda ()
                      ;; Issue #51 Create the list before `helm-buffer' creation.
-                     (setq helm-buffers-list-cache (projectile-project-buffer-names))
+                     (setq helm-buffers-list-cache (cdr (projectile-project-buffer-names)))
                      (let ((result (cl-loop for b in helm-buffers-list-cache
                                             maximize (length b) into len-buf
                                             maximize (length (with-current-buffer b
@@ -510,7 +510,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
                          ;; If a new buffer is longer that this value
                          ;; this value will be updated
                          (setq helm-buffer-max-len-mode (cdr result))))))
-   (candidates :initform (cdr helm-buffers-list-cache))
+   (candidates :initform helm-buffers-list-cache)
    (matchplugin :initform nil)
    (match :initform 'helm-buffers-match-function)
    (persistent-action :initform 'helm-buffers-list-persistent-action)


### PR DESCRIPTION
We need to remove the initial buffer before Helm uses populate the
buffer list in its own buffer, not after.