### PR TITLE
Use help-projectile-grep instead of helm-find-file when selecting a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is done via the variables `projectile-project-compilation-cmd` and `project
 * `projectile-compile-project` now offers appropriate completion
   targets even when called from a subdirectory.
 * Add an argument specifying the regexp to search to `projectile-grep`.
+* Use `help-projectile-grep` instead of `helm-find-file` when selecting a project.
 
 ### Bugs fixed
 

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -187,7 +187,7 @@ It is there because Helm requires it."
       (kbd "C-d") #'dired
       (kbd "M-g") #'helm-projectile-vc
       (kbd "M-e") #'helm-projectile-switch-to-eshell
-      (kbd "C-s") #'helm-find-files-grep
+      (kbd "C-s") #'helm-projectile-grep
       (kbd "M-c") #'helm-projectile-compile-project
       (kbd "M-t") #'helm-projectile-test-project
       (kbd "M-r") #'helm-projectile-run-project
@@ -212,7 +212,7 @@ It is there because Helm requires it."
               ("Open Dired in project's directory `C-d'" . dired)
               ("Open project root in vc-dir or magit `M-g'" . helm-projectile-vc)
               ("Switch to Eshell `M-e'" . helm-projectile-switch-to-eshell)
-              ("Grep in projects `C-s'.  With C-u, recurse" . helm-find-files-grep)
+              ("Grep in projects `C-s'" . helm-projectile-grep)
               ("Compile project `M-c'. With C-u, new compile command"
                . helm-projectile-compile-project)
               ("Remove project(s) `M-D'" . helm-projectile-remove-known-project)))
@@ -504,14 +504,14 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
                 (kbd "M-e")   #'helm-projectile-switch-to-eshell
                 (kbd "C-c f") #'helm-projectile-dired-files-new-action
                 (kbd "C-c a") #'helm-projectile-dired-files-add-action
-                (kbd "C-s")   #'helm-find-files-grep)
+                (kbd "C-s")   #'helm-projectile-grep)
               map)
     :help-message 'helm-ff-help-message
     :mode-line helm-read-file-name-mode-line-string
     :action '(("Open Dired" . helm-projectile-dired-find-dir)
               ("Open Dired in other window `C-c o'" . helm-projectile-dired-find-dir)
               ("Switch to Eshell `M-e'" . helm-projectile-switch-to-eshell)
-              ("Grep in projects `C-s C-u Recurse'" . helm-find-files-grep)
+              ("Grep in projects `C-s'" . helm-projectile-grep)
               ("Create Dired buffer from files `C-c f'" . helm-projectile-dired-files-new-action)
               ("Add files to Dired buffer `C-c a'" . helm-projectile-dired-files-add-action)))
   "Helm source for listing project directories.")

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -650,15 +650,16 @@ Other file extensions can be customized with the variable `projectile-other-file
                   :prompt (projectile-prepend-project-name "Find other file: ")))))
     (error "No other file found")))
 
-(defun helm-projectile-grep-or-ack (&optional use-ack-p ack-ignored-pattern ack-executable)
+(defun helm-projectile-grep-or-ack (&optional dir use-ack-p ack-ignored-pattern ack-executable)
   "Perform helm-grep at project root.
+DIR directory where to search
 USE-ACK-P indicates whether to use ack or not.
 ACK-IGNORED-PATTERN is a file regex to exclude from searching.
 ACK-EXECUTABLE is the actual ack binary name.
 It is usually \"ack\" or \"ack-grep\".
 If it is nil, or ack/ack-grep not found then use default grep command."
-  (let* ((default-directory (projectile-project-root))
-         (helm-ff-default-directory (projectile-project-root))
+  (let* ((default-directory (or dir (projectile-project-root)))
+         (helm-ff-default-directory default-directory)
          (follow (and helm-follow-mode-persistent
                       (assoc-default 'follow helm-source-grep)))
          (helm-grep-in-recurse t)
@@ -705,7 +706,7 @@ If it is nil, or ack/ack-grep not found then use default grep command."
      :buffer (format "*helm %s*" (if use-ack-p
                                      "ack"
                                    "grep"))
-     :default-directory (projectile-project-root)
+     :default-directory default-directory
      :keymap helm-grep-map
      :history 'helm-grep-history
      :truncate-lines t)))
@@ -725,13 +726,13 @@ If it is nil, or ack/ack-grep not found then use default grep command."
   (helm-projectile-toggle -1))
 
 ;;;###autoload
-(defun helm-projectile-grep ()
-  "Helm version of projectile-grep."
+(defun helm-projectile-grep (&optional dir)
+  "Helm version of `projectile-grep'.
+DIR is the project root, if not set then current directory is used"
   (interactive)
-  (if (projectile-project-p)
-      (funcall'run-with-timer 0.01 nil
-                              #'helm-projectile-grep-or-ack nil)
-    (error "You're not in a project")))
+  (let ((project-root (or dir (projectile-project-root) (error "You're not in a project"))))
+    (funcall'run-with-timer 0.01 nil
+                              #'helm-projectile-grep-or-ack project-root nil)))
 
 ;;;###autoload
 (defun helm-projectile-ack ()


### PR DESCRIPTION
This patch allows user to use helm-projectile-grep with all its
features (like ignored files and git-grep) during selecting project. 
The only downside of this patch is that user loses ability to run a
non-recursive grep.