### PR TITLE
fix non-ascii char parsing in dirconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This is done via the variables `projectile-project-compilation-cmd` and `project
 * [#667](https://github.com/bbatsov/projectile/issues/667) Use `file-truename` when caching filenames to prevent duplicate/symlinked filepaths from appearing when opening a project file.
 * [#625](https://github.com/bbatsov/projectile/issues/625): Ensure the directory has a trailing slash while searching for it.
 * [#763](https://github.com/bbatsov/projectile/issues/763): Check for `projectile-use-git-grep` in `helm-projectile-grep`
+* Fix `projectile-parse-dirconfig-file` to parse non-ASCII characters properly.
 
 ## 0.12.0 (03/29/2015)
 

--- a/projectile.el
+++ b/projectile.el
@@ -1107,7 +1107,7 @@ prefix the string will be assumed to be an ignore string."
   (let (keep ignore (dirconfig (projectile-dirconfig-file)))
     (when (projectile-file-exists-p dirconfig)
       (with-temp-buffer
-        (insert-file-contents-literally dirconfig)
+        (insert-file-contents dirconfig)
         (while (not (eobp))
           (pcase (char-after)
             (?+ (push (buffer-substring (1+ (point)) (line-end-position)) keep))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -127,7 +127,7 @@
 (ert-deftest projectile-test-parse-dirconfig-file ()
   (noflet ((file-exists-p (filename) t)
            (file-truename (filename) filename)
-           (insert-file-contents-literally
+           (insert-file-contents
             (filename)
             (save-excursion
               (insert


### PR DESCRIPTION
Fixed parsing non-ascii characters in dirconfig (for example ignored directories in `.projectile`). I noticed that when ignoring directories with names like `harjoitustyö.prv` in `.projectile` they were being mangled by `projectile-parse-dirconfig-file` (read as `harjoitusty\303\266.prv`) and as a result weren't actually ignored. Same happens with other non-ascii characters like é.

Not sure if this is the smartest way to fix it.

Some reference material I went through:
https://lists.gnu.org/archive/html/bug-gnu-emacs/2015-04/msg00331.html
https://lists.gnu.org/archive/html/emacs-diffs/2015-04/msg00308.html