### PR TITLE
backport emacs 25 etags-tags-completion-table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Bugs fixed
 
 * [#871](https://github.com/bbatsov/projectile/issues/871): Stop advice for `compilation-find-file` to override other advices.
+* [#557](https://github.com/bbatsov/projectile/issues/557): stack overflow in `projectile-find-tag'.
 
 ## 0.13.0 (10/21/2015)
 

--- a/projectile.el
+++ b/projectile.el
@@ -80,6 +80,35 @@ attention to case differences."
         (and (>= start-pos 0)
              (eq t (compare-strings suffix nil nil
                                     string start-pos nil ignore-case))))))
+
+  ;; Improved (no more stack overflows) in Emacs 24.5
+  (eval-after-load 'etags
+    '(when (< emacs-major-version 25)
+       (defvar etags--table-line-limit 500)
+       (defun etags-tags-completion-table ()
+         (let (table
+               (progress-reporter
+                (make-progress-reporter
+                 (format "Making tags completion table for %s..." buffer-file-name)
+                 (point-min) (point-max))))
+           (save-excursion
+             (goto-char (point-min))
+             (while (not (eobp))
+               (if (not (re-search-forward
+                         "[\f\t\n\r()=,; ]?\177\\\(?:\\([^\n\001]+\\)\001\\)?"
+                         (+ (point) etags--table-line-limit) t))
+                   (forward-line 1)
+                 (push (prog1 (if (match-beginning 1)
+                                  (buffer-substring (match-beginning 1) (match-end 1))
+                                (goto-char (match-beginning 0))
+                                (skip-chars-backward "^\f\t\n\r()=,; ")
+                                (prog1
+                                    (buffer-substring (point) (match-beginning 0))
+                                  (goto-char (match-end 0))))
+                         (progress-reporter-update progress-reporter (point)))
+                       table))))
+           table))))
+
   )
 
 (defun projectile-trim-string (string)


### PR DESCRIPTION
Workaround for https://github.com/bbatsov/projectile/issues/557 (Emacs 20703)

It now opens up the way for #947