### PR TITLE
Fix #830 (helm-projectile-ag issue)

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -41,6 +41,7 @@
 
 (require 'projectile)
 (require 'cl-lib)
+(require 'grep)
 (require 'helm)
 (require 'helm-types)
 (require 'helm-locate)
@@ -657,7 +658,6 @@ ACK-IGNORED-PATTERN is a file regex to exclude from searching.
 ACK-EXECUTABLE is the actual ack binary name.
 It is usually \"ack\" or \"ack-grep\".
 If it is nil, or ack/ack-grep not found then use default grep command."
-  (require 'grep)
   (let* ((default-directory (projectile-project-root))
          (helm-ff-default-directory (projectile-project-root))
          (follow (and helm-follow-mode-persistent


### PR DESCRIPTION
This is to import `grep` globally in helm-projectile, otherwise `helm-projectile-ag` would fail due to `grep-find-ignored-files` being void. See #830 for more details. I could've included `(require 'grep)` under `helm-projectile-ag` separately, but I see no harm importing it globally. 

This PR is to address #830.

Thanks!