### PR TITLE
Allow setting projectile root as a file local variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add [boot-clj](https://github.com/boot-clj/boot) project type.
 * Add support for projects using gradlew script.
 * Prefer Haskell stack projects over cabal projects.
+* Add file local variable projectile-custom-root, which allows overriding the project root on a per-file basis. This allows navigating a different project from, say, an org file in a another git repository.
 
 ## 0.13.0 (10/21/2015)
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,14 @@ To customize project root files settings:
 M-x customize-group RET projectile RET
 ```
 
+#### File-local project root definitions
+
+If you want to override the projectile project root for a specific
+file, you can set the file-local variable `projectile-custom-root`. This
+can be useful if you have files within one project that are related to
+a different project (for instance, Org files in one git repo that
+correspond to other projects).
+
 ### Storing project settings
 
 From project to project some things may differ even in same language -

--- a/projectile.el
+++ b/projectile.el
@@ -260,7 +260,8 @@ containing a root file."
   :type '(repeat string))
 
 (defcustom projectile-project-root-files-functions
-  '(projectile-root-bottom-up
+  '(projectile-root-file-local
+    projectile-root-bottom-up
     projectile-root-top-down
     projectile-root-top-down-recurring)
   "A list of functions for finding project roots."
@@ -677,6 +678,13 @@ which we're looking."
                                      (directory-file-name file))))
              (setq file nil))))
     (and root (expand-file-name (file-name-as-directory root)))))
+
+(defvar-local projectile-custom-root nil
+  "Defines a custom Projectile project root.
+   This is intended to be used as a file local variable.")
+
+(defun projectile-root-file-local (dir)
+  projectile-custom-root)
 
 (defun projectile-root-top-down (dir &optional list)
   "Identify a project root in DIR by top-down search for files in LIST.


### PR DESCRIPTION
This is useful, for example, if you keep your OrgMode files in one git
repo but associate them with other projects in other directories.

This is a resubmission of #398 addressing Bozhidar's comments. Any feedback is appreciated, again!