### PR TITLE
Enable custom project names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add ability to use elisp functions for test, compile and run commands.
 * Consider `TAGS` and `GTAGS` root markers.
 * Add relation between the `.h`, `.cxx`, `.ixx` and `.hxx` files in `projectile-other-file-alist`.
+* Add support to specify project name either via `.dir-locals.el` or by providing a customized `projectile-project-name-function'.
 
 ## 0.13.0 (10/21/2015)
 


### PR DESCRIPTION
This enables the user to customize the project name based on project-root. This is helpful in situations where the project base dir is not descriptive enough.

As an example, I use it like this:

```elisp
     (defun fvaresi/projectile-custom-project-name (project-root)
        (cond
         ((string-match "/Plugins/\\([^/]+\\)/\\(?:branches\\|tags\\)\\(?:.*\\)/\\([^/]+\\)" project-root)
          (let* ((product-name (match-string 1 project-root))
                 (branch-name (match-string 2 project-root)))
            (concat product-name "/" branch-name))) ;

         ((string-match "/Plugins/\\([^/]+\\)/trunk" project-root)
                (let* ((product-name (match-string 1 project-root)))
                  (concat product-name "/trunk")))
   
         ;; do the default
         (t
          (projectile-default-project-name project-root))))

      (setq projectile-project-name-function 'fvaresi/projectile-custom-project-name)
```