### PR TITLE
Align projectile-compile-project even more closely with M-x compile

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2136,6 +2136,10 @@ with a prefix ARG."
                               (compilation-read-command default-cmd)
                             default-cmd)))
     (puthash project-root compilation-cmd projectile-compilation-cmd-map)
+    (save-some-buffers (not compilation-ask-about-save)
+                       (lambda ()
+                         (projectile-project-buffer-p (current-buffer)
+                                                      project-root)))
     (compilation-start compilation-cmd)))
 
 (defadvice compilation-find-file (around projectile-compilation-find-file)


### PR DESCRIPTION
`projectile-compile-project` now respects the value of
`compilation-ask-about-save` just like `M-x compile` does, with the
exception that only buffers from the current project are considered for
saving.