### PR TITLE
Omit current buffer from switch-to-buffer choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This is done via the variables `projectile-project-compilation-cmd` and `project
   targets even when called from a subdirectory.
 * Add an argument specifying the regexp to search to `projectile-grep`.
 * Use `help-projectile-grep` instead of `helm-find-file` when selecting a project.
+* Omit current buffer from `projectile-switch-to-buffer` and `projectile-switch-to-buffer-other-window` choices.
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -968,23 +968,29 @@ opened through use of recentf."
   "Prepend the current project's name to STRING."
   (format "[%s] %s" (projectile-project-name) string))
 
+(defun projectile-read-buffer-to-switch (prompt)
+  "Read the name of a buffer to switch to, prompting with PROMPT.
+
+This function excludes the current buffer from the offered
+choices."
+  (projectile-completing-read
+   prompt
+   (-remove-item (buffer-name (current-buffer))
+                 (projectile-project-buffer-names))))
+
 ;;;###autoload
 (defun projectile-switch-to-buffer ()
   "Switch to a project buffer."
   (interactive)
   (switch-to-buffer
-   (projectile-completing-read
-    "Switch to buffer: "
-    (projectile-project-buffer-names))))
+   (projectile-read-buffer-to-switch "Switch to buffer: ")))
 
 ;;;###autoload
 (defun projectile-switch-to-buffer-other-window ()
   "Switch to a project buffer and show it in another window."
   (interactive)
   (switch-to-buffer-other-window
-   (projectile-completing-read
-    "Switch to buffer: "
-    (projectile-project-buffer-names))))
+   (projectile-read-buffer-to-switch "Switch to buffer: ")))
 
 ;;;###autoload
 (defun projectile-display-buffer ()


### PR DESCRIPTION
I'm new to projectile so I feel like this PR may be naive; please close if so! I couldn't understand why `projectile-switch-to-buffer` was offering the current buffer as a choice. This PR excludes it, thus giving similar behavior to core emacs' `read-buffer-to-switch ` for which the docstring says:

```
...
This function is intended for the `switch-to-buffer' family of
commands since these need to omit the name of the current buffer
from the list of completions and default values."
 ```