### PR TITLE
The first element of projectile-globally-ignored-directories is not used for grep

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1724,7 +1724,7 @@ to `projectile-grep-default-files'."
         ;; paths for find-grep should relative and without trailing /
         (let ((grep-find-ignored-directories
                (-union (--map (directory-file-name (file-relative-name it root-dir))
-                              (cdr (projectile-ignored-directories)))
+                              (projectile-ignored-directories))
                        grep-find-ignored-directories))
               (grep-find-ignored-files
                (-union (-map (lambda (file)


### PR DESCRIPTION
The default value of `projectile-globally-ignored-directories` (defined [here](https://github.com/bbatsov/projectile/blob/c0dcf03239dbc3d1c5307ff720cce3879984299e/projectile.el#L267)) is a list whose first element is ".idea". However, when you run `projectile-grep` you can see all the elements of the list being ignored except for ".idea".

If you do `(add-to-list 'projectile-globally-ignored-directories ".ensime_cache")` then ".ensime_cache" is added to the front of the list. Now, you can see that the `projectile-grep` passes ".idea" to find as one of the directories to skip but not ".ensime_cache".

This happens because the exception list is constructed in `projectile-ignored-directories` by appending `projectile-globally-ignored-directories` and `(projectile-project-ignored-directories)` [here](https://github.com/bbatsov/projectile/blob/c0dcf03239dbc3d1c5307ff720cce3879984299e/projectile.el#L1021). The result is then used in `projectile-grep` by taking `(cdr (projectile-ignored-directories))` [here](https://github.com/bbatsov/projectile/blob/c0dcf03239dbc3d1c5307ff720cce3879984299e/projectile.el#L1727). This drops the first item.

Note that all the other uses of `projectile-ignored-directories` use the whole list.

This `cdr` was added in commit 0060f6f by Andrew Hyatt with the comment "Support projects only for subdirs of the project root." It is not obvious why he added it, since it appears by inspection that that would have implemented the bug. The previous code appears to have operated on the whole list.

I am going to remove the `cdr` and run the code both with and without custom values in `projectile-globally-ignored-directories` and see how it works. Then I'll submit a pull request.

__Workaround__ Put a dummy item on the head of the list after you've added any directories that you want to ignore: `(add-to-list 'projectile-globally-ignored-directories ".a_random_placeholder_9999")`