### PR TITLE
Add projectile-discover-projects-in-directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * New command `projectile-run-eshell` (<kbd>C-c p x e</kbd>).
 * New command `projectile-run-term` (<kbd>C-c p x t</kbd>).
 * Let user unignore files in `.projectile` with the ! prefix.
+* Add a command to add all projects in a directory to the cache (`projectile-discover-projects-in-directory`).
 
 ### Changes
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -2,7 +2,7 @@
 
 ### Basic setup
 
-To add a project to Projectile, open a file in the project and enable `projectile-mode` in that buffer.
+To add a project to Projectile, open a file in the project and enable `projectile-mode` in that buffer. If you have a projects directory, you can tell Projectile about all of the projects in it with the command `M-x projectile-discover-projects-in-directory`.
 
 To make Projectile automatically remember projects that you access files in, enable Projectile globally:
 

--- a/projectile.el
+++ b/projectile.el
@@ -721,6 +721,23 @@ The cache is created both in memory and on the hard drive."
                                           projectile-cache-file))
     (projectile-invalidate-cache nil)))
 
+;;;###autoload
+(defun projectile-discover-projects-in-directory (directory)
+  "Discover any projects in DIRECTORY and add them to the projectile cache.
+This function is not recursive and only adds projects with roots
+at the top level of DIRECTORY."
+  (interactive
+   (list (read-directory-name "Starting directory: ")))
+  (let ((subdirs (directory-files directory t)))
+    (mapcar
+     (lambda (dir)
+       (when (and (file-directory-p dir)
+                  (not (member (file-name-nondirectory dir) '(".." "."))))
+         (let ((default-directory dir))
+           (when (projectile-project-p)
+             (projectile-add-known-project (projectile-project-root))))))
+     subdirs)))
+
 
 (defadvice delete-file (before purge-from-projectile-cache (filename &optional trash))
   (if (and projectile-enable-caching (projectile-project-p))
@@ -3081,6 +3098,7 @@ is chosen."
    ["Open project in dired" projectile-dired]
    ["Switch to project" projectile-switch-project]
    ["Switch to open project" projectile-switch-open-project]
+   ["Discover projects in directory" projectile-discover-projects-in-directory]
    ["Search in project (grep)" projectile-grep]
    ["Search in project (ag)" projectile-ag]
    ["Replace in project" projectile-replace]


### PR DESCRIPTION
This is a helper function to go through the subdirectories of a
directory, check which ones are valid projects and add them to the cache
file. I didn't make it recursive although it could be. 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

