### PR TITLE
load dir-locals before switching project

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2843,12 +2843,14 @@ With a prefix ARG invokes `projectile-commander' instead of
 Invokes the command referenced by `projectile-switch-project-action' on switch.
 With a prefix ARG invokes `projectile-commander' instead of
 `projectile-switch-project-action.'"
-  (let* ((default-directory project-to-switch)
-         (switch-project-action (if arg
+  (let ((switch-project-action (if arg
                                     'projectile-commander
                                   projectile-switch-project-action)))
     (run-hooks 'projectile-before-switch-project-hook)
-    (funcall switch-project-action)
+    (with-temp-buffer
+      (setq default-directory project-to-switch)
+      (hack-dir-local-variables-non-file-buffer)
+      (funcall switch-project-action))
     (run-hooks 'projectile-after-switch-project-hook)))
 
 ;;;###autoload

--- a/projectile.el
+++ b/projectile.el
@@ -2847,10 +2847,11 @@ With a prefix ARG invokes `projectile-commander' instead of
                                     'projectile-commander
                                   projectile-switch-project-action)))
     (run-hooks 'projectile-before-switch-project-hook)
+    ;; use a temporary buffer to load PROJECT-TO-SWITCH's dir-locals before calling SWITCH-PROJECT-ACTION
     (with-temp-buffer
-      (setq default-directory project-to-switch)
-      (hack-dir-local-variables-non-file-buffer)
-      (funcall switch-project-action))
+      (let ((default-directory project-to-switch))
+        (hack-dir-local-variables-non-file-buffer)
+        (funcall switch-project-action)))
     (run-hooks 'projectile-after-switch-project-hook)))
 
 ;;;###autoload


### PR DESCRIPTION
Modified function `projectile-switch-project-by-name`. Instead of calling `switch-project-action` from the current buffer, this is done in a temporary buffer after calling `hack-dir-local-variables-non-file-buffer`.

I think this fixes #413 and #1005 . It is the same solution I proposed there, but maybe easier to test for you with a PR.

Sorry I don't know how to add tests or `make test`. I don't think the changelog or readme should be updated since the function is not "visible".

Thanks

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

