### PR TITLE
helm-projectile.el: make compatible with Helm refactoring

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -40,10 +40,12 @@
 ;;; Code:
 
 (require 'projectile)
+(require 'cl-lib)
+(require 'helm)
+(require 'helm-types)
 (require 'helm-locate)
 (require 'helm-buffers)
 (require 'helm-files)
-(require 'cl-lib)
 
 (declare-function eshell "eshell")
 (declare-function helm-do-ag "helm-ag")


### PR DESCRIPTION
Helm change 6cd108f moved types to helm-types.el. Require this in
the way expected by helm.

Fixes bbatsov/projectile#797