### PR TITLE
[Fix #521] Don't add non-projects to project cache

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -690,11 +690,9 @@ The current directory is assumed to be the project's root otherwise."
     (or (--some (let* ((cache-key (format "%s-%s" it dir))
                        (cache-value (gethash cache-key projectile-project-root-cache)))
                   (if cache-value
-                      (if (eq cache-value 'no-project-root)
-                          nil
-                        cache-value)
+                      cache-value
                     (let ((value (funcall it (file-truename dir))))
-                      (puthash cache-key (or value 'no-project-root) projectile-project-root-cache)
+                      (puthash cache-key value projectile-project-root-cache)
                       value)))
                 projectile-project-root-files-functions)
         (if projectile-require-project-root


### PR DESCRIPTION
When a user invokes Projectile on a non-project directory, such
directory is cached as 'no-project-root in projectile-project-root-cache,
and the second time when such directory is added with a .projectile file
or anything that Projectile can recognize as a project, it will never
become a project because the cache always suggests Projectile such
directory is not a project. This is a mistake. We should only cache
projects, not non-projects.