### PR TITLE
Make helm-projectile-ag respects .projectile whitelist

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -769,7 +769,7 @@ If it is nil, or ack/ack-grep not found then use default grep command."
                  (helm-ag-command-option options)
                  (helm-ag-base-command (concat helm-ag-base-command " " ignored))
                  (current-prefix-arg nil))
-            (helm-do-ag (projectile-project-root)))
+            (helm-do-ag (projectile-project-root) (or (car (projectile-parse-dirconfig-file)) nil)))
         (error "You're not in a project"))
     (error "helm-ag not available")))
 

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -769,7 +769,7 @@ If it is nil, or ack/ack-grep not found then use default grep command."
                  (helm-ag-command-option options)
                  (helm-ag-base-command (concat helm-ag-base-command " " ignored))
                  (current-prefix-arg nil))
-            (helm-do-ag (projectile-project-root) (or (car (projectile-parse-dirconfig-file)) nil)))
+            (helm-do-ag (projectile-project-root) (car (projectile-parse-dirconfig-file))))
         (error "You're not in a project"))
     (error "helm-ag not available")))
 


### PR DESCRIPTION
Make helm-projectile-ag respects .projectile whitelist, so it's usable for large scale projects.

Multi-target supports for helm-do-ag has been added in: https://github.com/syohex/emacs-helm-ag/pull/169