### PR TITLE
Allow specifying regexp to projectile-grep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is done via the variables `projectile-project-compilation-cmd` and `project
 
 * `projectile-compile-project` now offers appropriate completion
   targets even when called from a subdirectory.
+* Add an argument specifying the regexp to search to `projectile-grep`.
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -1779,19 +1779,22 @@ This is a subset of `grep-read-files', where either a matching entry from
                (and ext (concat "*." ext)))))
       (or default-alias default-extension))))
 
-(defun projectile-grep (&optional arg)
+(defun projectile-grep (&optional regexp arg)
   "Perform rgrep in the project.
 
 With a prefix ARG asks for files (globbing-aware) which to grep in.
 With prefix ARG of `-' (such as `M--'), default the files (without prompt),
-to `projectile-grep-default-files'."
-  (interactive "P")
+to `projectile-grep-default-files'.
+
+With REGEXP given, don't query the user for a regexp."
+  (interactive "i\nP")
   (require 'grep) ;; for `rgrep'
   (let* ((roots (projectile-get-project-directories))
-         (search-regexp (if (and transient-mark-mode mark-active)
-                            (buffer-substring (region-beginning) (region-end))
-                          (read-string (projectile-prepend-project-name "Grep for: ")
-                                       (projectile-symbol-at-point))))
+         (search-regexp (or regexp
+                            (if (and transient-mark-mode mark-active)
+                                (buffer-substring (region-beginning) (region-end))
+                              (read-string (projectile-prepend-project-name "Grep for: ")
+                                           (projectile-symbol-at-point)))))
          (files (and arg (or (and (equal current-prefix-arg '-)
                                   (projectile-grep-default-files))
                              (read-string (projectile-prepend-project-name "Grep in: ")

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -481,7 +481,7 @@
             (with-current-buffer (find-file-noselect (car test) t)
 	      (save-excursion
 		(re-search-forward sym)
-		(projectile-grep ?-)))))))))
+		(projectile-grep nil ?-)))))))))
 
 ;;;;;;;;; fresh tests
 


### PR DESCRIPTION
This makes overriding the "query the user" part easier.

This is pull request #616 rebased onto current master.