### PR TITLE
[Fix #1033]  Move defcustom projectile-go-function above its usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1024](https://github.com/bbatsov/projectile/issues/1024): Do not cache ignored project files.
 * [#1022](https://github.com/bbatsov/projectile/issues/1022): Scan for Fossil's checkout DB, not its config DB.
 * [#1007](https://github.com/bbatsov/projectile/issues/1007): Make use of `projectile-go-function`.
+* [#1033](https://github.com/bbatsov/projectile/issues/1033): projectile-compile-project: Symbol's function definition is void: projectile-go-function
 
 ## 0.14.0 (2016-07-08)
 

--- a/projectile.el
+++ b/projectile.el
@@ -1829,6 +1829,22 @@ With a prefix ARG invalidates the cache first."
   "Return a list of test files for the current project."
   (projectile-test-files (projectile-current-project-files)))
 
+(defun projectile-cabal ()
+  "Check if a project contains *.cabal files but no stack.yaml file."
+  (and (projectile-verify-file "*.cabal")
+       (not (projectile-verify-file "stack.yaml"))))
+
+(defun projectile-go ()
+  "Check if a project contains Go source files."
+  (-any? (lambda (file)
+           (string= (file-name-extension file) "go"))
+         (projectile-current-project-files)))
+
+(defcustom projectile-go-function 'projectile-go
+  "Function to determine if project's type is go."
+  :group 'projectile
+  :type 'function)
+
 (defvar projectile-project-types (make-hash-table)
   "A hash table holding all project types that are known to Projectile.")
 
@@ -1874,22 +1890,6 @@ a COMPILE-CMD, a TEST-CMD, and a RUN-CMD."
 (projectile-register-project-type 'go projectile-go-function "go build ./..." "go test ./...")
 (projectile-register-project-type 'racket '("info.rkt") nil "raco test .")
 (projectile-register-project-type 'elixir '("mix.exs") "mix compile" "mix test")
-
-(defun projectile-cabal ()
-  "Check if a project contains *.cabal files but no stack.yaml file."
-  (and (projectile-verify-file "*.cabal")
-       (not (projectile-verify-file "stack.yaml"))))
-
-(defun projectile-go ()
-  "Check if a project contains Go source files."
-  (-any? (lambda (file)
-           (string= (file-name-extension file) "go"))
-         (projectile-current-project-files)))
-
-(defcustom projectile-go-function 'projectile-go
-  "Function to determine if project's type is go."
-  :group 'projectile
-  :type 'function)
 
 (defvar-local projectile-project-type nil
   "Buffer local var for overriding the auto-detected project type.


### PR DESCRIPTION
I found out that the sharp quote is necessary and indicates to the compiler that `projectile-go-function` is variable referencing a function.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

