### PR TITLE
[Fix #871] Stop advice from overriding original function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 * Prefer ag's internal .gitignore parsing.
 * Always use external find-tag implementations.
 
+### Bugs fixed
+
+* [#871](https://github.com/bbatsov/projectile/issues/871): Stop advice for `compilation-find-file` to override other advices.
+
 ## 0.13.0 (10/21/2015)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -2238,21 +2238,22 @@ with a prefix ARG."
   "Try to find a buffer for FILENAME, if we cannot find it,
 fallback to the original function."
   (let ((filename (ad-get-arg 1)))
-    (setf ad-return-value
-          (or
-           (if (file-exists-p (expand-file-name filename))
-               (find-file-noselect filename))
-           ;; Try to find the filename using projectile
-           (and (projectile-project-p)
-                (let ((root (projectile-project-root))
-                      (dirs (cons "" (projectile-current-project-dirs))))
-                  (-when-let (full-filename (->> dirs
-                                                 (--map (expand-file-name filename (expand-file-name it root)))
-                                                 (-filter #'file-exists-p)
-                                                 (-first-item)))
-                    (find-file-noselect full-filename))))
-           ;; Fall back to the old function `compilation-find-file'
-           ad-do-it))))
+    (ad-set-arg 1
+                (or
+                 (if (file-exists-p (expand-file-name filename))
+                     filename)
+                 ;; Try to find the filename using projectile
+                 (and (projectile-project-p)
+                      (let ((root (projectile-project-root))
+                            (dirs (cons "" (projectile-current-project-dirs))))
+                        (-when-let (full-filename (->> dirs
+                                                       (--map (expand-file-name filename (expand-file-name it root)))
+                                                       (-filter #'file-exists-p)
+                                                       (-first-item)))
+                          full-filename)))
+                 ;; Fall back to the old argument
+                 filename))
+    ad-do-it))
 
 ;; TODO - factor this duplication out
 (defun projectile-test-project (arg)


### PR DESCRIPTION
Original advice was overriding the return from `compilation-find-file` with the result from other functions. This was causing other advices for `compilation-find-file` to be ignored.
I changed the advice to set the argument to the original function with the calculated value, thus having the desired effect, but now respecting the other advices.