### PR TITLE
Optionally run monky on Mercurial projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add the ability to specify a project compilation and test commands via `.dir-locals.el`.
 This is done via the variables `projectile-project-compilation-cmd` and `projectile-project-test-cmd`.
 * [#489](https://github.com/bbatsov/projectile/issues/489): New interactive command `projectile-run-project`.
+* Optionally run [monky](http://ananthakumaran.in/monky/) on Mercurial projects.
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -2040,17 +2040,24 @@ to run the replacement."
 (defun projectile-vc (&optional project-root)
   "Open `vc-dir' at the root of the project.
 
-For git projects `magit-status-internal' is used if available."
+For git projects `magit-status-internal' is used if available.
+For hg projects `monky-status' is used if available."
   (interactive)
   (or project-root (setq project-root (projectile-project-root)))
-  (if (eq (projectile-project-vcs project-root) 'git)
-      (cond ((fboundp 'magit-status-internal)
-             (magit-status-internal project-root))
-            ((fboundp 'magit-status)
-             (with-no-warnings (magit-status project-root)))
-            (t
-             (vc-dir project-root)))
-    (vc-dir project-root)))
+  (let ((vcs (projectile-project-vcs project-root)))
+    (pcase vcs
+      (`git
+       (cond ((fboundp 'magit-status-internal)
+              (magit-status-internal project-root))
+             ((fboundp 'magit-status)
+              (with-no-warnings (magit-status project-root)))
+             (t
+              (vc-dir project-root))))
+      (`hg
+       (if (fboundp 'monky-status)
+           (monky-status project-root)
+         (vc-dir project-root)))
+      (_ (vc-dir project-root)))))
 
 ;;;###autoload
 (defun projectile-recentf ()


### PR DESCRIPTION
VC handling of Mercurial repos is quite poor. I much prefer "Monky" https://github.com/ananthakumaran/monky

Arguably, the best solution would be to allow users to customize `projectile-vc`, instead of having special cases for "magit", "monky" or the like.