### PR TITLE
Replace dash with cl-lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 emacs ?= emacs
 bemacs = $(emacs) -batch -l test/elpa.el
 
-elpa: compile test
+elpa: update compile test
 
 update:
 	$(emacs) -batch -l test/make-update.el

--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,18 @@
-EMACS ?= emacs
-EMACSFLAGS =
-CASK = cask
+emacs ?= emacs
+bemacs = $(emacs) -batch -l test/elpa.el
 
-OBJECTS = projectile.elc
+all: compile test
 
-elpa:
-	$(CASK) install
-	$(CASK) update
-	touch $@
+update:
+	$(emacs) -batch -l test/make-update.el
 
-.PHONY: build
-build : elpa $(OBJECTS)
+compile:
+	$(bemacs) -l test/make-compile.el
 
-.PHONY: byte-compile-strict
-byte-compile-strict : elpa
-	$(CASK) exec $(EMACS) --no-site-file --no-site-lisp --batch \
-		--directory "."                          \
-		$(EMACSFLAGS)                            \
-		--eval "(progn                           \
-			(setq byte-compile-error-on-warn t)  \
-			(batch-byte-compile))" projectile.el
+test:
+	$(bemacs) -l test/run-tests
 
-.PHONY: test
-test : byte-compile-strict
-	$(CASK) exec $(EMACS) --no-site-file --no-site-lisp --batch \
-		$(EMACSFLAGS) \
-		-l test/run-tests
+clean:
+	rm -f *.elc
 
-.PHONY: clean
-clean :
-	rm -f $(OBJECTS)
-	rm -f elpa
-	rm -rf .cask # Clean packages installed for development
-
-%.elc : %.el
-	$(CASK) exec $(EMACS) --no-site-file --no-site-lisp --batch \
-		$(EMACSFLAGS) \
-		-f batch-byte-compile $<
+.PHONY: all update compile test clean

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 emacs ?= emacs
 bemacs = $(emacs) -batch -l test/elpa.el
 
-all: compile test
+elpa: compile test
 
 update:
 	$(emacs) -batch -l test/make-update.el

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -63,12 +63,11 @@ You can support the development of Projectile via
 
 ## Running the tests in batch mode
 
-Install [cask](https://github.com/cask/cask) if you haven't
-already, then:
-
 ```
 $ cd /path/to/projectile
-$ cask
+$ make update
+$ make compile
+$ make test
 ```
 
 Run all tests with:
@@ -77,5 +76,4 @@ Run all tests with:
 $ make test
 ```
 
-(Note: tests may not run correctly inside Emacs' `shell-mode` buffers. Running
-them in a terminal is recommended.)
+Tests should run fine in `shell-mode` or `term-mode`. It's also possible to use <kbd>M-x</kbd> `compile` (or `helm-make`).

--- a/projectile.el
+++ b/projectile.el
@@ -1845,10 +1845,10 @@ With a prefix ARG invalidates the cache first."
 
 (defun projectile-test-file-p (file)
   "Check if FILE is a test file."
-  (or (--any? (string-prefix-p it (file-name-nondirectory file))
-              (delq nil (list (funcall projectile-test-prefix-function (projectile-project-type)))))
-      (--any? (string-suffix-p it (file-name-sans-extension (file-name-nondirectory file)))
-              (delq nil (list (funcall projectile-test-suffix-function (projectile-project-type)))))))
+  (or (cl-some (lambda (it) (string-prefix-p it (file-name-nondirectory file)))
+               (delq nil (list (funcall projectile-test-prefix-function (projectile-project-type)))))
+      (cl-some (lambda (it) (string-suffix-p it (file-name-sans-extension (file-name-nondirectory file))))
+               (delq nil (list (funcall projectile-test-suffix-function (projectile-project-type)))))))
 
 (defun projectile-current-project-test-files ()
   "Return a list of test files for the current project."

--- a/projectile.el
+++ b/projectile.el
@@ -2897,10 +2897,8 @@ See `projectile-cleanup-known-projects'."
   "Remove known projects that don't exist anymore."
   (interactive)
   (projectile-merge-known-projects)
-  (let* ((separated-projects
-          (-separate #'projectile-keep-project-p projectile-known-projects))
-         (projects-kept (car separated-projects))
-         (projects-removed (cadr separated-projects)))
+  (let ((projects-kept (cl-remove-if-not #'projectile-keep-project-p projectile-known-projects))
+        (projects-removed (cl-remove-if #'projectile-keep-project-p projectile-known-projects)))
     (setq projectile-known-projects projects-kept)
     (projectile-merge-known-projects)
     (if projects-removed

--- a/projectile.el
+++ b/projectile.el
@@ -1248,7 +1248,7 @@ Only buffers not visible in windows are returned."
 
 (defun projectile-normalise-paths (patterns)
   "Remove leading `/' from the elements of PATTERNS."
-  (-non-nil (mapcar (lambda (it) (and (string-prefix-p "/" it)
+  (delq nil (mapcar (lambda (it) (and (string-prefix-p "/" it)
                                       ;; remove the leading /
                                       (substring it 1)))
                     patterns)))
@@ -1827,9 +1827,9 @@ With a prefix ARG invalidates the cache first."
 (defun projectile-test-file-p (file)
   "Check if FILE is a test file."
   (or (--any? (string-prefix-p it (file-name-nondirectory file))
-              (-non-nil (list (funcall projectile-test-prefix-function (projectile-project-type)))))
+              (delq nil (list (funcall projectile-test-prefix-function (projectile-project-type)))))
       (--any? (string-suffix-p it (file-name-sans-extension (file-name-nondirectory file)))
-              (-non-nil (list (funcall projectile-test-suffix-function (projectile-project-type)))))))
+              (delq nil (list (funcall projectile-test-suffix-function (projectile-project-type)))))))
 
 (defun projectile-current-project-test-files ()
   "Return a list of test files for the current project."
@@ -2679,12 +2679,12 @@ with a prefix ARG."
   "Return a list of all open projects.
 An open project is a project with any open buffers."
   (-distinct
-   (-non-nil
-    (mapcar (lambda (buffer)
-            (with-current-buffer buffer
-              (when (projectile-project-p)
-                (abbreviate-file-name (projectile-project-root)))))
-          (buffer-list)))))
+   (delq nil
+         (mapcar (lambda (buffer)
+                   (with-current-buffer buffer
+                     (when (projectile-project-p)
+                       (abbreviate-file-name (projectile-project-root)))))
+                 (buffer-list)))))
 
 (defun projectile--remove-current-project (projects)
   "Remove the current project (if any) from the list of PROJECTS."

--- a/projectile.el
+++ b/projectile.el
@@ -695,7 +695,7 @@ The cache is created both in memory and on the hard drive."
   (let* ((project-root (projectile-project-root))
          (project-cache (gethash project-root projectile-projects-cache)))
     (puthash project-root
-             (--filter (string-prefix-p dir it) project-cache)
+             (cl-remove-if-not (lambda (it) (string-prefix-p dir it)) project-cache)
              projectile-projects-cache)))
 
 (defun projectile-file-cached-p (file project)
@@ -1128,12 +1128,12 @@ this case unignored files will be absent from FILES."
 
 (defun projectile-buffers-with-file (buffers)
   "Return only those BUFFERS backed by files."
-  (--filter (buffer-file-name it) buffers))
+  (cl-remove-if-not (lambda (it) (buffer-file-name it)) buffers))
 
 (defun projectile-buffers-with-file-or-process (buffers)
   "Return only those BUFFERS backed by files or processes."
-  (--filter (or (buffer-file-name it)
-                (get-buffer-process it)) buffers))
+  (cl-remove-if-not (lambda (it) (or (buffer-file-name it)
+                                     (get-buffer-process it))) buffers))
 
 (defun projectile-project-buffers ()
   "Get a list of project buffers."
@@ -2329,8 +2329,8 @@ regular expression."
   "Return a list of files in DIRECTORY."
   (let ((dir (file-relative-name (expand-file-name directory)
                                  (projectile-project-root))))
-    (--filter (string-prefix-p dir it)
-              (projectile-current-project-files))))
+    (cl-remove-if-not (lambda (it) (string-prefix-p dir it))
+                      (projectile-current-project-files))))
 
 (defun projectile-unixy-system-p ()
   "Check to see if unixy text utilities are installed."
@@ -2508,7 +2508,7 @@ For hg projects `monky-status' is used if available."
   (and (boundp 'recentf-list)
        (let ((project-root (projectile-project-root)))
          (->> recentf-list
-              (--filter (string-prefix-p project-root it))
+              (cl-remove-if-not (lambda (it) (string-prefix-p project-root it)))
               (--map (file-relative-name it project-root))))))
 
 (defun projectile-serialize-cache ()

--- a/projectile.el
+++ b/projectile.el
@@ -1103,19 +1103,20 @@ you can filter ignored files in subdirectories by setting
 SUBDIRECTORIES to a non-nil value."
   (let ((ignored (append (projectile-ignored-files-rel)
                          (projectile-ignored-directories-rel))))
-    (-remove (lambda (file)
-               (or (cl-some
-                    (lambda (it)
-                      (string-prefix-p
-                       it (if subdirectories
-                              (file-name-nondirectory file)
-                            file)))
-                    ignored)
-                   (cl-some
-                    (lambda (it)
-                      (string-suffix-p it file))
-                    projectile-globally-ignored-file-suffixes)))
-             files)))
+    (cl-remove-if
+     (lambda (file)
+       (or (cl-some
+            (lambda (it)
+              (string-prefix-p
+               it (if subdirectories
+                      (file-name-nondirectory file)
+                    file)))
+            ignored)
+           (cl-some
+            (lambda (it)
+              (string-suffix-p it file))
+            projectile-globally-ignored-file-suffixes)))
+     files)))
 
 (defun projectile-keep-ignored-files (files)
   "Filter FILES to retain only those that are ignored."
@@ -1355,7 +1356,7 @@ according to PATTERNS: (ignored . unignored)"
 (defun projectile-project-ignored-files ()
   "Return list of project ignored files. Unignored files are not
 included."
-  (-remove 'file-directory-p (projectile-project-ignored)))
+  (cl-remove-if 'file-directory-p (projectile-project-ignored)))
 
 (defun projectile-project-ignored-directories ()
   "Return list of project ignored directories. Unignored
@@ -1404,7 +1405,7 @@ files/directories are not included."
 
 (defun projectile-project-unignored-files ()
   "Return list of project unignored files."
-  (-remove 'file-directory-p (projectile-project-unignored)))
+  (cl-remove-if 'file-directory-p (projectile-project-unignored)))
 
 (defun projectile-project-unignored-directories ()
   "Return list of project unignored directories."
@@ -1529,9 +1530,10 @@ https://github.com/abo-abo/swiper")))
 
 (defun projectile-current-project-dirs ()
   "Return a list of dirs for the current project."
-  (-remove #'null (delete-dups
-                   (mapcar #'file-name-directory
-                           (projectile-current-project-files)))))
+  (delete-dups
+   (delq nil
+         (mapcar #'file-name-directory
+                 (projectile-current-project-files)))))
 
 (defun projectile-hash-keys (hash)
   "Return a list of all HASH keys."
@@ -2498,7 +2500,7 @@ to run the replacement."
                  (length buffers) name))
         ;; we take care not to kill indirect buffers directly
         ;; as we might encounter them after their base buffers are killed
-        (mapc #'kill-buffer (-remove 'buffer-base-buffer buffers)))))
+        (mapc #'kill-buffer (cl-remove-if 'buffer-base-buffer buffers)))))
 
 ;;;###autoload
 (defun projectile-save-project-buffers ()

--- a/projectile.el
+++ b/projectile.el
@@ -1899,9 +1899,10 @@ a COMPILE-CMD, a TEST-CMD, and a RUN-CMD."
 
 (defun projectile-go ()
   "Check if a project contains Go source files."
-  (-any? (lambda (file)
-           (string= (file-name-extension file) "go"))
-         (projectile-current-project-files)))
+  (cl-some
+   (lambda (file)
+     (string= (file-name-extension file) "go"))
+   (projectile-current-project-files)))
 
 (defcustom projectile-go-function 'projectile-go
   "Function to determine if project's type is go."

--- a/projectile.el
+++ b/projectile.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/bbatsov/projectile
 ;; Keywords: project, convenience
 ;; Version: 0.14.0
-;; Package-Requires: ((dash "2.11.0") (pkg-info "0.4"))
+;; Package-Requires: ((pkg-info "0.4"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -36,8 +36,8 @@
 ;;
 ;;; Code:
 
+(require 'cl-lib)
 (require 'thingatpt)
-(require 'dash)
 (require 'ibuffer)
 (require 'ibuf-ext)
 (require 'compile)

--- a/projectile.el
+++ b/projectile.el
@@ -2988,7 +2988,7 @@ is chosen."
   (ignore-errors (kill-buffer projectile-commander-help-buffer))
   (with-current-buffer (get-buffer-create projectile-commander-help-buffer)
     (insert "Projectile Commander Methods:\n\n")
-    (--each projectile-commander-methods
+    (dolist (it projectile-commander-methods)
       (-let [(key line _) it]
         (insert (format "%c:\t%s\n" key line))))
     (goto-char (point-min))

--- a/projectile.el
+++ b/projectile.el
@@ -1250,10 +1250,10 @@ Only buffers not visible in windows are returned."
 
 (defun projectile-normalise-paths (patterns)
   "Remove leading `/' from the elements of PATTERNS."
-  (-non-nil (--map (and (string-prefix-p "/" it)
-                        ;; remove the leading /
-                        (substring it 1))
-                   patterns)))
+  (-non-nil (mapcar (lambda (it) (and (string-prefix-p "/" it)
+                                      ;; remove the leading /
+                                      (substring it 1)))
+                    patterns)))
 
 (defun projectile-expand-paths (paths)
   "Expand the elements of PATHS.
@@ -1275,7 +1275,7 @@ projectile project root."
 (defun projectile-make-relative-to-root (files)
   "Make FILES relative to the project root."
   (let ((project-root (projectile-project-root)))
-    (--map (file-relative-name it project-root) files)))
+    (mapcar (lambda (it) (file-relative-name it project-root)) files)))
 
 (defun projectile-ignored-directory-p (directory)
   "Check if DIRECTORY should be ignored."
@@ -1391,8 +1391,8 @@ files/directories are not included."
   (projectile-normalise-paths (nth 2 (projectile-parse-dirconfig-file))))
 
 (defun projectile-files-to-ensure ()
-  (-flatten (--map (file-expand-wildcards it t)
-                   (projectile-patterns-to-ensure))))
+  (-flatten (mapcar (lambda (it) (file-expand-wildcards it t))
+                    (projectile-patterns-to-ensure))))
 
 (defun projectile-patterns-to-ensure ()
   "Return a list of relative file patterns."
@@ -1433,14 +1433,14 @@ prefix the string will be assumed to be an ignore string."
             (?+ (push (buffer-substring (1+ (point)) (line-end-position)) keep))
             (?- (push (buffer-substring (1+ (point)) (line-end-position)) ignore))
             (?! (push (buffer-substring (1+ (point)) (line-end-position)) ensure))
-            (_  (push (buffer-substring     (point)  (line-end-position)) ignore)))
+            (_ (push (buffer-substring (point) (line-end-position)) ignore)))
           (forward-line)))
-      (list (--map (file-name-as-directory (projectile-trim-string it))
-                   (delete "" (reverse keep)))
-            (-map  #'projectile-trim-string
-                   (delete "" (reverse ignore)))
-            (-map  #'projectile-trim-string
-                   (delete "" (reverse ensure)))))))
+      (list (mapcar (lambda (it) (file-name-as-directory (projectile-trim-string it)))
+                    (delete "" (reverse keep)))
+            (-map #'projectile-trim-string
+                  (delete "" (reverse ignore)))
+            (-map #'projectile-trim-string
+                  (delete "" (reverse ensure)))))))
 
 (defun projectile-expand-root (name)
   "Expand NAME to project root.
@@ -2127,7 +2127,7 @@ This is a subset of `grep-read-files', where either a matching entry from
 
 (defun projectile--globally-ignored-file-suffixes-glob ()
   "Return ignored file suffixes as a list of glob patterns."
-  (--map (concat "*" it) projectile-globally-ignored-file-suffixes))
+  (mapcar (lambda (it) (concat "*" it)) projectile-globally-ignored-file-suffixes))
 
 ;;;###autoload
 (defun projectile-grep (&optional regexp arg)
@@ -2157,8 +2157,8 @@ With REGEXP given, don't query the user for a regexp."
           (vc-git-grep search-regexp (or files "") root-dir)
         ;; paths for find-grep should relative and without trailing /
         (let ((grep-find-ignored-directories
-               (-union (--map (directory-file-name (file-relative-name it root-dir))
-                              (projectile-ignored-directories))
+               (-union (mapcar (lambda (it) (directory-file-name (file-relative-name it root-dir)))
+                               (projectile-ignored-directories))
                        grep-find-ignored-directories))
               (grep-find-ignored-files
                (-union (append (-map (lambda (file)
@@ -2343,11 +2343,11 @@ CMD should include the necessary search params and should output
 equivalently to grep -HlI (only unique matching filenames).
 Returns a list of expanded filenames."
   (let ((default-directory directory))
-    (--map (concat directory
-                   (if (string-prefix-p "./" it) (substring it 2) it))
-           (-> (shell-command-to-string cmd)
-               projectile-trim-string
-               (split-string "\n+" t)))))
+    (mapcar (lambda (it) (concat directory
+                                 (if (string-prefix-p "./" it) (substring it 2) it)))
+            (-> (shell-command-to-string cmd)
+                projectile-trim-string
+                (split-string "\n+" t)))))
 
 (defun projectile-files-with-string (string directory)
   "Return a list of all files containing STRING in DIRECTORY.
@@ -2509,7 +2509,7 @@ For hg projects `monky-status' is used if available."
        (let ((project-root (projectile-project-root)))
          (->> recentf-list
               (cl-remove-if-not (lambda (it) (string-prefix-p project-root it)))
-              (--map (file-relative-name it project-root))))))
+              (mapcar (lambda (it) (file-relative-name it project-root)))))))
 
 (defun projectile-serialize-cache ()
   "Serializes the memory cache to the hard drive."
@@ -2637,7 +2637,7 @@ fallback to the original function."
                       (let ((root (projectile-project-root))
                             (dirs (cons "" (projectile-current-project-dirs))))
                         (-when-let (full-filename (->> dirs
-                                                       (--map (expand-file-name filename (expand-file-name it root)))
+                                                       (mapcar (lambda (it) (expand-file-name filename (expand-file-name it root))))
                                                        (-filter #'file-exists-p)
                                                        (-first-item)))
                           full-filename)))

--- a/projectile.el
+++ b/projectile.el
@@ -2381,11 +2381,16 @@ CMD should include the necessary search params and should output
 equivalently to grep -HlI (only unique matching filenames).
 Returns a list of expanded filenames."
   (let ((default-directory directory))
-    (mapcar (lambda (it) (concat directory
-                                 (if (string-prefix-p "./" it) (substring it 2) it)))
-            (-> (shell-command-to-string cmd)
-                projectile-trim-string
-                (split-string "\n+" t)))))
+    (mapcar (lambda (it)
+              (concat directory
+                      (if (string-prefix-p "./" it)
+                          (substring it 2)
+                        it)))
+            (split-string
+             (projectile-trim-string
+              (shell-command-to-string cmd))
+             "\n+"
+             t))))
 
 (defun projectile-files-with-string (string directory)
   "Return a list of all files containing STRING in DIRECTORY.

--- a/projectile.el
+++ b/projectile.el
@@ -2637,7 +2637,7 @@ fallback to the original function."
                         (-when-let (full-filename (->> dirs
                                                        (mapcar (lambda (it) (expand-file-name filename (expand-file-name it root))))
                                                        (-filter #'file-exists-p)
-                                                       (-first-item)))
+                                                       (car)))
                           full-filename)))
                  ;; Fall back to the old argument
                  filename))

--- a/projectile.el
+++ b/projectile.el
@@ -2205,15 +2205,15 @@ With REGEXP given, don't query the user for a regexp."
           (vc-git-grep search-regexp (or files "") root-dir)
         ;; paths for find-grep should relative and without trailing /
         (let ((grep-find-ignored-directories
-               (-union (mapcar (lambda (it) (directory-file-name (file-relative-name it root-dir)))
-                               (projectile-ignored-directories))
-                       grep-find-ignored-directories))
+               (cl-union (mapcar (lambda (it) (directory-file-name (file-relative-name it root-dir)))
+                                 (projectile-ignored-directories))
+                         grep-find-ignored-directories))
               (grep-find-ignored-files
-               (-union (append (mapcar (lambda (file)
-                                       (file-relative-name file root-dir))
-                                     (projectile-ignored-files))
-                               (projectile--globally-ignored-file-suffixes-glob))
-                       grep-find-ignored-files)))
+               (cl-union (append (mapcar (lambda (file)
+                                           (file-relative-name file root-dir))
+                                         (projectile-ignored-files))
+                                 (projectile--globally-ignored-file-suffixes-glob))
+                         grep-find-ignored-files)))
           (grep-compute-defaults)
           (rgrep search-regexp (or files "* .*") root-dir))))
     (run-hooks 'projectile-grep-finished-hook)))
@@ -2233,7 +2233,7 @@ regular expression."
       (let ((ag-command (if arg 'ag-regexp 'ag))
             (ag-ignore-list (unless (eq (projectile-project-vcs) 'git)
                               ;; ag supports git ignore files
-                              (-union ag-ignore-list
+                              (cl-union ag-ignore-list
                                       (append
                                        (projectile-ignored-files-rel) (projectile-ignored-directories-rel)
                                        (projectile--globally-ignored-file-suffixes-glob)

--- a/projectile.el
+++ b/projectile.el
@@ -1903,12 +1903,13 @@ Normally you'd set this from .dir-locals.el.")
 
 (defun projectile-detect-project-type ()
   "Detect the type of the current project."
-  (let ((project-type (-first (lambda (project-type)
-                                (let ((marker (plist-get (gethash project-type projectile-project-types) 'marker-files)))
-                                  (if (listp marker)
-                                      (and (projectile-verify-files marker) project-type)
-                                    (and (funcall marker) project-type))))
-                              (projectile-hash-keys projectile-project-types))))
+  (let ((project-type (cl-find-if
+                       (lambda (project-type)
+                         (let ((marker (plist-get (gethash project-type projectile-project-types) 'marker-files)))
+                           (if (listp marker)
+                               (and (projectile-verify-files marker) project-type)
+                             (and (funcall marker) project-type))))
+                       (projectile-hash-keys projectile-project-types))))
     (when project-type
       (puthash (projectile-project-root) project-type projectile-project-type-cache))
     project-type))

--- a/projectile.el
+++ b/projectile.el
@@ -815,8 +815,8 @@ Return the first (topmost) matched directory or nil if not found."
   (projectile-locate-dominating-file
    dir
    (lambda (dir)
-     (--first (projectile-file-exists-p (expand-file-name it dir))
-              (or list projectile-project-root-files)))))
+     (cl-find-if (lambda (it) (projectile-file-exists-p (expand-file-name it dir)))
+                 (or list projectile-project-root-files)))))
 
 (defun projectile-root-bottom-up (dir &optional list)
   "Identify a project root in DIR by bottom-up search for files in LIST.

--- a/projectile.el
+++ b/projectile.el
@@ -1976,7 +1976,7 @@ Normally you'd set this from .dir-locals.el.")
 
 (defun projectile-verify-files (files)
   "Check whether all FILES exist in the current project."
-  (-all? 'projectile-verify-file files))
+  (cl-every 'projectile-verify-file files))
 
 (defun projectile-verify-file (file)
   "Check whether FILE exists in the current project.

--- a/projectile.el
+++ b/projectile.el
@@ -2887,8 +2887,8 @@ overwriting each other's changes."
           (-difference known-on-last-sync known-on-file))
          (result (-distinct
                   (-difference
-                   (-concat known-now known-on-file)
-                   (-concat removed-after-sync removed-in-other-process)))))
+                   (append known-now known-on-file)
+                   (append removed-after-sync removed-in-other-process)))))
     (setq projectile-known-projects result)
     (projectile-save-known-projects)))
 

--- a/projectile.el
+++ b/projectile.el
@@ -2854,7 +2854,9 @@ See `projectile-cleanup-known-projects'."
   (interactive (list (projectile-completing-read "Remove from known projects: "
                                                  projectile-known-projects)))
   (setq projectile-known-projects
-        (--reject (string= project it) projectile-known-projects))
+        (cl-remove-if
+         (lambda (it) (string= project it))
+         projectile-known-projects))
   (projectile-merge-known-projects)
   (when projectile-verbose
     (message "Project %s removed from the list of known projects." project)))

--- a/projectile.el
+++ b/projectile.el
@@ -3035,10 +3035,10 @@ available actions.
 
 See `def-projectile-commander-method' for defining new methods."
   (interactive)
-  (-let* ((choices (mapcar #'car projectile-commander-methods))
-          (prompt (concat "Commander [" choices "]: "))
-          (ch (read-char-choice prompt choices))
-          ((_ _ fn) (assq ch projectile-commander-methods)))
+  (let* ((choices (mapcar #'car projectile-commander-methods))
+         (prompt (concat "Commander [" choices "]: "))
+         (ch (read-char-choice prompt choices))
+         (fn (nth 2 (assq ch projectile-commander-methods))))
     (funcall fn)))
 
 (defmacro def-projectile-commander-method (key description &rest body)
@@ -3062,8 +3062,7 @@ is chosen."
   (with-current-buffer (get-buffer-create projectile-commander-help-buffer)
     (insert "Projectile Commander Methods:\n\n")
     (dolist (it projectile-commander-methods)
-      (-let [(key line _) it]
-        (insert (format "%c:\t%s\n" key line))))
+      (insert (format "%c:\t%s\n" (car it) (cadr it))))
     (goto-char (point-min))
     (help-mode)
     (display-buffer (current-buffer) t))

--- a/projectile.el
+++ b/projectile.el
@@ -1197,6 +1197,9 @@ this case unignored files will be absent from FILES."
                         (symbol-name major-mode)))
       projectile-globally-ignored-modes))))
 
+(defun projectile-difference (list1 list2)
+  (cl-set-difference list1 list2 :test #'equal))
+
 (defun projectile-recently-active-files ()
   "Get list of recently active files.
 
@@ -1204,8 +1207,9 @@ Files are ordered by recently active buffers, and then recently
 opened through use of recentf."
   (let ((project-buffer-files (projectile-project-buffer-files)))
     (append project-buffer-files
-            (-difference (projectile-recentf-files)
-                         project-buffer-files))))
+            (projectile-difference
+             (projectile-recentf-files)
+             project-buffer-files))))
 
 (defun projectile-project-buffer-names ()
   "Get a list of project buffer names."
@@ -1325,7 +1329,7 @@ according to PATTERNS: (ignored . unignored)"
 
 (defun projectile-ignored-files ()
   "Return list of ignored files."
-  (-difference
+  (projectile-difference
    (mapcar
     #'projectile-expand-root
     (append
@@ -1335,7 +1339,7 @@ according to PATTERNS: (ignored . unignored)"
 
 (defun projectile-ignored-directories ()
   "Return list of ignored directories."
-  (-difference
+  (projectile-difference
    (mapcar
     #'file-name-as-directory
     (mapcar
@@ -1785,13 +1789,13 @@ With a prefix ARG invalidates the cache first."
   "Sort FILES by a recent first scheme."
   (let ((project-recentf-files (projectile-recentf-files)))
     (append project-recentf-files
-            (-difference files project-recentf-files))))
+            (projectile-difference files project-recentf-files))))
 
 (defun projectile-sort-by-recently-active-first (files)
   "Sort FILES by most recently active buffers or opened files."
   (let ((project-recently-active-files (projectile-recently-active-files)))
     (append project-recently-active-files
-            (-difference files project-recently-active-files))))
+            (projectile-difference files project-recently-active-files))))
 
 (defun projectile-sort-by-modification-time (files)
   "Sort FILES by modification time."
@@ -2742,7 +2746,7 @@ An open project is a project with any open buffers."
 (defun projectile--remove-current-project (projects)
   "Remove the current project (if any) from the list of PROJECTS."
   (if (projectile-project-p)
-      (-difference projects
+      (projectile-difference projects
                    (list (abbreviate-file-name (projectile-project-root))))
     projects))
 
@@ -2938,11 +2942,11 @@ overwriting each other's changes."
          (known-on-last-sync projectile-known-projects-on-file)
          (known-on-file
           (projectile-unserialize projectile-known-projects-file))
-         (removed-after-sync (-difference known-on-last-sync known-now))
+         (removed-after-sync (projectile-difference known-on-last-sync known-now))
          (removed-in-other-process
-          (-difference known-on-last-sync known-on-file))
+          (projectile-difference known-on-last-sync known-on-file))
          (result (delete-dups
-                  (-difference
+                  (projectile-difference
                    (append known-now known-on-file)
                    (append removed-after-sync removed-in-other-process)))))
     (setq projectile-known-projects result)

--- a/projectile.el
+++ b/projectile.el
@@ -2121,8 +2121,18 @@ It assumes the test/ folder is at the same level as src/."
 
 (defun projectile-group-file-candidates (file candidates)
   "Group file candidates by dirname matching count."
-  (--sort (> (car it) (car other))
-          (--group-by (projectile-dirname-matching-count file it) candidates)))
+  (cl-sort (lambda (it other) (> (car it) (car other)))
+           (copy-sequence
+            (let (value result)
+              (while (setq value (pop candidates))
+                (let* ((key (projectile-dirname-matching-count file value))
+                       (kv (assoc key result)))
+                  (if kv
+                      (setcdr kv (cons value (cdr kv)))
+                    (push (list key value) result))))
+              (mapcar (lambda (x)
+                        (cons (car x) (nreverse (cdr x))))
+                      (nreverse result))))))
 
 (defun projectile-find-matching-test (file)
   "Compute the name of the test matching FILE."

--- a/projectile.el
+++ b/projectile.el
@@ -2116,7 +2116,7 @@ It assumes the test/ folder is at the same level as src/."
      ((= (length candidates) 1) (car candidates))
      (t (let ((grouped-candidates (projectile-group-file-candidates file candidates)))
           (if (= (length (car grouped-candidates)) 2)
-              (-last-item (car grouped-candidates))
+              (car (last (car grouped-candidates)))
             (projectile-completing-read
              "Switch to: "
              (apply 'append (mapcar 'cdr grouped-candidates)))))))))
@@ -2141,7 +2141,7 @@ It assumes the test/ folder is at the same level as src/."
      ((= (length candidates) 1) (car candidates))
      (t (let ((grouped-candidates (projectile-group-file-candidates test-file candidates)))
           (if (= (length (car grouped-candidates)) 2)
-              (-last-item (car grouped-candidates))
+              (car (last (car grouped-candidates)))
             (projectile-completing-read
              "Switch to: "
              (apply 'append (mapcar 'cdr grouped-candidates)))))))))

--- a/projectile.el
+++ b/projectile.el
@@ -1308,7 +1308,9 @@ according to PATTERNS: (ignored . unignored)"
     (and (cl-some
           (lambda (it) (projectile-check-pattern-p file it))
           (car patterns))
-         (--none-p (projectile-check-pattern-p file it) (cdr patterns)))))
+         (cl-notany
+          (lambda (it) (projectile-check-pattern-p file it))
+          (cdr patterns)))))
 
 (defun projectile-ignored-files ()
   "Return list of ignored files."

--- a/projectile.el
+++ b/projectile.el
@@ -1504,8 +1504,9 @@ https://github.com/abo-abo/swiper")))
     (unless files
       (when projectile-enable-caching
         (message "Empty cache. Projectile is initializing cache..."))
-      (setq files (-mapcat #'projectile-dir-files
-                           (projectile-get-project-directories)))
+      (setq files (cl-mapcan
+                   #'projectile-dir-files
+                   (projectile-get-project-directories)))
       ;; cache the resulting list of files
       (when projectile-enable-caching
         (projectile-cache-project (projectile-project-root) files)))
@@ -2789,13 +2790,14 @@ This command will first prompt for the directory the file is in."
 
 (defun projectile-all-project-files ()
   "Get a list of all files in all projects."
-  (-mapcat (lambda (project)
-             (when (file-exists-p project)
-               (let ((default-directory project))
-                 (mapcar (lambda (file)
-                         (expand-file-name file project))
-                       (projectile-current-project-files)))))
-           projectile-known-projects))
+  (cl-mapcan
+   (lambda (project)
+     (when (file-exists-p project)
+       (let ((default-directory project))
+         (mapcar (lambda (file)
+                   (expand-file-name file project))
+                 (projectile-current-project-files)))))
+   projectile-known-projects))
 
 ;;;###autoload
 (defun projectile-find-file-in-known-projects ()

--- a/projectile.el
+++ b/projectile.el
@@ -1502,9 +1502,9 @@ https://github.com/abo-abo/swiper")))
 
 (defun projectile-current-project-dirs ()
   "Return a list of dirs for the current project."
-  (-remove #'null (-distinct
+  (-remove #'null (delete-dups
                    (mapcar #'file-name-directory
-                         (projectile-current-project-files)))))
+                           (projectile-current-project-files)))))
 
 (defun projectile-hash-keys (hash)
   "Return a list of all HASH keys."
@@ -2678,7 +2678,7 @@ with a prefix ARG."
 (defun projectile-open-projects ()
   "Return a list of all open projects.
 An open project is a project with any open buffers."
-  (-distinct
+  (delete-dups
    (delq nil
          (mapcar (lambda (buffer)
                    (with-current-buffer buffer
@@ -2849,7 +2849,7 @@ See `projectile-cleanup-known-projects'."
   "Add PROJECT-ROOT to the list of known projects."
   (unless (projectile-ignored-project-p project-root)
     (setq projectile-known-projects
-          (-distinct
+          (delete-dups
            (cons (abbreviate-file-name project-root)
                  projectile-known-projects)))))
 
@@ -2885,7 +2885,7 @@ overwriting each other's changes."
          (removed-after-sync (-difference known-on-last-sync known-now))
          (removed-in-other-process
           (-difference known-on-last-sync known-on-file))
-         (result (-distinct
+         (result (delete-dups
                   (-difference
                    (append known-now known-on-file)
                    (append removed-after-sync removed-in-other-process)))))

--- a/projectile.el
+++ b/projectile.el
@@ -1280,7 +1280,7 @@ projectile project root."
 
 (defun projectile-normalise-patterns (patterns)
   "Remove paths from PATTERNS."
-  (--remove (string-prefix-p "/" it) patterns))
+  (cl-remove-if (lambda (it) (string-prefix-p "/" it)) patterns))
 
 (defun projectile-make-relative-to-root (files)
   "Make FILES relative to the project root."

--- a/projectile.el
+++ b/projectile.el
@@ -1232,8 +1232,8 @@ This function excludes the current buffer from the offered
 choices."
   (projectile-completing-read
    prompt
-   (-remove-item (buffer-name (current-buffer))
-                 (projectile-project-buffer-names))))
+   (delete (buffer-name (current-buffer))
+           (projectile-project-buffer-names))))
 
 ;;;###autoload
 (defun projectile-switch-to-buffer ()

--- a/projectile.el
+++ b/projectile.el
@@ -2429,8 +2429,9 @@ files in the project."
                          (format "grep -rHlI %s ." search-term)))))
         (projectile-files-from-cmd cmd directory))
     ;; we have to reject directories as a workaround to work with git submodules
-    (-reject #'file-directory-p
-             (mapcar #'projectile-expand-root (projectile-dir-files directory)))))
+    (cl-remove-if
+     #'file-directory-p
+     (mapcar #'projectile-expand-root (projectile-dir-files directory)))))
 
 ;;;###autoload
 (defun projectile-replace (&optional arg)
@@ -2485,8 +2486,9 @@ to run the replacement."
           ;; We can't narrow the list of files with
           ;; `projectile-files-with-string' because those regexp tools
           ;; don't support Emacs regular expressions.
-          (-reject #'file-directory-p
-                   (mapcar #'projectile-expand-root (projectile-dir-files directory)))))
+          (cl-remove-if
+           #'file-directory-p
+           (mapcar #'projectile-expand-root (projectile-dir-files directory)))))
     (tags-query-replace old-text new-text nil (cons 'list files))))
 
 (defun projectile-symbol-or-selection-at-point ()

--- a/projectile.el
+++ b/projectile.el
@@ -1000,6 +1000,12 @@ Files are returned as relative paths to the project root."
      ((eq vcs 'git) projectile-git-ignored-command)
      (t (error "VCS command for ignored files not implemented yet")))))
 
+(defun projectile-flatten (lst)
+  "Take a nested list LST and return its contents as a single, flat list."
+  (if (and (listp lst) (listp (cdr lst)))
+      (cl-mapcan 'projectile-flatten lst)
+    (list lst)))
+
 (defun projectile-get-all-sub-projects (project)
   "Get all sub-projects for a given project.
 
@@ -1009,7 +1015,7 @@ PROJECT is base directory to start search recursively."
      ((null submodules)
       nil)
      (t
-      (nconc submodules (-flatten
+      (nconc submodules (projectile-flatten
                          ;; recursively get sub-projects of each sub-project
                          (mapcar (lambda (s)
                                    (projectile-get-all-sub-projects s)) submodules)))))))
@@ -1044,7 +1050,7 @@ they are excluded from the results of this function."
 
 (defun projectile-get-sub-projects-files ()
   "Get files from sub-projects recursively."
-  (-flatten
+  (projectile-flatten
    (mapcar (lambda (s)
              (let ((default-directory s))
                (mapcar (lambda (f)
@@ -1287,7 +1293,7 @@ Elements containing wildcards are expanded and spliced into the
 resulting paths.  The returned PATHS are absolute, based on the
 projectile project root."
   (let ((default-directory (projectile-project-root)))
-    (-flatten (mapcar
+    (projectile-flatten (mapcar
                (lambda (pattern)
                  (or (file-expand-wildcards pattern t)
                      (projectile-expand-root pattern)))
@@ -1420,7 +1426,7 @@ files/directories are not included."
   (projectile-normalise-paths (nth 2 (projectile-parse-dirconfig-file))))
 
 (defun projectile-files-to-ensure ()
-  (-flatten (mapcar (lambda (it) (file-expand-wildcards it t))
+  (projectile-flatten (mapcar (lambda (it) (file-expand-wildcards it t))
                     (projectile-patterns-to-ensure))))
 
 (defun projectile-patterns-to-ensure ()
@@ -1643,7 +1649,7 @@ With FLEX-MATCHING, match any file that contains the base name of current file"
                         (string-match filename project-file))
                       project-file-list))
          (candidates
-          (-flatten (mapcar
+          (projectile-flatten (mapcar
                      (lambda (file)
                        (cl-remove-if-not
                         (lambda (project-file)

--- a/projectile.el
+++ b/projectile.el
@@ -2349,12 +2349,15 @@ regular expression."
   "Return a list of files in DIRECTORY."
   (let ((dir (file-relative-name (expand-file-name directory)
                                  (projectile-project-root))))
-    (cl-remove-if-not (lambda (it) (string-prefix-p dir it))
-                      (projectile-current-project-files))))
+    (cl-remove-if-not
+     (lambda (it) (string-prefix-p dir it))
+     (projectile-current-project-files))))
 
 (defun projectile-unixy-system-p ()
   "Check to see if unixy text utilities are installed."
-  (--all? (executable-find it) '("grep" "cut" "uniq")))
+  (cl-every
+   (lambda (it) (executable-find it))
+   '("grep" "cut" "uniq")))
 
 (defun projectile-files-from-cmd (cmd directory)
   "Use a grep-like CMD to search for files within DIRECTORY.

--- a/projectile.el
+++ b/projectile.el
@@ -890,7 +890,7 @@ A thin wrapper around `file-truename' that handles nil."
 ;;; Project indexing
 (defun projectile-get-project-directories ()
   "Get the list of project directories that are of interest to the user."
-  (-map (lambda (subdir) (concat (projectile-project-root) subdir))
+  (mapcar (lambda (subdir) (concat (projectile-project-root) subdir))
         (or (nth 0 (projectile-parse-dirconfig-file)) '(""))))
 
 (defun projectile-dir-files (directory)
@@ -914,14 +914,14 @@ Files are returned as relative paths to the project root."
           (format "Projectile is indexing %s"
                   (propertize directory 'face 'font-lock-keyword-face)))))
     ;; we need the files with paths relative to the project root
-    (-map (lambda (file) (file-relative-name file root))
+    (mapcar (lambda (file) (file-relative-name file root))
           (projectile-index-directory directory (projectile-filtering-patterns)
                                       progress-reporter))))
 
 (defun projectile-dir-files-external (root directory)
   "Get the files for ROOT under DIRECTORY using external tools."
   (let ((default-directory directory))
-    (-map (lambda (file)
+    (mapcar (lambda (file)
             (file-relative-name (expand-file-name file directory) root))
           (projectile-get-repo-files))))
 
@@ -1153,7 +1153,7 @@ this case unignored files will be absent from FILES."
   "Get a list of project buffer files."
   (let ((project-root (projectile-project-root)))
     (->> (projectile-buffers-with-file (projectile-project-buffers))
-         (-map (lambda (buffer)
+         (mapcar (lambda (buffer)
                  (file-relative-name (buffer-file-name buffer) project-root))))))
 
 (defun projectile-project-buffer-p (buffer project-root)
@@ -1187,7 +1187,7 @@ opened through use of recentf."
 
 (defun projectile-project-buffer-names ()
   "Get a list of project buffer names."
-  (-map #'buffer-name (projectile-project-buffers)))
+  (mapcar #'buffer-name (projectile-project-buffers)))
 
 (defun projectile-prepend-project-name (string)
   "Prepend the current project's name to STRING."
@@ -1260,7 +1260,7 @@ Elements containing wildcards are expanded and spliced into the
 resulting paths.  The returned PATHS are absolute, based on the
 projectile project root."
   (let ((default-directory (projectile-project-root)))
-    (-flatten (-map
+    (-flatten (mapcar
                (lambda (pattern)
                  (or (file-expand-wildcards pattern t)
                      (projectile-expand-root pattern)))
@@ -1299,7 +1299,7 @@ according to PATTERNS: (ignored . unignored)"
 (defun projectile-ignored-files ()
   "Return list of ignored files."
   (-difference
-   (-map
+   (mapcar
     #'projectile-expand-root
     (append
      projectile-globally-ignored-files
@@ -1309,9 +1309,9 @@ according to PATTERNS: (ignored . unignored)"
 (defun projectile-ignored-directories ()
   "Return list of ignored directories."
   (-difference
-   (-map
+   (mapcar
     #'file-name-as-directory
-    (-map
+    (mapcar
      #'projectile-expand-root
      (append
       projectile-globally-ignored-directories
@@ -1352,7 +1352,7 @@ files/directories are not included."
 
 (defun projectile-unignored-files ()
   "Return list of unignored files."
-  (-map
+  (mapcar
    #'projectile-expand-root
    (append
     projectile-globally-unignored-files
@@ -1360,9 +1360,9 @@ files/directories are not included."
 
 (defun projectile-unignored-directories ()
   "Return list of unignored directories."
-  (-map
+  (mapcar
    #'file-name-as-directory
-   (-map
+   (mapcar
     #'projectile-expand-root
     (append
      projectile-globally-unignored-directories
@@ -1435,9 +1435,9 @@ prefix the string will be assumed to be an ignore string."
           (forward-line)))
       (list (mapcar (lambda (it) (file-name-as-directory (projectile-trim-string it)))
                     (delete "" (reverse keep)))
-            (-map #'projectile-trim-string
+            (mapcar #'projectile-trim-string
                   (delete "" (reverse ignore)))
-            (-map #'projectile-trim-string
+            (mapcar #'projectile-trim-string
                   (delete "" (reverse ensure)))))))
 
 (defun projectile-expand-root (name)
@@ -1503,7 +1503,7 @@ https://github.com/abo-abo/swiper")))
 (defun projectile-current-project-dirs ()
   "Return a list of dirs for the current project."
   (-remove #'null (-distinct
-                   (-map #'file-name-directory
+                   (mapcar #'file-name-directory
                          (projectile-current-project-files)))))
 
 (defun projectile-hash-keys (hash)
@@ -2160,7 +2160,7 @@ With REGEXP given, don't query the user for a regexp."
                                (projectile-ignored-directories))
                        grep-find-ignored-directories))
               (grep-find-ignored-files
-               (-union (append (-map (lambda (file)
+               (-union (append (mapcar (lambda (file)
                                        (file-relative-name file root-dir))
                                      (projectile-ignored-files))
                                (projectile--globally-ignored-file-suffixes-glob))
@@ -2374,7 +2374,7 @@ files in the project."
         (projectile-files-from-cmd cmd directory))
     ;; we have to reject directories as a workaround to work with git submodules
     (-reject #'file-directory-p
-             (-map #'projectile-expand-root (projectile-dir-files directory)))))
+             (mapcar #'projectile-expand-root (projectile-dir-files directory)))))
 
 ;;;###autoload
 (defun projectile-replace (&optional arg)
@@ -2430,7 +2430,7 @@ to run the replacement."
           ;; `projectile-files-with-string' because those regexp tools
           ;; don't support Emacs regular expressions.
           (-reject #'file-directory-p
-                   (-map #'projectile-expand-root (projectile-dir-files directory)))))
+                   (mapcar #'projectile-expand-root (projectile-dir-files directory)))))
     (tags-query-replace old-text new-text nil (cons 'list files))))
 
 (defun projectile-symbol-or-selection-at-point ()
@@ -2680,7 +2680,7 @@ with a prefix ARG."
 An open project is a project with any open buffers."
   (-distinct
    (-non-nil
-    (-map (lambda (buffer)
+    (mapcar (lambda (buffer)
             (with-current-buffer buffer
               (when (projectile-project-p)
                 (abbreviate-file-name (projectile-project-root)))))
@@ -2762,7 +2762,7 @@ This command will first prompt for the directory the file is in."
   (-mapcat (lambda (project)
              (when (file-exists-p project)
                (let ((default-directory project))
-                 (-map (lambda (file)
+                 (mapcar (lambda (file)
                          (expand-file-name file project))
                        (projectile-current-project-files)))))
            projectile-known-projects))
@@ -2837,7 +2837,7 @@ See `projectile-cleanup-known-projects'."
 
 (defun projectile-ignored-projects ()
   "A list of projects that should not be save in `projectile-known-projects'."
-  (-map #'file-truename projectile-ignored-projects))
+  (mapcar #'file-truename projectile-ignored-projects))
 
 (defun projectile-ignored-project-p (project-root)
   "Return t if PROJECT-ROOT should not be added to `projectile-known-projects'."
@@ -2938,7 +2938,7 @@ available actions.
 
 See `def-projectile-commander-method' for defining new methods."
   (interactive)
-  (-let* ((choices (-map #'car projectile-commander-methods))
+  (-let* ((choices (mapcar #'car projectile-commander-methods))
           (prompt (concat "Commander [" choices "]: "))
           (ch (read-char-choice prompt choices))
           ((_ _ fn) (assq ch projectile-commander-methods)))

--- a/projectile.el
+++ b/projectile.el
@@ -79,7 +79,7 @@ buffer-local wherever it is set."
 
   ;; Added in Emacs 24.4
   (unless (fboundp 'string-suffix-p)
-    (defun string-suffix-p (suffix string  &optional ignore-case)
+    (defun string-suffix-p (suffix string &optional ignore-case)
       "Return non-nil if SUFFIX is a suffix of STRING.
 If IGNORE-CASE is non-nil, the comparison is done without paying
 attention to case differences."
@@ -114,9 +114,7 @@ attention to case differences."
                                     (goto-char (match-end 0))))
                            (progress-reporter-update progress-reporter (point)))
                          table))))
-           table))))
-
-  )
+           table)))))
 
 (defun projectile-trim-string (string)
   "Remove whitespace at the beginning and end of STRING."
@@ -1595,16 +1593,16 @@ Returns a list of possible files for users to choose.
 
 With FLEX-MATCHING, match any file that contains the base name of current file"
   (let* ((file-ext-list (projectile-associated-file-name-extensions current-file))
-         (fulldirname  (if (file-name-directory current-file)
-                           (file-name-directory current-file) "./"))
-         (dirname  (file-name-nondirectory (directory-file-name fulldirname)))
+         (fulldirname (if (file-name-directory current-file)
+                          (file-name-directory current-file) "./"))
+         (dirname (file-name-nondirectory (directory-file-name fulldirname)))
          (filename (projectile--file-name-sans-extensions current-file))
          (file-list (mapcar (lambda (ext)
                               (if flex-matching
                                   (concat ".*" filename ".*" "\." ext "\\'")
                                 (concat "^" filename
                                         (unless (equal ext "")
-                                          (concat  "\." ext))
+                                          (concat "\." ext))
                                         "\\'")))
                             file-ext-list))
          (candidates (-filter (lambda (project-file)
@@ -1617,7 +1615,7 @@ With FLEX-MATCHING, match any file that contains the base name of current file"
                                   (string-match file
                                                 (concat (file-name-base project-file)
                                                         (unless (equal (file-name-extension project-file) nil)
-                                                          (concat  "\." (file-name-extension project-file))))))
+                                                          (concat "\." (file-name-extension project-file))))))
                                 candidates))
                      file-list)))
          (candidates
@@ -1744,12 +1742,12 @@ With a prefix ARG invalidates the cache first."
 
 (defun projectile-sort-files (files)
   "Sort FILES according to `projectile-sort-order'."
-  (pcase projectile-sort-order
-    (`default files)
-    (`recentf (projectile-sort-by-recentf-first files))
-    (`recently-active (projectile-sort-by-recently-active-first files))
-    (`modification-time (projectile-sort-by-modification-time files))
-    (`access-time (projectile-sort-by-access-time files))))
+  (cl-case projectile-sort-order
+    (default files)
+    (recentf (projectile-sort-by-recentf-first files))
+    (recently-active (projectile-sort-by-recently-active-first files))
+    (modification-time (projectile-sort-by-modification-time files))
+    (access-time (projectile-sort-by-access-time files))))
 
 (defun projectile-sort-by-recentf-first (files)
   "Sort FILES by a recent first scheme."
@@ -2481,19 +2479,19 @@ For hg projects `monky-status' is used if available."
   (interactive)
   (or project-root (setq project-root (projectile-project-root)))
   (let ((vcs (projectile-project-vcs project-root)))
-    (pcase vcs
-      (`git
+    (cl-case vcs
+      (git
        (cond ((fboundp 'magit-status-internal)
               (magit-status-internal project-root))
              ((fboundp 'magit-status)
               (with-no-warnings (magit-status project-root)))
              (t
               (vc-dir project-root))))
-      (`hg
+      (hg
        (if (fboundp 'monky-status)
            (monky-status project-root)
          (vc-dir project-root)))
-      (_ (vc-dir project-root)))))
+      (t (vc-dir project-root)))))
 
 ;;;###autoload
 (defun projectile-recentf ()

--- a/projectile.el
+++ b/projectile.el
@@ -2546,8 +2546,8 @@ to run the replacement."
 (defun projectile-save-project-buffers ()
   "Save all project buffers."
   (interactive)
-  (--each (projectile-project-buffers)
-    (with-current-buffer it
+  (dolist (buf (projectile-project-buffers))
+    (with-current-buffer buf
       (when buffer-file-name
         (save-buffer)))))
 

--- a/projectile.el
+++ b/projectile.el
@@ -1204,7 +1204,9 @@ this case unignored files will be absent from FILES."
       projectile-globally-ignored-modes))))
 
 (defun projectile-difference (list1 list2)
-  (cl-set-difference list1 list2 :test #'equal))
+  (cl-remove-if
+   (lambda (x) (member x list2))
+   list1))
 
 (defun projectile-recently-active-files ()
   "Get list of recently active files.

--- a/projectile.el
+++ b/projectile.el
@@ -1072,18 +1072,20 @@ they are excluded from the results of this function."
 The function calls itself recursively until all sub-directories
 have been indexed.  The PROGRESS-REPORTER is updated while the
 function is executing."
-  (--mapcat
-   (unless (or (and patterns (projectile-ignored-rel-p it directory patterns))
-               (member (file-name-nondirectory (directory-file-name it))
-                       '("." ".." ".svn" ".cvs")))
-     (progress-reporter-update progress-reporter)
-     (if (file-directory-p it)
-         (unless (projectile-ignored-directory-p
-                  (file-name-as-directory it))
-           (projectile-index-directory it patterns progress-reporter))
-       (unless (projectile-ignored-file-p it)
-         (list it))))
-   (directory-files directory t)))
+  (apply 'append
+         (mapcar
+          (lambda (it)
+            (unless (or (and patterns (projectile-ignored-rel-p it directory patterns))
+                        (member (file-name-nondirectory (directory-file-name it))
+                                '("." ".." ".svn" ".cvs")))
+              (progress-reporter-update progress-reporter)
+              (if (file-directory-p it)
+                  (unless (projectile-ignored-directory-p
+                           (file-name-as-directory it))
+                    (projectile-index-directory it patterns progress-reporter))
+                (unless (projectile-ignored-file-p it)
+                  (list it)))))
+          (directory-files directory t))))
 
 (defun projectile-adjust-files (files)
   "First remove ignored files from FILES, then add back unignored files."
@@ -2094,7 +2096,9 @@ It assumes the test/ folder is at the same level as src/."
      (t (let ((grouped-candidates (projectile-group-file-candidates file candidates)))
           (if (= (length (car grouped-candidates)) 2)
               (-last-item (car grouped-candidates))
-            (projectile-completing-read "Switch to: " (--mapcat (cdr it) grouped-candidates))))))))
+            (projectile-completing-read
+             "Switch to: "
+             (apply 'append (mapcar 'cdr grouped-candidates)))))))))
 
 (defun projectile-find-matching-file (test-file)
   "Compute the name of a file matching TEST-FILE."
@@ -2117,7 +2121,9 @@ It assumes the test/ folder is at the same level as src/."
      (t (let ((grouped-candidates (projectile-group-file-candidates test-file candidates)))
           (if (= (length (car grouped-candidates)) 2)
               (-last-item (car grouped-candidates))
-            (projectile-completing-read "Switch to: " (--mapcat (cdr it) grouped-candidates))))))))
+            (projectile-completing-read
+             "Switch to: "
+             (apply 'append (mapcar 'cdr grouped-candidates)))))))))
 
 (defun projectile-grep-default-files ()
   "Try to find a default pattern for `projectile-grep'.

--- a/projectile.el
+++ b/projectile.el
@@ -118,9 +118,13 @@ attention to case differences."
 
 (defun projectile-trim-string (string)
   "Remove whitespace at the beginning and end of STRING."
-  (->> string
-       (replace-regexp-in-string "\\`[ \t\n\r]+" "")
-       (replace-regexp-in-string "[ \t\n\r]+\\'" "")))
+  (replace-regexp-in-string
+   "[ 	\n\r]+\\'"
+   ""
+   (replace-regexp-in-string
+    "\\`[ 	\n\r]+"
+    ""
+    string)))
 
 
 ;;; Customization
@@ -1163,9 +1167,13 @@ this case unignored files will be absent from FILES."
 (defun projectile-project-buffer-files ()
   "Get a list of project buffer files."
   (let ((project-root (projectile-project-root)))
-    (->> (projectile-buffers-with-file (projectile-project-buffers))
-         (mapcar (lambda (buffer)
-                 (file-relative-name (buffer-file-name buffer) project-root))))))
+    (mapcar
+     (lambda (buffer)
+       (file-relative-name
+        (buffer-file-name buffer)
+        project-root))
+     (projectile-buffers-with-file
+      (projectile-project-buffers)))))
 
 (defun projectile-project-buffer-p (buffer project-root)
   "Check if BUFFER is under PROJECT-ROOT."
@@ -2537,9 +2545,11 @@ For hg projects `monky-status' is used if available."
   "Return a list of recently visited files in a project."
   (and (boundp 'recentf-list)
        (let ((project-root (projectile-project-root)))
-         (->> recentf-list
-              (cl-remove-if-not (lambda (it) (string-prefix-p project-root it)))
-              (mapcar (lambda (it) (file-relative-name it project-root)))))))
+         (mapcar
+          (lambda (it) (file-relative-name it project-root))
+          (cl-remove-if-not
+           (lambda (it) (string-prefix-p project-root it))
+           recentf-list)))))
 
 (defun projectile-serialize-cache ()
   "Serializes the memory cache to the hard drive."
@@ -2666,10 +2676,15 @@ fallback to the original function."
                  (and (projectile-project-p)
                       (let ((root (projectile-project-root))
                             (dirs (cons "" (projectile-current-project-dirs))))
-                        (-when-let (full-filename (->> dirs
-                                                       (mapcar (lambda (it) (expand-file-name filename (expand-file-name it root))))
-                                                       (cl-remove-if-not #'file-exists-p)
-                                                       (car)))
+                        (-when-let (full-filename
+                                    (car (cl-remove-if-not
+                                          #'file-exists-p
+                                          (mapcar
+                                           (lambda (it)
+                                             (expand-file-name
+                                              filename
+                                              (expand-file-name it root)))
+                                           dirs))))
                           full-filename)))
                  ;; Fall back to the old argument
                  filename))

--- a/script/emacs.sh
+++ b/script/emacs.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-rm -f projectile.elc
-
-cask exec emacs -nw -Q --directory $PWD --eval "(progn (require 'projectile) (projectile-global-mode))" $@

--- a/test/elpa.el
+++ b/test/elpa.el
@@ -1,0 +1,5 @@
+(setq package-user-dir
+      (expand-file-name (format ".cask/%s/elpa" emacs-version)))
+(package-initialize)
+(add-to-list 'load-path default-directory)
+

--- a/test/elpa.el
+++ b/test/elpa.el
@@ -1,5 +1,5 @@
 (setq package-user-dir
-      (expand-file-name (format ".cask/%s/elpa" emacs-version)))
+      (expand-file-name (format ".elpa/%s/elpa" emacs-version)))
 (package-initialize)
 (add-to-list 'load-path default-directory)
 

--- a/test/make-compile.el
+++ b/test/make-compile.el
@@ -1,0 +1,3 @@
+(setq files '("projectile.el"))
+(setq byte-compile--use-old-handlers nil)
+(mapc #'byte-compile-file files)

--- a/test/make-update.el
+++ b/test/make-update.el
@@ -1,0 +1,26 @@
+(setq package-user-dir
+      (expand-file-name (format ".cask/%s/elpa" emacs-version)))
+(message "installing in %s ...\n" package-user-dir)
+(package-initialize)
+(setq package-archives
+      '(("melpa" . "http://melpa.org/packages/")
+        ("gnu" . "http://elpa.gnu.org/packages/")))
+(package-refresh-contents)
+
+(defconst dev-packages
+  '(helm noflet ag))
+
+(dolist (package dev-packages)
+  (unless (package-installed-p package)
+    (ignore-errors
+     (package-install package))))
+
+(save-window-excursion
+  (package-list-packages t)
+  (condition-case nil
+      (progn
+        (package-menu-mark-upgrades)
+        (package-menu-execute t))
+    (error
+     (message "All packages up to date"))))
+

--- a/test/make-update.el
+++ b/test/make-update.el
@@ -1,5 +1,5 @@
 (setq package-user-dir
-      (expand-file-name (format ".cask/%s/elpa" emacs-version)))
+      (expand-file-name (format ".elpa/%s/elpa" emacs-version)))
 (message "installing in %s ...\n" package-user-dir)
 (package-initialize)
 (setq package-archives

--- a/travis/provision.sh
+++ b/travis/provision.sh
@@ -22,14 +22,3 @@ apt_update
 # Install Emacs 24.x and Emacs snapshot
 apt emacs24 emacs24-el emacs24-common-non-dfsg \
     emacs-snapshot emacs-snapshot-el
-
-# Install Cask for Emacs dependency management
-CASK_VERSION=0.7.2
-CASK_DIR=/opt/cask-$CASK_VERSION
-CASK_ARCHIVE=https://github.com/cask/cask/archive/v$CASK_VERSION.tar.gz
-if ! [ -d "$CASK_DIR" -a -x "/$CASK_DIR/bin/cask" ]; then
-  sudo rm -rf "$CASK_DIR"
-  wget -O - $CASK_ARCHIVE | sudo tar xz -C /opt
-  # Bring Cask into $PATH
-  sudo ln -fs "$CASK_DIR/bin/cask" /usr/local/bin
-fi


### PR DESCRIPTION
Using e.g. the standard `cl-remove-if` in place of 4 aliases (`-remove`, `--remove`, `-reject`, `--reject`) improves code quality and eases new contributions and refactoring.

I've also rewritten `Makefile`, because any Cask-based `make test` stopped working on my system some time ago (and it fails intermittently on Travis CI as well).

I have more stuff on top of this PR in my develop branch, I'll open a new PR if this gets merged.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
