### PR TITLE
Edit .dir-locals.el file of a project.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add relation between the `.h`, `.cxx`, `.ixx` and `.hxx` files in `projectile-other-file-alist`.
 * Add support to specify project name either via `.dir-locals.el` or by providing a customized `projectile-project-name-function'.
 * Add a command to switch between open projects (`projectile-switch-open-project`).
+* Add a command to edit the .dir-locals.el file of the project (`projectile-edit-dir-locals`).
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Keybinding         | Description
 <kbd>C-c p k</kbd> | Kills all project buffers.
 <kbd>C-c p D</kbd> | Opens the root of the project in `dired`.
 <kbd>C-c p e</kbd> | Shows a list of recently visited project files.
+<kbd>C-c p E</kbd> | Opens the `.dirs-local.el` file of the project.
 <kbd>C-c p s s</kbd> | Runs `ag` on the project. Requires the presence of `ag.el`.
 <kbd>C-c p !</kbd> | Runs `shell-command` in the root directory of the project.
 <kbd>C-c p &</kbd> | Runs `async-shell-command` in the root directory of the project.
@@ -497,6 +498,9 @@ The top-level alist member referenced with the key `nil` applies to the
 entire project. A key with the name `eval` will evaluate its
 arguments. In the example above, this is used to create a function. It
 could also be used to e.g. add such a function to a key map.
+
+You can also quickly visit the the `.dir-locals.el` file with <kbd>C-c
+p E</kbd> (<kbd>M-x projectile-edit-dir-locals RET</kbd>).
 
 Here are a few examples of how to use this feature with Projectile.
 

--- a/projectile.el
+++ b/projectile.el
@@ -2640,6 +2640,41 @@ is chosen."
 
 (projectile-commander-bindings)
 
+(defun projectile-read-variable ()
+  "Prompt for a variable and return its name."
+  (completing-read "Variable: "
+                   obarray
+                   '(lambda (v)
+                      (and (boundp v) (not (keywordp v))))
+                   t))
+
+(define-skeleton projectile-skel-variable-cons
+  "Insert a variable-name and a value in a cons-cell."
+  "Value: "
+  "("
+  (projectile-read-variable)
+  " . "
+  str
+  ")")
+
+(define-skeleton projectile-skel-dir-locals
+  "Insert a .dir-locals.el template."
+  nil
+  "((nil . (("
+  ("" '(projectile-skel-variable-cons) \n)
+  resume:
+  "))))")
+
+(defun projectile-edit-dir-locals ()
+  "Edit or create a .dir-locals.el file of the project."
+  (interactive)
+  (let ((file (expand-file-name ".dir-locals.el" (projectile-project-root))))
+    (find-file file)
+    (when (not (file-exists-p file))
+      (unwind-protect
+          (projectile-skel-dir-locals)
+        (save-buffer)))))
+
 ;;; Minor mode
 (defvar projectile-command-map
   (let ((map (make-sparse-keymap)))
@@ -2658,6 +2693,7 @@ is chosen."
     (define-key map (kbd "d") #'projectile-find-dir)
     (define-key map (kbd "D") #'projectile-dired)
     (define-key map (kbd "e") #'projectile-recentf)
+    (define-key map (kbd "E") #'projectile-edit-dir-locals)
     (define-key map (kbd "f") #'projectile-find-file)
     (define-key map (kbd "g") #'projectile-find-file-dwim)
     (define-key map (kbd "F") #'projectile-find-file-in-known-projects)
@@ -2704,6 +2740,7 @@ is chosen."
    ["Jump between implementation file and test file" projectile-toggle-between-implementation-and-test]
    ["Kill project buffers" projectile-kill-buffers]
    ["Recent files" projectile-recentf]
+   ["Edit .dir-locals.el" projectile-edit-dir-locals]
    "--"
    ["Open project in dired" projectile-dired]
    ["Switch to project" projectile-switch-project]


### PR DESCRIPTION
Add a command `projectile-edit-dir-locals' to quickly edit or create a
.dir-locals.el file for the project.