### PR TITLE
Add projectile-before-switch-project-hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Add `projectile-before-switch-project-hook`.
 * Add the ability to specify the project type via `.dir-locals.el`.
 * Add support for projects using Midje.
 * Add the ability to create missing tests automatically (controlled via the `projectile-create-missing-test-files` defcustom).

--- a/projectile.el
+++ b/projectile.el
@@ -2237,6 +2237,7 @@ With a prefix ARG invokes `projectile-commander' instead of
          (switch-project-action (if arg
                                     'projectile-commander
                                   projectile-switch-project-action)))
+    (run-hooks 'projectile-before-switch-project-hook)
     (funcall switch-project-action)
     (run-hooks 'projectile-switch-project-hook)))
 
@@ -2276,6 +2277,11 @@ This command will first prompt for the directory the file is in."
 
 (defcustom projectile-switch-project-hook nil
   "Hooks run when project is switched."
+  :group 'projectile
+  :type 'hook)
+
+(defcustom projectile-before-switch-project-hook nil
+  "Hooks run when right before project is switched."
   :group 'projectile
   :type 'hook)
 


### PR DESCRIPTION
Add hook right before `switch-project-action` is called.

This is related to the discussion at https://github.com/milkypostman/melpa/pull/3177