### PR TITLE
 Error while toggling between test and source file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * [#871](https://github.com/bbatsov/projectile/issues/871): Stop advice for `compilation-find-file` to override other advices.
 * [#557](https://github.com/bbatsov/projectile/issues/557): stack overflow in `projectile-find-tag'.
+* [#955](https://github.com/bbatsov/projectile/issues/955): Error while toggling between test and source file.
 
 ## 0.13.0 (10/21/2015)
 

--- a/projectile.el
+++ b/projectile.el
@@ -1795,8 +1795,8 @@ It assumes the test/ folder is at the same level as src/."
 
 (defun projectile-dirname-matching-count (a b)
   "Count matching dirnames ascending file paths."
-  (setq a (reverse (split-string (file-name-directory a) "/" t))
-        b (reverse (split-string (file-name-directory b) "/" t)))
+  (setq a (reverse (split-string (or (file-name-directory a) "") "/" t))
+        b (reverse (split-string (or (file-name-directory b) "") "/" t)))
   (let ((common 0))
     (while (and a b (string-equal (pop a) (pop b)))
       (setq common (1+ common)))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -596,7 +596,10 @@
                                                     "src/food/cat.c")))
   (should (equal 0
                  (projectile-dirname-matching-count "src/weed/sea.c"
-                                                    "src/food/sea.c"))))
+                                                    "src/food/sea.c")))
+  (should (equal 0
+                 (projectile-dirname-matching-count "test/demo-test.el"
+                                                    "demo.el"))))
 
 (ert-deftest projectile-test-find-matching-test ()
   (projectile-test-with-sandbox


### PR DESCRIPTION
As described in https://github.com/bbatsov/projectile/issues/955 I rand into difficulties when I was switching from the test file to the source file using `C-c p t`. 

When a matching count is calculated for files in the project root, the parameter `b` in the `projectile-dirname-matching-count` function will not have directory part, just the relative filename. The `file-name-directory` returns nil what the `split-string` cannot interpret, leading to the error "Wrong type argument: stringp, nil". Please see the added test case.

Solution: defaulting to empty string in this case solves the problem. I have added this safety check to the parameter `a` just in case although it seems always to be an absolute path at the moment.