### PR TITLE
Let user override ignored files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * New command `projectile-run-shell` (<kbd>C-c p x s</kbd>).
 * New command `projectile-run-eshell` (<kbd>C-c p x e</kbd>).
 * New command `projectile-run-term` (<kbd>C-c p x t</kbd>).
+* Let user unignore files in `.projectile` with the ! prefix.
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -465,6 +465,19 @@ If both directories to keep and ignore are specified, the directories
 to keep first apply, restricting what files are considered. The paths
 and patterns to ignore are then applied to that set.
 
+Finally, you can override ignored files. This is especially useful
+when some files ignored by your VCS should be considered as part of
+your project by projectile:
+
+```
+!/src/foo
+!*.yml
+```
+
+When a path is overridden, its contents are still subject to ignore
+patterns. To override those files as well, specify their full path
+with a bang prefix.
+
 ### Customizing project root files
 
 You can set the values of `projectile-project-root-files`,


### PR DESCRIPTION
This adds a modifier (bang symbol !) for the `.projectile` file to override ignored files and ensure they are part of the project.

It works with paths and patterns:

```lisp
!/src/foo
!*.yml
```

Closes #892 