### PR TITLE
Add build.boot to projectile-project-root-files

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -210,6 +210,7 @@ Two example filter functions are shipped by default -
 (defcustom projectile-project-root-files
   '("rebar.config"       ; Rebar project file
     "project.clj"        ; Leiningen project file
+    "build.boot"         ; Boot-clj project file
     "SConstruct"         ; Scons project file
     "pom.xml"            ; Maven project file
     "build.sbt"          ; SBT project file


### PR DESCRIPTION
In my previous pull request I forgot to include build.boot in projectile-project-root files so I am fixing this omission.

Let me know if I should update CHANGELOG with this change.