### PR TITLE
RFC: Use `find` for listing files in subversion repositories, for a massive speedup

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -890,7 +890,7 @@ Files are returned as relative paths to the project root."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-svn-command "svn list -R . | grep -v '$/' | tr '\\n' '\\0'"
+(defcustom projectile-svn-command "find . -type f | grep -v '/.svn/' | tr '\\n' '\\0'"
   "Command used by projectile to get the files in a svn project."
   :group 'projectile
   :type 'string)


### PR DESCRIPTION
`svn list` queries the remote server to find out what files are
included. This is extremely slow for repositories with thousands of
files. It also requires a network connection.

For example, given a checkout of the LLVM source code:

    $ svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm
    ... lots of files
     U   llvm
    Checked out revision 262801.
    $ cd llvm

Using `svn` takes almost two minutes, whereas `find` takes under a
second:

    $ time svn list -R . > files.txt
    svn list -R . > files.txt  0.79s user 0.13s system 0% cpu 1:50.73 total

    $ time find . -type f > find_files.txt
    find . -type f > find_files.txt  0.02s user 0.02s system 98% cpu 0.040 total

Let me know what you think. I appreciate it's less elegant (it doesn't respect svn ignores) but the speedup is massive. Even with caching, waiting 2 minutes for projectile to build an index is painful.