### PR TITLE
Fix issue with ack vs. grep in last update

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -735,25 +735,24 @@ DIR is the project root, if not set then current directory is used"
                               #'helm-projectile-grep-or-ack project-root nil)))
 
 ;;;###autoload
-(defun helm-projectile-ack ()
+(defun helm-projectile-ack (&optional dir)
   "Helm version of projectile-ack."
   (interactive)
-  (if (projectile-project-p)
-      (let ((ack-ignored (mapconcat
-                          'identity
-                          (-union (-map (lambda (path)
-                                          (concat "--ignore-dir=" (file-name-nondirectory (directory-file-name path))))
-                                        (projectile-ignored-directories))
-                                  (-map (lambda (path)
-                                          (concat "--ignore-file=match:" (shell-quote-argument path)))
-                                        (projectile-ignored-files))) " "))
-            (helm-ack-grep-executable (cond
-                                       ((executable-find "ack") "ack")
-                                       ((executable-find "ack-grep") "ack-grep")
-                                       (t (error "ack or ack-grep is not available.")))))
-        (funcall 'run-with-timer 0.01 nil
-                 #'helm-projectile-grep-or-ack t ack-ignored helm-ack-grep-executable))
-    (error "You're not in a project")))
+  (let ((project-root (or dir (projectile-project-root) (error "You're not in a project"))))
+    (let ((ack-ignored (mapconcat
+                        'identity
+                        (-union (-map (lambda (path)
+                                        (concat "--ignore-dir=" (file-name-nondirectory (directory-file-name path))))
+                                      (projectile-ignored-directories))
+                                (-map (lambda (path)
+                                        (concat "--ignore-file=match:" (shell-quote-argument path)))
+                                      (projectile-ignored-files))) " "))
+          (helm-ack-grep-executable (cond
+                                     ((executable-find "ack") "ack")
+                                     ((executable-find "ack-grep") "ack-grep")
+                                     (t (error "ack or ack-grep is not available.")))))
+      (funcall 'run-with-timer 0.01 nil
+               #'helm-projectile-grep-or-ack project-root t ack-ignored helm-ack-grep-executable))))
 
 ;;;###autoload
 (defun helm-projectile-ag (&optional options)


### PR DESCRIPTION
The latest update broke helm-projectile-ack. This should restore functionality.

I don't see where the dir argument is used in the grep scenario, so not sure that works here.