### PR TITLE
helm-projectile.el: compatible with the latest Helm

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -359,8 +359,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
 
 (defvar helm-projectile-file-actions
   (helm-projectile-hack-actions
-   (cdr (assq 'action (or helm-source-find-files
-                          (helm-make-source "Find files" 'helm-source-ffiles))))
+   helm-find-files-actions
    ;; Delete these actions
    'helm-ff-browse-project
    'helm-insert-file-name-completion-at-point


### PR DESCRIPTION
Recent changes in Helm (f71ce5e) broke the `helm-projectile-hack-actions`. This commit addresses the incompatible issue introduced by Helm f71ce5e.