### PR TITLE
Support use of recompile

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2534,7 +2534,7 @@ Should be set via .dir-locals.el.")
   "Run external or Elisp compilation command CMD."
   (if (functionp cmd)
       (funcall cmd)
-    (compilation-start cmd)))
+    (compile cmd)))
 
 ;;;###autoload
 (defun projectile-compile-project (arg &optional dir)


### PR DESCRIPTION
In order to use the `recompile' command, both `compilation-directory'
and `compile-command' variables need to be set.  This is taken care of
when using the `compile' function, but not `compilation-start'.