### PR TITLE
fix helm-projectile-ack

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -718,10 +718,10 @@ If it is nil, or ack/ack-grep not found then use default grep command."
                           'identity
                           (-union (-map (lambda (path)
                                           (concat "--ignore-dir=" (file-name-nondirectory (directory-file-name path))))
-                                        projectile-ignored-directories)
+                                        (projectile-ignored-directories))
                                   (-map (lambda (path)
                                           (concat "--ignore-file=match:" (shell-quote-argument path)))
-                                        projectile-ignored-files)) " "))
+                                        (projectile-ignored-files))) " "))
             (helm-ack-grep-executable (cond
                                        ((executable-find "ack") "ack")
                                        ((executable-find "ack-grep") "ack-grep")


### PR DESCRIPTION
I forgot to wrap projectile-ignored-files/directories in parenthesis to actually call the functions.

see #767 