### PR TITLE
Make projectile work with fossil ls

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -868,7 +868,7 @@ Files are returned as relative paths to the project root."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-fossil-command "fossil ls"
+(defcustom projectile-fossil-command "fossil ls | tr '\\n' '\\0'"
   "Command used by projectile to get the files in a fossil project."
   :group 'projectile
   :type 'string)


### PR DESCRIPTION
Hi,

projectile-find-other-file did not work with fossil. After investigating, I figured out that `fossil ls` gives a file list separated by `\n`, but projectile expects them separated by `\0`.

This changes the default projectile-fossil-command to give a zero-separated file list, just like the git and svn commands.

Unfortunately, `fossil ls` doesn't have a `-0` switch like `hg` and `bzr`.