### PR TITLE
Test file cannot be implementation file to itself

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2290,7 +2290,8 @@ It assumes the test/ folder is at the same level as src/."
                      (string-equal (concat test-prefix name) basename))
                    (when test-suffix
                      (string-equal (concat name test-suffix) basename)))))
-           (projectile-current-project-files))))
+           (delete (file-relative-name test-file (projectile-project-root))
+                   (projectile-current-project-files)))))
     (cond
      ((null candidates) nil)
      ((= (length candidates) 1) (car candidates))


### PR DESCRIPTION
This is basically a question with a little workaround shown in code.

Main problem I'm facing with is that my project is standard Clojure Luminus one and its tests are not named using any suffix or prefix but rather pointed by project structure. Therefore, test file for `my-project/src/clj/my-project/handler.clj` is `my-project/test/clj/my-project/test/handler.clj`. It means that standard `projectile-toggle-between-implementation-and-test` can't work since its test and implementation finding mechanism is based on suffixes and prefixes by project type, correct me if I'm wrong.  
So the basic question is - How can I use `projectile-toggle-between-implementation-and-test` with project structure like this?
### What those proposed code changes have to do with my problem?

If I got it right, they just ensure that currently visited test file cannot be considered as implementation file to itself. With those changes I can add following to `.dir-locals.el`:

``` elisp
((clojure-mode
  . ((projectile-test-suffix-function
      . (lambda (_) "")))))
```

and it will accomplish that all files in my project are considered as test files (`projectile-test-file-p` will be true for every file). Hence, for every file in project it will call `projectile-find-matching-file` and will open file with the same name as currently visited, which is usually correct one. Exceptional case is when there is multiple files with same name and then it will prompt to choose one of them.

This evidently is not the solution but rather just a naive trick. It is very likely that there is a simple and elegant solution that I've missed.

---

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):
- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
