### PR TITLE
Unify modifications to find-file-hook

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3300,6 +3300,13 @@ entirely."
   :risky t
   :package-version '(projectile "0.12.0"))
 
+(defun projectile-find-file-hook-function ()
+  "Called by `find-file-hook' when `projectile-mode' is on."
+  (unless (file-remote-p default-directory)
+    (projectile-cache-files-find-file-hook)
+    (projectile-cache-projects-find-file-hook)
+    (projectile-visit-project-tags-table)))
+
 ;;;###autoload
 (define-minor-mode projectile-mode
   "Minor mode to assist project management and navigation.
@@ -3324,17 +3331,13 @@ Otherwise behave as if called interactively.
       (setq projectile-projects-cache
             (or (projectile-unserialize projectile-cache-file)
                 (make-hash-table :test 'equal))))
-    (add-hook 'find-file-hook #'projectile-cache-files-find-file-hook t t)
-    (add-hook 'find-file-hook #'projectile-cache-projects-find-file-hook t t)
-    (add-hook 'projectile-find-dir-hook #'projectile-cache-projects-find-file-hook)
-    (add-hook 'find-file-hook #'projectile-visit-project-tags-table t t)
+    (add-hook 'find-file-hook 'projectile-find-file-hook-function)
+    (add-hook 'projectile-find-dir-hook #'projectile-cache-projects-find-file-hook t)
     (add-hook 'dired-before-readin-hook #'projectile-cache-projects-find-file-hook t t)
     (ad-activate 'compilation-find-file)
     (ad-activate 'delete-file))
    (t
-    (remove-hook 'find-file-hook #'projectile-cache-files-find-file-hook t)
-    (remove-hook 'find-file-hook #'projectile-cache-projects-find-file-hook t)
-    (remove-hook 'find-file-hook #'projectile-visit-project-tags-table t)
+    (remove-hook 'find-file-hook #'projectile-find-file-hook-function)
     (remove-hook 'dired-before-readin-hook #'projectile-cache-projects-find-file-hook t)
     (ad-deactivate 'compilation-find-file)
     (ad-deactivate 'delete-file))))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -198,19 +198,15 @@
 
 (ert-deftest projectile-test-setup-hook-functions-projectile-mode ()
   (projectile-mode 1)
-  (should (and (memq 'projectile-cache-files-find-file-hook find-file-hook)
-               (memq 'projectile-cache-projects-find-file-hook find-file-hook)))
+  (should (memq 'projectile-find-file-hook-function find-file-hook))
   (projectile-mode -1)
-  (should (and (not (memq 'projectile-cache-files-find-file-hook find-file-hook))
-               (not (memq 'projectile-cache-projects-find-file-hook find-file-hook)))))
+  (should (not (memq 'projectile-find-file-hook-function find-file-hook))))
 
 (ert-deftest projectile-test-setup-hook-functions-projectile-global-mode ()
   (projectile-global-mode 1)
-  (should (and (memq 'projectile-cache-files-find-file-hook find-file-hook)
-               (memq 'projectile-cache-projects-find-file-hook find-file-hook)))
+  (should (memq 'projectile-find-file-hook-function find-file-hook))
   (projectile-global-mode -1)
-  (should (and (not (memq 'projectile-cache-files-find-file-hook find-file-hook))
-               (not (memq 'projectile-cache-projects-find-file-hook find-file-hook)))))
+  (should (not (memq 'projectile-find-file-hook-function find-file-hook))))
 
 (ert-deftest projectile-test-relevant-known-projects ()
   (let ((projectile-known-projects '("/path/to/project1" "/path/to/project2")))


### PR DESCRIPTION
Currently, `projectile-mode` adds 3 functions to `find-file-hook`. Moreover, it does so locally, while most people use `projectile-global-mode`. This means it's really hard to suppress the modifications to the hook, since it would have to be done for many buffers separately.

I propose to add only a single function to `find-file-hook` that calls all 3. Moreover, consider modifying `find-file-hook` globally, not locally.

One more thing: projectile's modification to `find-file-hook` makes it really slow to open a file on two unrelated remotes that I have: around 20 second delay difference. Should there be a variable to disable the hook functions on a remote file, or do you want to do it uniformly?
