### PR TITLE
Prefer Haskell stack projects over cabal projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add [boot-clj](https://github.com/boot-clj/boot) project type.
 * Add support for projects using gradlew script.
+* Prefer Haskell stack projects over cabal projects.
 
 ## 0.13.0 (10/21/2015)
 

--- a/projectile.el
+++ b/projectile.el
@@ -1565,10 +1565,15 @@ a COMPILE-CMD, a TEST-CMD, and a RUN-CMD."
 (projectile-register-project-type 'grunt '("Gruntfile.js") "grunt" "grunt test")
 (projectile-register-project-type 'gulp '("gulpfile.js") "gulp" "gulp test")
 (projectile-register-project-type 'haskell-stack '("stack.yaml") "stack build" "stack build --test")
-(projectile-register-project-type 'haskell-cabal '("*.cabal") "cabal build" "cabal test")
+(projectile-register-project-type 'haskell-cabal #'projectile-cabal "cabal build" "cabal test")
 (projectile-register-project-type 'rust-cargo '("Cargo.toml") "cargo build" "cargo test")
 (projectile-register-project-type 'r '("DESCRIPTION") "R CMD INSTALL ." (concat "R CMD check -o " temporary-file-directory " ."))
 (projectile-register-project-type 'go #'projectile-go "go build ./..." "go test ./...")
+
+(defun projectile-cabal ()
+  "Check if a project contains *.cabal files but no stack.yaml file."
+  (and (projectile-verify-file "*.cabal")
+       (not (projectile-verify-file "stack.yaml"))))
 
 (defun projectile-go ()
   "Check if a project contains Go source files."


### PR DESCRIPTION
Haskell stack projects have both `*.cabal` files and a `stack.yaml` file.
Where as cabal projects only have `*.cabal` files.

If there is a `stack.yaml` file, users most certainly prefer to use stack
to build as it is the best way to get consistent builds for Haskell
projects.

Closes #884