### PR TITLE
Add check for byte-compiler warnings in make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,17 @@ elpa:
 .PHONY: build
 build : elpa $(OBJECTS)
 
+.PHONY: byte-compile-strict
+byte-compile-strict : elpa
+	$(CASK) exec $(EMACS) --no-site-file --no-site-lisp --batch \
+		--directory "."                          \
+		$(EMACSFLAGS)                            \
+		--eval "(progn                           \
+			(setq byte-compile-error-on-warn t)  \
+			(batch-byte-compile))" projectile.el helm-projectile.el
+
 .PHONY: test
-test : build
+test : byte-compile-strict
 	$(CASK) exec $(EMACS) --no-site-file --no-site-lisp --batch \
 		$(EMACSFLAGS) \
 		-l test/run-tests


### PR DESCRIPTION
Add a new byte-compile-strict command to Makefile which byte-compiles
`projectile.el` and `helm-projectile.el` with
`byte-compile-error-on-warn` true.

The new command is currently a dependency of `make test`. This should
ensure that contributors notice the warnings before submitting a pull
request. Alternatively we could have it as a separate make command and
run it separately on Travis if that's preferable, but this might result
in most people not seeing the warnings until the Travis build fails.

I didn't add automatic byte compilation of persp-projectile.el because it
requires a package which isn't included.

I had to use `--directory "."` so that emacs finds `projectile.el` while
compiling `helm-projectile.el`. I don't know why it doesn't
automatically have the path set correctly...