### PR TITLE
removed check for executable

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -734,8 +734,6 @@ If it is nil, or ack/ack-grep not found then use default grep command."
 (defun helm-projectile-ag (&optional options)
   "Helm version of projectile-ag."
   (interactive (if current-prefix-arg (list (read-string "option: " "" 'helm-ag-command-history))))
-  (unless (executable-find "ag")
-    (error "ag not available"))
   (if (require 'helm-ag nil  'noerror)
       (if (projectile-project-p)
           (let* ((grep-find-ignored-files (-union (projectile-ignored-files-rel)  grep-find-ignored-files))


### PR DESCRIPTION
`helm-ag` supports more than just `ag` (as outlined in the docs [here](https://github.com/syohex/emacs-helm-ag#helm-agel-with-the-platinum-searcher-or-ack)). Having this check in breaks code such as:

```
(let ((helm-ag-base-command "pt -e --nocolor --nogroup"))
      (call-interactively 'helm-projectile-ag))
```

unless you happen to have ag present (when it's not needed).