### PR TITLE
Make `projectile-find-matching-{test/file}` respect `projectile-test-*-function`

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1810,8 +1810,8 @@ It assumes the test/ folder is at the same level as src/."
 (defun projectile-find-matching-test (file)
   "Compute the name of the test matching FILE."
   (let* ((basename (file-name-nondirectory (file-name-sans-extension file)))
-         (test-prefix (projectile-test-prefix (projectile-project-type)))
-         (test-suffix (projectile-test-suffix (projectile-project-type)))
+         (test-prefix (funcall projectile-test-prefix-function (projectile-project-type)))
+         (test-suffix (funcall projectile-test-suffix-function (projectile-project-type)))
          (candidates
           (-filter (lambda (current-file)
                      (let ((name (file-name-nondirectory
@@ -1832,8 +1832,8 @@ It assumes the test/ folder is at the same level as src/."
 (defun projectile-find-matching-file (test-file)
   "Compute the name of a file matching TEST-FILE."
   (let* ((basename (file-name-nondirectory (file-name-sans-extension test-file)))
-         (test-prefix (projectile-test-prefix (projectile-project-type)))
-         (test-suffix (projectile-test-suffix (projectile-project-type)))
+         (test-prefix (funcall projectile-test-prefix-function (projectile-project-type)))
+         (test-suffix (funcall projectile-test-suffix-function (projectile-project-type)))
          (candidates
           (-filter (lambda (current-file)
                      (let ((name (file-name-nondirectory


### PR DESCRIPTION
These two functions did not use the value of `projectile-test-prefix/suffix-function`. This changes `projectile-find-matching-test/file` to call the function stored in `projectile-test-prefix/suffix-function`, which default to `projectile-test-prefix/suffix`, respectively.

I'd like to add tests for this as well but don't have time right now, but I might be able to get around to it this week or next.