### PR TITLE
[Fix #952] Exclude out-of-project VCS submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#871](https://github.com/bbatsov/projectile/issues/871): Stop advice for `compilation-find-file` to override other advices.
 * [#557](https://github.com/bbatsov/projectile/issues/557): stack overflow in `projectile-find-tag'.
 * [#955](https://github.com/bbatsov/projectile/issues/955): Error while toggling between test and source file.
+* [#952](https://github.com/bbatsov/projectile/issues/952): VCS submodules brought in even thought not descendent of project root.
 
 ## 0.13.0 (10/21/2015)
 

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -639,6 +639,31 @@
                          (projectile-find-matching-file
                           "spec/models/food/sea_spec.rb"))))))))
 
+(ert-deftest projectile-test-exclude-out-of-project-submodules ()
+  (projectile-test-with-files
+      (;; VSC root is here
+       "project/"
+       "project/.git/"
+       "project/.gitmodules"
+       ;; Current project root is here:
+       "project/web-ui/"
+       "project/web-ui/.projectile"
+       ;; VCS git submodule will return the following submodules,
+       ;; relative to current project root, 'project/web-ui/':
+       "project/web-ui/vendor/client-submodule/"
+       "project/server/vendor/server-submodule/")
+    (let ((project (file-truename (expand-file-name "project/web-ui"))))
+      (noflet ((projectile-files-via-ext-command
+                (arg) (when (string= default-directory project)
+                        '("vendor/client-submodule"
+                          "../server/vendor/server-submodule")))
+               (projectile-project-root
+                () project))
+
+        ;; assert that it only returns the submodule 'project/web-ui/vendor/client-submodule/'
+        (should (equal (list (expand-file-name "vendor/client-submodule/" project))
+                       (projectile-get-all-sub-projects project)))))))
+
 ;; Local Variables:
 ;; indent-tabs-mode: nil
 ;; End:


### PR DESCRIPTION
Given the following tree structure:

```
./.git # git repo top-level
./front-end/
./front-end/.projectile
./front-end/src/...
./server/
./server/vendor
./server/vendor/a-git-submodule/
./server/vendor/a-git-submodule/.git
```

If the current top-level folder is `./front-end/`, and you invoke `projectile-find-file`, then `../server/vendor/a-git-submodule/` will leak into your choices. Presently, all submodules for the current repository are traversed, recursively so, regardless of whether or not those submodules reside within the current project root.

The attached patch resolves that issue.

Thank you for projectile!
