### PR TITLE
Remove a couple of mode-line references from helm-projectile

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -542,7 +542,6 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
    (persistent-action :initform 'helm-buffers-list-persistent-action)
    (keymap :initform helm-buffer-map)
    (volatile :initform t)
-   (mode-line :initform helm-buffer-mode-line-string)
    (persistent-help
     :initform
     "Show this buffer / C-u \\[helm-execute-persistent-action]: Kill this buffer")))
@@ -681,7 +680,6 @@ If it is nil, or ack/ack-grep not found then use default grep command."
             :filter-one-by-one 'helm-grep-filter-one-by-one
             :candidate-number-limit 9999
             :nohighlight t
-            :mode-line helm-grep-mode-line-string
             ;; We need to specify keymap here and as :keymap arg [1]
             ;; to make it available in further resuming.
             :keymap helm-grep-map


### PR DESCRIPTION
It would appear there was a mass-deprecation of helm's mode-line settings in emacs-helm/helm@b95e5b049381b953c2d203eb39486344cc7165cd.  `helm-projectile.el` needs to remove those references or it breaks; I specifically witnessed the issue with the `helm-grep-mode-line-string`, and then did a little inspection to find the reference to `helm-buffer-mode-line-string`, which appears to also be removed in the referenced commit.