### PR TITLE
Rename projectile-switch-project-hook to projectile-after-switch-project-hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is done via the variables `projectile-project-compilation-cmd` and `project
 
 ### Changes
 
+* Rename `projectile-switch-project-hook` to `projectile-after-switch-project-hook`.
 * `projectile-compile-project` now offers appropriate completion
   targets even when called from a subdirectory.
 * Add an argument specifying the regexp to search to `projectile-grep`.

--- a/projectile.el
+++ b/projectile.el
@@ -2246,7 +2246,7 @@ With a prefix ARG invokes `projectile-commander' instead of
                                   projectile-switch-project-action)))
     (run-hooks 'projectile-before-switch-project-hook)
     (funcall switch-project-action)
-    (run-hooks 'projectile-switch-project-hook)))
+    (run-hooks 'projectile-after-switch-project-hook)))
 
 
 (defun projectile-find-file-in-directory (&optional directory)
@@ -2282,8 +2282,8 @@ This command will first prompt for the directory the file is in."
   (let ((projectile-require-project-root nil))
     (find-file (projectile-completing-read "Find file in projects: " (projectile-all-project-files)))))
 
-(defcustom projectile-switch-project-hook nil
-  "Hooks run when project is switched."
+(defcustom projectile-after-switch-project-hook nil
+  "Hooks run right after project is switched."
   :group 'projectile
   :type 'hook)
 


### PR DESCRIPTION
Rename `projectile-switch-project-hook` to `projectile-after-switch-project-hook`. 

This is related to PR https://github.com/bbatsov/projectile/pull/879 which adds a `projectile-before-switch-project-hook`.