### PR TITLE
907 Added elisp function call for run, test, compile commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add [boot-clj](https://github.com/boot-clj/boot) project type.
 * Add support for projects using gradlew script.
 * Prefer Haskell stack projects over cabal projects.
+* Add ability to use elisp functions for test, compile and run commands.
 
 ## 0.13.0 (10/21/2015)
 

--- a/README.md
+++ b/README.md
@@ -536,6 +536,11 @@ There are a few variables that are intended to be customized via `.dir-locals.el
 
 They're all set to `nil` by default, but by setting them you'll override the
 default commands per each supported project type.
+These variables can be strings to run external commands or Emacs Lisp functions:
+
+```
+(setq projectile-test-cmd #'custom-test-function)
+```
 
 
 ### Helm Integration

--- a/projectile.el
+++ b/projectile.el
@@ -2182,6 +2182,19 @@ Should be set via .dir-locals.el.")
                (file-name-as-directory projectile-project-compilation-dir)))
     (projectile-project-root)))
 
+(defun projectile-maybe-read-command (arg default-cmd prompt)
+  "Prompt user for command unless default-cmd is elisp function"
+  (if (and (or (stringp default-cmd) (null default-cmd))
+           (or compilation-read-command arg))
+      (projectile-read-command prompt default-cmd)
+    default-cmd))
+
+(defun projectile-run-compilation (cmd)
+  "Run external or elisp compilation command"
+  (if (functionp cmd)
+      (funcall cmd)
+    (compilation-start cmd)))
+
 (defun projectile-compile-project (arg &optional dir)
   "Run project compilation command.
 
@@ -2192,16 +2205,13 @@ with a prefix ARG."
   (let* ((project-root (projectile-project-root))
          (default-directory (or dir (projectile-compilation-dir)))
          (default-cmd (projectile-compilation-command default-directory))
-         (compilation-cmd (if (or compilation-read-command arg)
-                              (projectile-read-command "Compile command: "
-                                                       default-cmd)
-                            default-cmd)))
+         (compilation-cmd (projectile-maybe-read-command arg default-cmd "Compile command: ")))
     (puthash default-directory compilation-cmd projectile-compilation-cmd-map)
     (save-some-buffers (not compilation-ask-about-save)
                        (lambda ()
                          (projectile-project-buffer-p (current-buffer)
                                                       project-root)))
-    (compilation-start compilation-cmd)))
+    (projectile-run-compilation compilation-cmd)))
 
 (defadvice compilation-find-file (around projectile-compilation-find-file)
   "Try to find a buffer for FILENAME, if we cannot find it,
@@ -2233,13 +2243,10 @@ with a prefix ARG."
   (interactive "P")
   (let* ((project-root (projectile-project-root))
          (default-cmd (projectile-test-command project-root))
-         (test-cmd (if (or compilation-read-command arg)
-                       (projectile-read-command "Test command: "
-                                                default-cmd)
-                     default-cmd))
+         (test-cmd (projectile-maybe-read-command arg default-cmd "Test command: "))
          (default-directory project-root))
     (puthash project-root test-cmd projectile-test-cmd-map)
-    (compilation-start test-cmd)))
+    (projectile-run-compilation test-cmd)))
 
 (defun projectile-run-project (arg)
   "Run project run command.
@@ -2250,13 +2257,10 @@ with a prefix ARG."
   (interactive "P")
   (let* ((project-root (projectile-project-root))
          (default-cmd (projectile-run-command project-root))
-         (run-cmd (if (or compilation-read-command arg)
-                      (projectile-read-command "Run command: "
-                                               default-cmd)
-                    default-cmd))
+         (run-cmd (projectile-maybe-read-command arg default-cmd "Run command: "))
          (default-directory project-root))
     (puthash project-root run-cmd projectile-run-cmd-map)
-    (compilation-start run-cmd)))
+    (projectile-run-compilation run-cmd)))
 
 (defun projectile-relevant-known-projects ()
   "Return a list of known projects except the current one (if present)."


### PR DESCRIPTION
I've added check for string type for command read, cause in other case we should somehow detect if user's input is string compilation command or elisp function, so user input will only be requested if project's compilation command is a string.