### PR TITLE
Ignore cached project roots that point to nonexistent directories.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [#952](https://github.com/bbatsov/projectile/issues/952): VCS submodules brought in even thought not descendent of project root.
 * [#576](https://github.com/bbatsov/projectile/issues/576): `projectile-replace` stomps regular expressions.
 * [#957](https://github.com/bbatsov/projectile/pull/957): When opening a specified file from the terminal, do not error inside of `projectile-cache-current-file`.
+* [#984](https://github.com/bbatsov/projectile/pull/984): Error when a project is a symlink that changes target.
 
 ## 0.13.0 (10/21/2015)
 

--- a/projectile.el
+++ b/projectile.el
@@ -790,7 +790,7 @@ The current directory is assumed to be the project's root otherwise."
   (let ((dir default-directory))
     (or (--some (let* ((cache-key (format "%s-%s" it dir))
                        (cache-value (gethash cache-key projectile-project-root-cache)))
-                  (if cache-value
+                  (if (and cache-value (file-exists-p cache-value))
                       cache-value
                     (let ((value (funcall it (file-truename dir))))
                       (puthash cache-key value projectile-project-root-cache)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -455,6 +455,23 @@
               (should (member f (gethash (projectile-project-root)
                                          projectile-projects-cache))))))))))
 
+(ert-deftest projectile-test-old-project-root-gone ()
+  "Ensure that we don't cache a project root if the path has changed."
+  (projectile-test-with-sandbox
+    (projectile-test-with-files
+        ("project/"
+         "project/.projectile")
+      (cd "project")
+      (let* ((projectile-project-root-cache (make-hash-table :test #'equal))
+             (correct-project-root (projectile-project-root)))
+        ;; If this project has been moved, then we will have stale
+        ;; paths in the cache.
+        (puthash
+         (format "projectile-root-bottom-up-%s" correct-project-root)
+         "/this/path/does/not/exist"
+         projectile-project-root-cache)
+        (should (string= (projectile-project-root) correct-project-root))))))
+
 (ert-deftest projectile-test-git-grep-prefix ()
   (require 'vc-git)
   (projectile-test-with-sandbox


### PR DESCRIPTION
This fixes an awkward bug when the current project is a symlink that
changes. Suppose we have the following filesystem layout:

    /tmp/projectile_project -> /tmp/first_project

If we now delete /tmp/first_project and change the symlink:

    /tmp/projectile_project -> /tmp/second_project

then `projectile-project-root-cache` will contain a key
`"projectile-root-bottom-up-/tmp/projectile-project"` with value
`"/tmp/first_project"`. This will stop `projectile-find-file` from working
as it can't cd to /tmp/first_project.

Instead, we enforce that the string from `projectile-project-root`
points to a directory that currently exists.