### PR TITLE
Allow specification of a compilation dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 This is done via the variables `projectile-project-compilation-cmd` and `projectile-project-test-cmd`.
 * [#489](https://github.com/bbatsov/projectile/issues/489): New interactive command `projectile-run-project`.
 * Optionally run [monky](http://ananthakumaran.in/monky/) on Mercurial projects.
+* Add the ability to specify a project compilation directory relative to the root directory via `.dir-locals.el` with the variable `projectile-project-compilation-dir`.
 
 ### Changes
 

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -579,6 +579,16 @@
                    (projectile-get-other-files "src/test2.service.spec.js" source-tree)))
     ))
 
+(ert-deftest projectile-test-compilation-directory ()
+  (defun helper (project-root rel-dir)
+    (noflet ((projectile-project-root () project-root))
+            (let ((projectile-project-compilation-dir rel-dir))
+              (projectile-compilation-dir))))
+
+  (should (equal "/root/build/" (helper "/root/" "build")))
+  (should (equal "/root/build/" (helper "/root/" "build/")))
+  (should (equal "/root/build/" (helper "/root/" "./build")))
+  (should (equal "/root/local/build/" (helper "/root/" "local/build"))))
 
 (ert-deftest projectile-test-dirname-matching-count ()
   (should (equal 2


### PR DESCRIPTION
Other than the project root dir.

Fixes #874.

I added a test because there was some weird behavior with trailing slashes on the directory variable (fixed with `filename-as-directory`).