### PR TITLE
add a flag that activates helm fuzzy matching.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -199,6 +199,14 @@ and `projectile-buffers-with-file-or-process'."
   :group 'projectile
   :type 'symbol)
 
+(defcustom projectile-helm-fuzzy-matching nil
+  "A flag that specifies whether we activate helm fuzzy matching.
+
+Defaults to nil (exact matching)."
+
+  :group 'projectile
+  :type 'boolean)
+
 (defcustom projectile-project-root-files
   '("rebar.config"       ; Rebar project file
     "project.clj"        ; Leiningen project file
@@ -1112,6 +1120,7 @@ project-root for every file."
           (helm-comp-read prompt choices
                           :initial-input initial-input
                           :candidates-in-buffer t
+                          :fuzzy projectile-helm-fuzzy-matching
                           :must-match 'confirm)
         (user-error "Please install helm from \
 https://github.com/emacs-helm/helm")))


### PR DESCRIPTION
Fixes #759. 

Specifying a truthy value for `projectile-helm-fuzzy-matching` activates helm's fuzzy matching wherever projectile uses helm.