### PR TITLE
Inform the user once TAGS has been regenerated

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2174,7 +2174,8 @@ regular expression."
                             (buffer-substring (point-min) (point-max)))))
       (unless (zerop exit-code)
         (error shell-output))
-      (visit-tags-table tags-file))))
+      (visit-tags-table tags-file)
+      (message "Regenerated %s" tags-file))))
 
 (defun projectile-visit-project-tags-table ()
   "Visit the current project's tags table."


### PR DESCRIPTION
This is a small change, but I prefer getting feedback on when TAGS generation is done. At the moment, I end up pressing keys thinking 'is Emacs done yet?' as some of my projects take a few seconds to generate TAGS.