### PR TITLE
`etags-tags-completion-table` should return an obarray on Emacs 24.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -93,7 +93,7 @@ attention to case differences."
     '(when (< emacs-major-version 25)
        (defvar etags--table-line-limit 500)
        (defun etags-tags-completion-table ()
-         (let (table
+         (let ((table (make-vector 511 0))
                (progress-reporter
                 (make-progress-reporter
                  (format "Making tags completion table for %s..." buffer-file-name)
@@ -105,15 +105,15 @@ attention to case differences."
                          "[\f\t\n\r()=,; ]?\177\\\(?:\\([^\n\001]+\\)\001\\)?"
                          (+ (point) etags--table-line-limit) t))
                    (forward-line 1)
-                 (push (prog1 (if (match-beginning 1)
-                                  (buffer-substring (match-beginning 1) (match-end 1))
-                                (goto-char (match-beginning 0))
-                                (skip-chars-backward "^\f\t\n\r()=,; ")
-                                (prog1
-                                    (buffer-substring (point) (match-beginning 0))
-                                  (goto-char (match-end 0))))
-                         (progress-reporter-update progress-reporter (point)))
-                       table))))
+                 (intern (prog1 (if (match-beginning 1)
+                                    (buffer-substring (match-beginning 1) (match-end 1))
+                                  (goto-char (match-beginning 0))
+                                  (skip-chars-backward "^\f\t\n\r()=,; ")
+                                  (prog1
+                                      (buffer-substring (point) (match-beginning 0))
+                                    (goto-char (match-end 0))))
+                           (progress-reporter-update progress-reporter (point)))
+                         table))))
            table))))
 
   )


### PR DESCRIPTION
PR #946 copied the implementation from Emacs 25. However, Emacs 25
expects the function to return a list (see Emacs commit 0ac9d09b6dfe479),
whereas Emacs 24 expects an obarray:

    Debugger entered--Lisp error: (wrong-type-argument vectorp ("BUILD_DIR" "CFLAGS" ...))
      mapatoms((closure ((combined-table "Environment" "items" ...) (current-table "BUILD_DIR" "CFLAGS" ...) t) (sym) (intern (symbol-name sym) combined-table)) ("BUILD_DIR" "CFLAGS" ...))
      (if combined-table (mapatoms (function (lambda (sym) (intern (symbol-name sym) combined-table))) current-table) (setq combined-table current-table))
      (while (visit-tags-table-buffer (and combined-table t)) (setq current-table (funcall tags-completion-table-function)) (if combined-table (mapatoms (function (lambda (sym) (intern (symbol-name sym) combined-table))) current-table) (setq combined-table current-table)))
      (save-excursion (while (visit-tags-table-buffer (and combined-table t)) (setq current-table (funcall tags-completion-table-function)) (if combined-table (mapatoms (function (lambda (sym) (intern (symbol-name sym) combined-table))) current-table) (setq combined-table current-table))))
      (let (current-table combined-table) (message "Making tags completion table for %s..." buffer-file-name) (save-excursion (while (visit-tags-table-buffer (and combined-table t)) (setq current-table (funcall tags-completion-table-function)) (if combined-table (mapatoms (function (lambda (sym) (intern ... combined-table))) current-table) (setq combined-table current-table)))) (message "Making tags completion table for %s...done" buffer-file-name) (setq tags-completion-table combined-table))
      (condition-case nil (let (current-table combined-table) (message "Making tags completion table for %s..." buffer-file-name) (save-excursion (while (visit-tags-table-buffer (and combined-table t)) (setq current-table (funcall tags-completion-table-function)) (if combined-table (mapatoms (function (lambda ... ...)) current-table) (setq combined-table current-table)))) (message "Making tags completion table for %s...done" buffer-file-name) (setq tags-completion-table combined-table)) (quit (message "Tags completion table construction aborted.") (setq tags-completion-table nil)))
      (or tags-completion-table (condition-case nil (let (current-table combined-table) (message "Making tags completion table for %s..." buffer-file-name) (save-excursion (while (visit-tags-table-buffer (and combined-table t)) (setq current-table (funcall tags-completion-table-function)) (if combined-table (mapatoms (function ...) current-table) (setq combined-table current-table)))) (message "Making tags completion table for %s...done" buffer-file-name) (setq tags-completion-table combined-table)) (quit (message "Tags completion table construction aborted.") (setq tags-completion-table nil))))
      tags-completion-table()

If there are multiple entries in `tags-table-list`, and the variable
`tags-completion-table` is nil (no cached value), then the function
`tags-completion-table` combines all the tags tables in
`tags-table-list`.

However, the function `tags-completion-table` uses `mapatoms` because it
expects `tags-completion-table-function` to return an obarray. Insted,
it dies with the above error.

Several useful commands end up calling `tags-completion-table`, my
favourite is `company-capf`, which dies with "Company: An error occurred
in auto-begin" due to this issue.