### PR TITLE
Announce cache is empty before blocking.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -563,7 +563,6 @@ to invalidate."
   "Cache PROJECTs FILES.
 The cache is created both in memory and on the hard drive."
   (when projectile-enable-caching
-    (message "Empty cache. Projectile is initializing cache...")
     (puthash project files projectile-projects-cache)
     (projectile-serialize-cache)))
 
@@ -1185,6 +1184,8 @@ https://github.com/abo-abo/swiper")))
                     (gethash (projectile-project-root) projectile-projects-cache))))
     ;; nothing is cached
     (unless files
+      (when projectile-enable-caching
+        (message "Empty cache. Projectile is initializing cache..."))
       (setq files (-mapcat #'projectile-dir-files
                            (projectile-get-project-directories)))
       ;; cache the resulting list of files


### PR DESCRIPTION
It can take a long time before
```elisp
    (-mapcat #'projectile-dir-files
             (projectile-get-project-directories))
```
completes. This makes it more evident what's happening.

Fixes #899