### PR TITLE
Don't expand file names in *-files-in-all-projects-list source

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -434,7 +434,6 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
                 (let ((projectile-require-project-root nil))
                   (projectile-all-project-files))
               (error nil)))
-    :coerce 'helm-projectile-coerce-file
     :keymap helm-find-files-map
     :help-message 'helm-ff-help-message
     :mode-line helm-read-file-name-mode-line-string


### PR DESCRIPTION
`helm-projectile-coerce-file' uses project root to expand file names, so
it will fail when not under a project.  It is also redundant since the
file names have been expanded when collecting them.

Continue fixing #831