### PR TITLE
Associate .cc and .hpp files for C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add ability to use elisp functions for test, compile and run commands.
 * Consider `TAGS` and `GTAGS` root markers.
 * Add relation between the `.h`, `.cxx`, `.ixx` and `.hxx` files in `projectile-other-file-alist`.
+* Add relation between the `.hpp` and `.cc` files in `projectile-other-file-alist`.
 * Add support to specify project name either via `.dir-locals.el` or by providing a customized `projectile-project-name-function'.
 * Add a command to switch between open projects (`projectile-switch-open-project`).
 * Add a command to edit the .dir-locals.el file of the project (`projectile-edit-dir-locals`).

--- a/projectile.el
+++ b/projectile.el
@@ -1315,7 +1315,7 @@ https://github.com/abo-abo/swiper")))
   '(;; handle C/C++ extensions
     ("cpp" . ("h" "hpp" "ipp"))
     ("ipp" . ("h" "hpp" "cpp"))
-    ("hpp" . ("h" "ipp" "cpp"))
+    ("hpp" . ("h" "ipp" "cpp" "cc"))
     ("cxx" . ("h" "hxx" "ixx"))
     ("ixx" . ("h" "hxx" "cxx"))
     ("hxx" . ("h" "ixx" "cxx"))
@@ -1323,7 +1323,7 @@ https://github.com/abo-abo/swiper")))
     ("m" . ("h"))
     ("mm" . ("h"))
     ("h" . ("c" "cpp" "ipp" "hpp" "cxx" "ixx" "hxx" "m" "mm"))
-    ("cc" . ("hh"))
+    ("cc" . ("hh" "hpp"))
     ("hh" . ("cc"))
 
     ;; vertex shader and fragment shader extensions in glsl


### PR DESCRIPTION
Some C++ projects use the .hpp suffix for headers and .cc for source
files, and `projectile-find-other-file` function previously would not
work in this case. This commit updates the alist of associated file
extensions to link .cc and .hpp files in both directions.