### PR TITLE
Improve projectile ibuffer performance.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2440,9 +2440,8 @@ overwriting each other's changes."
   "Show Ibuffer with all buffers in the current project."
   (:reader (read-directory-name "Project root: " (ignore-errors (projectile-project-root)))
            :description nil)
-  (with-current-buffer buf
-    (equal (file-name-as-directory (expand-file-name qualifier))
-           (ignore-errors (projectile-project-root)))))
+  (string-prefix-p (file-name-as-directory (expand-file-name qualifier))
+                   (expand-file-name (buffer-local-value 'default-directory buf))))
 
 (defun projectile-ibuffer-by-project (project-root)
   "Open an IBuffer window showing all buffers in PROJECT-ROOT."


### PR DESCRIPTION
`with-current-buffer' is slow. Find all project buffers by only looking at their
`default-directory' value.

In my experience, with 200~ buffers the original projectile-ibuffer takes about 2 secs to dispaly the buffer list, which is really too slow.