### PR TITLE
Fix #695: 'If ignored directory doesn't have proper permissions, projectile-find-file displays "find: 'foldername': permission denied"'

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -884,7 +884,9 @@ Operates on filenames relative to the project root."
                          (projectile-ignored-directories-rel))))
     (-remove (lambda (file)
                (or (--any-p (string-prefix-p it file) ignored)
-                   (--any-p (string-suffix-p it file) projectile-globally-ignored-file-suffixes)))
+                   (--any-p (string-suffix-p it file) projectile-globally-ignored-file-suffixes)
+                   (and (string-prefix-p "find: `" file)
+                        (string-match "': Permission denied" file))))
              files)))
 
 


### PR DESCRIPTION
projectile-remove-ignored now checks to see if file names begin with "find: `" and contain "': Permission denied" and removes them if they do.