### PR TITLE
Do not consider backup files for projectile-get-other-file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Ignore backup files in `projectile-get-other-files`.
+
 ### Bugs fixed
 
 * [#1024](https://github.com/bbatsov/projectile/issues/1024): Do not cache ignored project files.

--- a/projectile.el
+++ b/projectile.el
@@ -1615,6 +1615,8 @@ With FLEX-MATCHING, match any file that contains the base name of current file"
                                 candidates))
                      file-list)))
          (candidates
+          (-filter (lambda (file) (not (backup-file-name-p file))) candidates))
+         (candidates
           (-sort (lambda (file _)
                    (let ((candidate-dirname (file-name-nondirectory (directory-file-name (file-name-directory file)))))
                      (unless (equal fulldirname (file-name-directory file))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -594,6 +594,7 @@
                        "src/some_module/same_name.c"
                        "include1/same_name.h"
                        "include1/test1.h"
+                       "include1/test1.h~"
                        "include1/test2.h"
                        "include1/test1.hpp"
                        "include2/some_module/same_name.h"


### PR DESCRIPTION
A minor annoyance for me while using projectile is that when I use `projectile-find-other-file`, it will often prompt me which file to use because it counts backup files as candidates. For example you have a project with 3 files, test.c, test.h and test.h~. If you are then editing test.c and use `projectile-find-other-file`, it will present both test.h and test.h~ as options, while the user probably wouldn't want to edit a backup file. So I think it would be better if this function ignored backup files.

The function didn't already ignore backup files, because it uses `file-name-extension`, which ignores backup suffixes. This pull request fixes this issue by filtering the candidates on not being backup files. I have also added a backup file to the files in the `projectile-test-get-other-files`, so that it also tests that the backup files aren't included.

I added a line to the changelog about the change, but I didn't edit the README, because I don't think this change should be detailed there.

Thanks!

-----------------

- [X] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
