### PR TITLE
Fix URL of contribution guidelines in docs

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -20,7 +20,7 @@ Patches in any form are always welcome! GitHub pull requests are even better! :-
 
 Before submitting a patch or a pull request make sure all tests are
 passing and that your patch is in line with the [contribution
-guidelines](https://github.com/bbatsov/projectile/blob/master/.github/CONTRIBUTING.md).
+guidelines](https://github.com/bbatsov/projectile/blob/master/CONTRIBUTING.md).
 
 ## Documentation
 


### PR DESCRIPTION
When looking to contribute to the code part of the project, I noticed that the link to contribution guidelines on the doc site was broken. This fixes it!

