### PR TITLE
Improve error message when file not found

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1946,14 +1946,17 @@ It assumes the test/ folder is at the same level as src/."
       (let ((impl-file (projectile-find-matching-file file-name)))
         (if impl-file
             (projectile-expand-root impl-file)
-          (error "No matching source file found")))
+          (error
+           (format "No matching source file found for project type: %s"
+                   (projectile-project-type)))))
     ;; find the matching test file
     (let ((test-file (projectile-find-matching-test file-name)))
       (if test-file
           (projectile-expand-root test-file)
         (if projectile-create-missing-test-files
             (projectile-create-test-file-for file-name)
-          (error "No matching test file found"))))))
+          (error "No matching test file found for project type: %s"
+                 (projectile-project-type)))))))
 
 ;;;###autoload
 (defun projectile-find-implementation-or-test-other-window ()


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):
- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

The project type is now displayed when a file a matching test or
implementation is not found, which is useful when the project type
has been mis-identified.
