### PR TITLE
[Fix #750] Avoid helm source conflict

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -494,13 +494,15 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
               ("Add files to Dired buffer `C-c a'" . helm-projectile-dired-files-add-action)))
   "Helm source for listing project directories.")
 
+(defvar helm-projectile-buffers-list-cache nil)
+
 (defclass helm-source-projectile-buffer (helm-source-sync helm-type-buffer)
   ((init :initform (lambda ()
                      ;; Issue #51 Create the list before `helm-buffer' creation.
-                     (setq helm-buffers-list-cache (condition-case nil
-                                                       (cdr (projectile-project-buffer-names))
-                                                     (error nil)))
-                     (let ((result (cl-loop for b in helm-buffers-list-cache
+                     (setq helm-projectile-buffers-list-cache (condition-case nil
+                                                                  (cdr (projectile-project-buffer-names))
+                                                                (error nil)))
+                     (let ((result (cl-loop for b in helm-projectile-buffers-list-cache
                                             maximize (length b) into len-buf
                                             maximize (length (with-current-buffer b
                                                                (symbol-name major-mode)))
@@ -512,7 +514,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
                          ;; If a new buffer is longer that this value
                          ;; this value will be updated
                          (setq helm-buffer-max-len-mode (cdr result))))))
-   (candidates :initform helm-buffers-list-cache)
+   (candidates :initform helm-projectile-buffers-list-cache)
    (matchplugin :initform nil)
    (match :initform 'helm-buffers-match-function)
    (persistent-action :initform 'helm-buffers-list-persistent-action)


### PR DESCRIPTION
To make it possible to use `helm-source-projectile-buffers-list` and `helm-source-buffers-list` at the same time, for example:

```elisp
(defun foo ()
  (interactive)
  (helm :sources '(helm-source-projectile-buffers-list
                   helm-source-buffers-list)))
```