### PR TITLE
Avoid using `find -perm +mode`

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -800,7 +800,7 @@ Files are returned as relative paths to the project root."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-generic-command "find . \\! -perm +444 -prune -o \\( -type f -print0 \\)"
+(defcustom projectile-generic-command "find . \\! -perm /444 -prune -o \\( -type f -print0 \\)"
   "Command used by projectile to get the files in a generic project."
   :group 'projectile
   :type 'string)


### PR DESCRIPTION
POSIX does not specify the behaviour of `-perm +mode` as used with
`-perm +444`. This was a GNU extension that was deprecated on
2005-06-07 [1] and finally removed on 2013-04-21 [2].

Use the suggested replacement of `-perm /mode` instead.

[1] http://git.savannah.gnu.org/cgit/findutils.git/commit/?id=de2a4f4dd1c2e375eaea97386032f2e6720e3008
[2] http://git.savannah.gnu.org/cgit/findutils.git/commit/?id=90f0c5d24153ad3327edd6f2249fc95a5cfb72e0