### PR TITLE
Improve projectile--detect-find-command

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -800,7 +800,7 @@ Files are returned as relative paths to the project root."
 (defun projectile--detect-find-command ()
   "Determine the appropriate default find command based on its capabilities.
 Needed because of the differences between GNU find and BSD find."
-  (if (zerop (shell-command "find /dev/null -readable"))
+  (if (zerop (call-process "find" nil nil nil "/dev/null" "-readable"))
       "find . \\! -readable -prune -o \\( -type f -print0 \\)"
       "find . \\! -perm +444 -prune -o \\( -type f -print0 \\)"))
 


### PR DESCRIPTION
1. Don't invoke shell by calling call-process instead of shell-command
2. Don't output error message when 'find' does not support '-readable' option

`1.` improves performance. https://github.com/bbatsov/projectile/pull/811#issuecomment-124335174 (CC: @xuchunyang). (Your benchmark result on my machine. Original: `0.007559`, This version: `0.002801`)
`2.` resolved https://github.com/bbatsov/projectile/pull/811#issuecomment-124343190(CC: @bixuanzju)