### PR TITLE
Mention projectile-remove-known-project.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -475,7 +475,10 @@ The saved data can be restored with `projectile-unserialize'."
 
 (defvar projectile-known-projects nil
   "List of locations where we have previously seen projects.
-The list of projects is ordered by the time they have been accessed.")
+The list of projects is ordered by the time they have been accessed.
+
+See also `projectile-remove-known-project',
+`projectile-cleanup-known-projects' and `projectile-clear-known-projects'.")
 
 (defvar projectile-known-projects-on-file nil
   "List of known projects reference point.


### PR DESCRIPTION
This handy function isn't mentioned anywhere, so add it to the docstring
to aid discoverability.

(Following on from #950)