### PR TITLE
Improve projectile-project-buffer-p for nested projects

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1191,7 +1191,9 @@ this case unignored files will be absent from FILES."
          (string-equal (file-remote-p default-directory)
                        (file-remote-p project-root))
          (not (string-match-p "^http\\(s\\)?://" default-directory))
-         (string-prefix-p project-root (file-truename default-directory) (eq system-type 'windows-nt)))))
+         (eq t (compare-strings project-root nil nil
+                                (or (ignore-errors (projectile-project-root)) "") nil nil
+                                (eq system-type 'windows-nt))))))
 
 (defun projectile-ignored-buffer-p (buffer)
   "Check if BUFFER should be ignored."


### PR DESCRIPTION
Currently if project A is in a subdirectory of project B which is ignored in project B, then project A buffers are considered part of both project A and project B by `projectile-project-buffer-p`.

Perhaps I'm wrong and this behavior is intended, but it seems to me that it would be better to consider these buffers as part of project A only, so as not to appear when working on project B and calling `projectile-switch-to-buffer`.

Hence I made a simple modification to `projectile-project-buffer-p` to make it so. I tested it and it works for me, but if it matters note that I don't have remote projects.

---

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):
- [X] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
