### PR TITLE
Commit allows turning gtags support off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 ### Changes
 
 * Prefer ag's internal .gitignore parsing.
-* Always use external find-tag implementations.
+* Added variable to control use of external find-tag implementations.
 * Specify `--with-keep.source` argument when installing R projects
 
 ### Bugs fixed

--- a/projectile.el
+++ b/projectile.el
@@ -218,6 +218,26 @@ Otherwise consider the current directory the project root."
   :group 'projectile
   :type 'string)
 
+(defcustom projectile-tags-backend 'auto
+  "The tag backend that Projectile should use.
+
+If set to 'auto', `projectile-find-tag' will automatically choose
+which backend to use. Preference order is ggtags -> etags-select
+-> find-tag. Variable can also be set to specify which backend to
+use. If selected backend is unavailable, fall back to `find-tag'.
+
+If this variable is set to 'auto' and ggtags is available, or if
+set to 'ggtags', then ggtags will be used for
+`projectile-regenerate-tags'. For all other settings
+`projectile-tags-command' will be used."
+  :group 'projectile
+  :type '(radio
+          (const :tag "auto" auto)
+          (const :tag "ggtags" ggtags)
+          (const :tag "etags" etags-select)
+          (const :tag "standard" find-tag))
+  :package-version '(projectile . "0.14.0"))
+
 (defcustom projectile-sort-order 'default
   "The sort order used for a project's files."
   :group 'projectile
@@ -2153,7 +2173,8 @@ regular expression."
 (defun projectile-regenerate-tags ()
   "Regenerate the project's [e|g]tags."
   (interactive)
-  (if (boundp 'ggtags-mode)
+  (if (and (boundp 'ggtags-mode)
+       (memq projectile-tags-backend '(auto ggtags)))
       (progn
         (let* ((ggtags-project-root (projectile-project-root))
                (default-directory ggtags-project-root))
@@ -2182,19 +2203,31 @@ regular expression."
         (with-demoted-errors "Error loading tags-file: %s"
           (visit-tags-table tags-file t))))))
 
+(defun projectile-determine-find-tag-fn ()
+  "Determine which function to use for a call to `projectile-find-tag'."
+  (cond
+    ((eq projectile-tags-backend 'auto)
+      (cond
+        ((fboundp 'ggtags-find-tag-dwim)
+          'ggtags-find-tag-dwim)
+        ((fboundp 'etags-select-find-tag)
+          'etags-select-find-tag)
+        (t 'find-tag)))
+    ((eq projectile-tags-backend 'ggtags)
+      (if (fboundp 'ggtags-find-tag-dwim)
+        'ggtags-find-tag-dwim 'find-tag))
+    ((eq projectile-tags-backend 'etags-select)
+      (if (fboundp 'etags-select-find-tag)
+        'etags-select-find-tag 'find-tag))
+    (t 'find-tag)))
+
 ;;;###autoload
 (defun projectile-find-tag ()
   "Find tag in project."
   (interactive)
   (projectile-visit-project-tags-table)
   ;; Auto-discover the user's preference for tags
-  (let ((find-tag-fn (cond
-                      ((fboundp 'ggtags-find-tag-dwim)
-                       'ggtags-find-tag-dwim)
-                      ((fboundp 'etags-select-find-tag)
-                       'etags-select-find-tag)
-                      (t
-                       'find-tag))))
+  (let ((find-tag-fn (projectile-determine-find-tag-fn)))
     (call-interactively find-tag-fn)))
 
 (defmacro projectile-with-default-dir (dir &rest body)


### PR DESCRIPTION
GNU global/ggtags-mode support was introduced in #267. This works well, but doesn't give the user the ability to control whether to use ggtags-mode or not. I imagine use cases where users would want to have the ability to control which backend to use for `projectile-regenerate-tags` and `projectile-find-tag` on a project-by-project basis.