### PR TITLE
Add "Spec" test suffix for SBT project type.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1987,7 +1987,8 @@ It assumes the test/ folder is at the same level as src/."
    ((member project-type '(rails-test ruby-test lein-test boot-clj go)) "_test")
    ((member project-type '(scons)) "test")
    ((member project-type '(maven symfony)) "Test")
-   ((member project-type '(gradle gradlew grails)) "Spec")))
+   ((member project-type '(gradle gradlew grails)) "Spec")
+   ((member project-type '(sbt)) "Spec")))
 
 (defun projectile-dirname-matching-count (a b)
   "Count matching dirnames ascending file paths."


### PR DESCRIPTION
Commonly Scala tests are appended with "Spec".
This is a triage solution until #268 is implemented.