### PR TITLE
support gradle projects with gradlew script; resolves #840

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.13.0 (10/21/2015)
+
 ### New features
 
 * Add `projectile-before-switch-project-hook`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* Add [boot-clj](https://github.com/boot-clj/boot) project type.
+
 ## 0.13.0 (10/21/2015)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is done via the variables `projectile-project-compilation-cmd` and `project
 * [#489](https://github.com/bbatsov/projectile/issues/489): New interactive command `projectile-run-project`.
 * Optionally run [monky](http://ananthakumaran.in/monky/) on Mercurial projects.
 * Add the ability to specify a project compilation directory relative to the root directory via `.dir-locals.el` with the variable `projectile-project-compilation-dir`.
+* When there is a selected region, projectile-ag, projectile-grep, projectile-replace and projectile-find-tag uses it's content as a search term instead of symbol at point.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Add [boot-clj](https://github.com/boot-clj/boot) project type.
+* Add support for projects using gradlew wrapper script.
 
 ## 0.13.0 (10/21/2015)
 

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -7,7 +7,7 @@
 ;; Created: 2011-31-07
 ;; Keywords: project, convenience
 ;; Version: 0.12.0
-;; Package-Requires: ((helm "1.4.0") (projectile "0.12.0") (dash "1.5.0") (cl-lib "0.3"))
+;; Package-Requires: ((helm "1.7.7") (projectile "0.12.0") (dash "1.5.0") (cl-lib "0.3"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -83,7 +83,7 @@ This needs to be set before loading helm-projectile."
        `(define-key ,keymap ,key
           (lambda ()
             (interactive)
-            (helm-quit-and-execute-action ,def)))
+            (helm-exit-and-execute-action ,def)))
        ret)
       (setq key (pop bindings)
             def (pop bindings)))
@@ -221,9 +221,10 @@ It is there because Helm requires it."
               ("Remove project(s) `M-D'" . helm-projectile-remove-known-project)))
   "Helm source for known projectile projects.")
 
-(define-key helm-etags-map (kbd "C-c p f") (lambda ()
-                                             (interactive)
-                                             (helm-run-after-quit 'helm-projectile-find-file nil)))
+(define-key helm-etags-map (kbd "C-c p f")
+  (lambda ()
+    (interactive)
+    (helm-run-after-exit 'helm-projectile-find-file nil)))
 
 (defun helm-projectile-find-files-eshell-command-on-file-action (_candidate)
   (interactive)

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -52,6 +52,9 @@
 (declare-function helm-do-ag "helm-ag")
 (defvar helm-ag-base-command)
 
+(defvar grep-find-ignored-directories)
+(defvar grep-find-ignored-files)
+
 (defgroup helm-projectile nil
   "Helm support for projectile."
   :prefix "helm-projectile-"

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -6,8 +6,8 @@
 ;; URL: https://github.com/bbatsov/projectile
 ;; Created: 2011-31-07
 ;; Keywords: project, convenience
-;; Version: 0.12.0
-;; Package-Requires: ((helm "1.7.7") (projectile "0.12.0") (dash "1.5.0") (cl-lib "0.3"))
+;; Version: 0.13.0
+;; Package-Requires: ((helm "1.7.7") (projectile "0.13.0") (dash "1.5.0") (cl-lib "0.3"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -156,14 +156,14 @@ DIR is the project root."
 DIR is the project root."
   (let ((helm--reading-passwd-or-string t)
         (default-directory dir))
-    (projectile-test-project helm-current-prefix-arg dir)))
+    (projectile-test-project helm-current-prefix-arg)))
 
 (defun helm-projectile-run-project (dir)
   "A Helm action for run a project.
 DIR is the project root."
   (let ((helm--reading-passwd-or-string t)
         (default-directory dir))
-    (projectile-run-project helm-current-prefix-arg dir)))
+    (projectile-run-project helm-current-prefix-arg)))
 
 (defun helm-projectile-remove-known-project (_ignore)
   "Delete selected projects.

--- a/projectile.el
+++ b/projectile.el
@@ -1810,10 +1810,8 @@ With REGEXP given, don't query the user for a regexp."
   (require 'grep) ;; for `rgrep'
   (let* ((roots (projectile-get-project-directories))
          (search-regexp (or regexp
-                            (if (and transient-mark-mode mark-active)
-                                (buffer-substring (region-beginning) (region-end))
-                              (read-string (projectile-prepend-project-name "Grep for: ")
-                                           (projectile-symbol-at-point)))))
+                            (read-string (projectile-prepend-project-name "Grep for: ")
+                                         (projectile-symbol-or-selection-at-point))))
          (files (and arg (or (and (equal current-prefix-arg '-)
                                   (projectile-grep-default-files))
                              (read-string (projectile-prepend-project-name "Grep in: ")
@@ -1846,7 +1844,7 @@ regular expression."
   (interactive
    (list (read-from-minibuffer
           (projectile-prepend-project-name (format "Ag %ssearch for: " (if current-prefix-arg "regexp " "")))
-          (projectile-symbol-at-point))
+          (projectile-symbol-or-selection-at-point))
          current-prefix-arg))
   (if (require 'ag nil 'noerror)
       (let ((ag-command (if arg 'ag-regexp 'ag))
@@ -1912,7 +1910,7 @@ regular expression."
                 (projectile--tags tags-completion-table))))
     (funcall find-tag-function (projectile-completing-read "Find tag: "
                                                            tags
-                                                           (projectile-symbol-at-point)))))
+                                                           (projectile-symbol-or-selection-at-point)))))
 
 (defun projectile--tags (completion-table)
   "Find tags using COMPLETION-TABLE."
@@ -2008,7 +2006,7 @@ to run the replacement."
   (interactive "P")
   (let* ((old-text (read-string
                     (projectile-prepend-project-name "Replace: ")
-                    (projectile-symbol-at-point)))
+                    (projectile-symbol-or-selection-at-point)))
          (new-text (read-string
                     (projectile-prepend-project-name
                      (format "Replace %s with: " old-text))))
@@ -2018,6 +2016,12 @@ to run the replacement."
                       (projectile-project-root)))
          (files (projectile-files-with-string old-text directory)))
     (tags-query-replace old-text new-text nil (cons 'list files))))
+
+(defun projectile-symbol-or-selection-at-point ()
+  "Get the symbol or selected text at point."
+  (if (use-region-p)
+      (buffer-substring-no-properties (region-beginning) (region-end))
+    (projectile-symbol-at-point)))
 
 (defun projectile-symbol-at-point ()
   "Get the symbol at point and strip its properties."

--- a/projectile.el
+++ b/projectile.el
@@ -53,6 +53,10 @@
 (declare-function pkg-info-version-info "pkg-info")
 (declare-function tags-completion-table "etags")
 
+(defvar grep-files-aliases)
+(defvar grep-find-ignored-directories)
+(defvar grep-find-ignored-files)
+
 ;;;; Compatibility
 (eval-and-compile
   ;; Added in Emacs 24.3.

--- a/projectile.el
+++ b/projectile.el
@@ -1529,11 +1529,12 @@ With a prefix ARG invalidates the cache first."
 (defvar projectile-project-types (make-hash-table)
   "A hash table holding all project types that are known to Projectile.")
 
-(defun projectile-register-project-type (project-type marker-files &optional compile-command test-command run-command)
+(defun projectile-register-project-type
+    (project-type marker-files &optional compile-command test-command run-command)
   "Register a project type with projectile.
 
 A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
-a COMPILE-COMMAND and a TEST-COMMAND."
+a COMPILE-COMMAND, a TEST-COMMAND, and a RUN-COMMAND."
   (puthash project-type (list 'marker-files marker-files
                               'compile-command compile-command
                               'test-command test-command

--- a/projectile.el
+++ b/projectile.el
@@ -5,7 +5,7 @@
 ;; Author: Bozhidar Batsov <bozhidar@batsov.com>
 ;; URL: https://github.com/bbatsov/projectile
 ;; Keywords: project, convenience
-;; Version: 0.13.0-cvs
+;; Version: 0.13.0
 ;; Package-Requires: ((dash "2.11.0") (pkg-info "0.4"))
 
 ;; This file is NOT part of GNU Emacs.

--- a/projectile.el
+++ b/projectile.el
@@ -208,6 +208,7 @@ Two example filter functions are shipped by default -
     "SConstruct"         ; Scons project file
     "pom.xml"            ; Maven project file
     "build.sbt"          ; SBT project file
+    "gradlew"            ; Gradle wrapper script
     "build.gradle"       ; Gradle project file
     "Gemfile"            ; Bundler file
     "requirements.txt"   ; Pip file
@@ -1535,6 +1536,7 @@ a COMPILE-COMMAND and a TEST-COMMAND."
 (projectile-register-project-type 'scons '("SConstruct") "scons" "scons test")
 (projectile-register-project-type 'maven '("pom.xml") "mvn clean install" "mvn test")
 (projectile-register-project-type 'gradle '("build.gradle") "gradle build" "gradle test")
+(projectile-register-project-type 'gradlew '("gradlew") "./gradlew build" "./gradlew test")
 (projectile-register-project-type 'grails '("application.properties" "grails-app") "grails package" "grails test-app")
 (projectile-register-project-type 'lein-test '("project.clj") "lein compile" "lein test")
 (projectile-register-project-type 'lein-midje '("project.clj" ".midje.clj") "lein compile" "lein midje")
@@ -1709,7 +1711,7 @@ It assumes the test/ folder is at the same level as src/."
    ((member project-type '(rails-test ruby-test lein-test go)) "_test")
    ((member project-type '(scons)) "test")
    ((member project-type '(maven symfony)) "Test")
-   ((member project-type '(gradle grails)) "Spec")))
+   ((member project-type '(gradle gradlew grails)) "Spec")))
 
 (defun projectile-dirname-matching-count (a b)
   "Count matching dirnames ascending file paths."

--- a/projectile.el
+++ b/projectile.el
@@ -1530,15 +1530,15 @@ With a prefix ARG invalidates the cache first."
   "A hash table holding all project types that are known to Projectile.")
 
 (defun projectile-register-project-type
-    (project-type marker-files &optional compile-command test-command run-command)
+    (project-type marker-files &optional compile-cmd test-cmd run-cmd)
   "Register a project type with projectile.
 
 A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
-a COMPILE-COMMAND, a TEST-COMMAND, and a RUN-COMMAND."
+a COMPILE-CMD, a TEST-CMD, and a RUN-CMD."
   (puthash project-type (list 'marker-files marker-files
-                              'compile-command compile-command
-                              'test-command test-command
-                              'run-command run-command)
+                              'compile-command compile-cmd
+                              'test-command test-cmd
+                              'run-command run-cmd)
            projectile-project-types))
 
 (projectile-register-project-type 'rails-rspec '("Gemfile" "app" "lib" "db" "config" "spec") "bundle exec rails server" "bundle exec rspec")

--- a/projectile.el
+++ b/projectile.el
@@ -44,6 +44,7 @@
 (require 'grep)
 
 (eval-when-compile
+  (defvar ag-ignore-list)
   (defvar ggtags-completion-table)
   (defvar tags-completion-table))
 

--- a/projectile.el
+++ b/projectile.el
@@ -338,6 +338,17 @@ Any function that does not take arguments will do."
   "If true, use `vc-git-grep' in git projects."
   :group 'projectile
   :type 'boolean)
+
+(defcustom projectile-test-prefix-function 'projectile-test-prefix
+  "Function to find test files prefix based on PROJECT-TYPE."
+  :group 'projectile
+  :type 'function)
+
+(defcustom projectile-test-suffix-function 'projectile-test-suffix
+  "Function to find test files suffix based on PROJECT-TYPE."
+  :group 'projectile
+  :type 'function)
+
 
 ;;; Idle Timer
 (defvar projectile-idle-timer nil
@@ -1682,16 +1693,6 @@ It assumes the test/ folder is at the same level as src/."
   (interactive)
   (find-file
    (projectile-find-implementation-or-test (buffer-file-name))))
-
-(defcustom projectile-test-prefix-function 'projectile-test-prefix
-  "Function to find test files prefix based on PROJECT-TYPE."
-  :group 'projectile
-  :type 'function)
-
-(defcustom projectile-test-suffix-function 'projectile-test-suffix
-  "Function to find test files suffix based on PROJECT-TYPE."
-  :group 'projectile
-  :type 'function)
 
 (defun projectile-test-affix (project-type)
   "Find test files affix based on PROJECT-TYPE."

--- a/projectile.el
+++ b/projectile.el
@@ -1557,6 +1557,7 @@ a COMPILE-CMD, a TEST-CMD, and a RUN-CMD."
 (projectile-register-project-type 'grails '("application.properties" "grails-app") "grails package" "grails test-app")
 (projectile-register-project-type 'lein-test '("project.clj") "lein compile" "lein test")
 (projectile-register-project-type 'lein-midje '("project.clj" ".midje.clj") "lein compile" "lein midje")
+(projectile-register-project-type 'boot-clj '("build.boot") "boot aot" "boot test")
 (projectile-register-project-type 'rebar '("rebar") "rebar" "rebar eunit")
 (projectile-register-project-type 'sbt '("build.sbt") "sbt compile" "sbt test")
 (projectile-register-project-type 'make '("Makefile") "make" "make test")
@@ -1715,7 +1716,7 @@ It assumes the test/ folder is at the same level as src/."
   "Find default test files suffix based on PROJECT-TYPE."
   (cond
    ((member project-type '(rails-rspec ruby-rspec)) "_spec")
-   ((member project-type '(rails-test ruby-test lein-test go)) "_test")
+   ((member project-type '(rails-test ruby-test lein-test boot-clj go)) "_test")
    ((member project-type '(scons)) "test")
    ((member project-type '(maven symfony)) "Test")
    ((member project-type '(gradle gradlew grails)) "Spec")))


### PR DESCRIPTION
This won't work on Windows due to use of `./`. Presumably we could condition on the OS and drop the `./` to run the `.bat` file, but I have no easy way to test.