### PR TITLE
Use project ignored files for helm-projectile-ack

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -718,10 +718,10 @@ If it is nil, or ack/ack-grep not found then use default grep command."
                           'identity
                           (-union (-map (lambda (path)
                                           (concat "--ignore-dir=" (file-name-nondirectory (directory-file-name path))))
-                                        projectile-globally-ignored-directories)
+                                        projectile-ignored-directories)
                                   (-map (lambda (path)
                                           (concat "--ignore-file=match:" (shell-quote-argument path)))
-                                        projectile-globally-ignored-files)) " "))
+                                        projectile-ignored-files)) " "))
             (helm-ack-grep-executable (cond
                                        ((executable-find "ack") "ack")
                                        ((executable-find "ack-grep") "ack-grep")


### PR DESCRIPTION
So far only the globally ignored files/directories have been used
while the grep command uses also the ignored files/directories
defined in `.projectile`

This should fix #766. Seem like I was wrong and only the helm-ack command is affected.