### PR TITLE
Add check for dirty projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * New command `projectile-run-term` (<kbd>C-c p x t</kbd>).
 * Let user unignore files in `.projectile` with the ! prefix.
 * Add a command to add all projects in a directory to the cache (`projectile-discover-projects-in-directory`).
+* Add a command to list dirty projects (for version controlled projects)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 * New command `projectile-run-term` (<kbd>C-c p x t</kbd>).
 * Let user unignore files in `.projectile` with the ! prefix.
 * Add a command to add all projects in a directory to the cache (`projectile-discover-projects-in-directory`).
-* Add a command to list dirty projects (for version controlled projects)
+* Add a command to list dirty version controlled projects (`projectile-browse-dirty-projects`).
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ it. Some of Projectile's features:
 * regenerate project etags or gtags (requires [ggtags](https://github.com/leoliu/ggtags)).
 * visit project in dired
 * run make in a project with a single key chord
+* check for dirty repositories
 
 Here's a glimpse of Projectile in action:
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -34,6 +34,7 @@ it. Some of Projectile's features:
 * regenerate project etags or gtags (requires [ggtags](https://github.com/leoliu/ggtags)).
 * visit project in dired
 * run make in a project with a single key chord
+* browse dirty version controlled projects
 
 Here's a glimpse of Projectile in action:
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -34,6 +34,7 @@ Keybinding         | Description
 <kbd>C-c p s g</kbd> | Run grep on the files in the project.
 <kbd>M-- C-c p s g</kbd> | Run grep on `projectile-grep-default-files` in the project.
 <kbd>C-c p v</kbd> | Run `vc-dir` on the root directory of the project.
+<kbd>C-c p V</kbd> | Browse dirty version controlled projects.
 <kbd>C-c p b</kbd> | Display a list of all project buffers currently open.
 <kbd>C-c p 4 b</kbd> | Switch to a project buffer and show it in another window.
 <kbd>C-c p 4 C-o</kbd> | Display a project buffer in another window without selecting it.


### PR DESCRIPTION
Add two functions to check if Git projects are dirty
(uncommitted changes and/or unpushed commits).
Use [vc-check-status](https://github.com/thisirs/vc-check-status) package.

`projectile-check-project-dirty` check if the project associated with the given directory is dirty.
`projectile-see-dirty-projects` list all dirty projects (very useful before leaving Emacs after a day of hard work)

I used it for a while now and it work flawlessly for me.
If the community is interested, I can work on it a little more 
(add tests, maybe support for others vcs... ).


-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
