### PR TITLE
[Fix #743] Allow buffer source to be composable

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -497,7 +497,9 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
 (defclass helm-source-projectile-buffer (helm-source-sync helm-type-buffer)
   ((init :initform (lambda ()
                      ;; Issue #51 Create the list before `helm-buffer' creation.
-                     (setq helm-buffers-list-cache (cdr (projectile-project-buffer-names)))
+                     (setq helm-buffers-list-cache (condition-case nil
+                                                       (cdr (projectile-project-buffer-names))
+                                                     (error nil)))
                      (let ((result (cl-loop for b in helm-buffers-list-cache
                                             maximize (length b) into len-buf
                                             maximize (length (with-current-buffer b


### PR DESCRIPTION
Similar to other sources, simply returns nil when not in a project, so
it can be used with other Helm commands. For explicity
helm-projectile-switch-to-buffer, the default error is still signaled.