### PR TITLE
[Fix #987] Add the ability to omit ignored patterns/paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * New command `projectile-run-eshell` (<kbd>C-c p x e</kbd>).
 * New command `projectile-run-term` (<kbd>C-c p x t</kbd>).
 * Let user unignore files in `.projectile` with the ! prefix.
+* Add the ability to omit ignored patterns/paths for `projectile-ag` (controlled via the `projectile-ag-use-ignored` defcustom).
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -417,6 +417,11 @@ Any function that does not take arguments will do."
   :type 'hook
   :package-version '(projectile . "0.14.0"))
 
+(defcustom projectile-ag-use-ignored t
+  "If true, use ignored paths/patterns in search."
+  :group 'projectile
+  :type 'boolean)
+
 (defcustom projectile-test-prefix-function 'projectile-test-prefix
   "Function to find test files prefix based on PROJECT-TYPE."
   :group 'projectile
@@ -2128,13 +2133,13 @@ regular expression."
          current-prefix-arg))
   (if (require 'ag nil 'noerror)
       (let ((ag-command (if arg 'ag-regexp 'ag))
-            (ag-ignore-list (unless (eq (projectile-project-vcs) 'git)
-                              ;; ag supports git ignore files
-                              (-union ag-ignore-list
-                                      (append
-                                       (projectile-ignored-files-rel) (projectile-ignored-directories-rel)
-                                       (projectile--globally-ignored-file-suffixes-glob)
-                                       grep-find-ignored-files grep-find-ignored-directories))))
+            (ag-ignore-list (if projectile-ag-use-ignored
+                                ;; ag supports git ignore files
+                                (-union ag-ignore-list
+                                        (append
+                                         (projectile-ignored-files-rel) (projectile-ignored-directories-rel)
+                                         (projectile--globally-ignored-file-suffixes-glob)
+                                         grep-find-ignored-files grep-find-ignored-directories))))
             ;; reset the prefix arg, otherwise it will affect the ag-command
             (current-prefix-arg nil))
         (funcall ag-command search-term (projectile-project-root)))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes): 
- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

Add the ability to omit ignored patterns/paths for `projectile-ag` (controlled via the `projectile-ag-use-ignored` defcustom).
