### PR TITLE
Honor projectile-use-git-grep in helm-projectile-grep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This is done via the variables `projectile-project-compilation-cmd` and `project
 * [#721](https://github.com/bbatsov/projectile/issues/721#issuecomment-100830507): Remove current buffer from `helm-projectile-switch-project`.
 * [#667](https://github.com/bbatsov/projectile/issues/667) Use `file-truename` when caching filenames to prevent duplicate/symlinked filepaths from appearing when opening a project file.
 * [#625](https://github.com/bbatsov/projectile/issues/625): Ensure the directory has a trailing slash while searching for it.
+* [#763](https://github.com/bbatsov/projectile/issues/763): Check for `projectile-use-git-grep` in `helm-projectile-grep`
 
 ## 0.12.0 (03/29/2015)
 

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -666,7 +666,9 @@ If it is nil, or ack/ack-grep not found then use default grep command."
          (helm-grep-ignored-directories (-union (projectile-ignored-directories-rel) grep-find-ignored-directories))
          (helm-grep-default-command (if use-ack-p
                                         (concat ack-executable " -H --no-group --no-color " ack-ignored-pattern " %p %f")
-                                      "grep -a -r %e -n%cH -e %p %f ."))
+                                      (if (and projectile-use-git-grep (eq (projectile-project-vcs) 'git))
+                                          "git --no-pager grep --no-color -n -e %p -- %f"
+                                        "grep -a -r %e -n%cH -e %p %f .")))
          (helm-grep-default-recurse-command helm-grep-default-command)
          (helm-source-grep
           (helm-build-async-source


### PR DESCRIPTION
If projectile-use-git-grep set to a non-nil then helm-projectile-grep will
use git-grep in git projects, otherwise fall back to regular grep.

This patch fixes #763 
