### PR TITLE
Ignore ensime cache directory, and consider .ensime file as project root.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New Features
+
+* Consider Ensime configuration file as root marker, `.ensime`.
+
 ### Changes
 
 * Ignore backup files in `projectile-get-other-files`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * Ignore backup files in `projectile-get-other-files`.
+* Ignore Ensime cache directory, `.ensime_cache`.
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -288,6 +288,7 @@ If variable `projectile-project-name' is non-nil, this function will not be used
     "build.sbt"          ; SBT project file
     "gradlew"            ; Gradle wrapper script
     "build.gradle"       ; Gradle project file
+    ".ensime"            ; Ensime configuration file
     "Gemfile"            ; Bundler file
     "requirements.txt"   ; Pip file
     "setup.py"           ; Setuptools file

--- a/projectile.el
+++ b/projectile.el
@@ -363,6 +363,7 @@ containing a root file."
 
 (defcustom projectile-globally-ignored-directories
   '(".idea"
+    ".ensime_cache"
     ".eunit"
     ".git"
     ".hg"


### PR DESCRIPTION
Ensime creates a .ensime file, and .ensime_cache in the project directory.  The .ensime file is considered a project root, subordinate to the respective SBT, Gradle, or Maven files.  The .ensime_cache directory is ignored from indexing.
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

