### PR TITLE
Ignore .elpa and project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /elpa
+/.elpa
 /.cask
 *.elc
 *~
 [#]*[#]
 /TAGS
+/project


### PR DESCRIPTION
Running `make` with Emacs 25.1.1 results in an _.elpa_ and _project_ directory that are not ignored.
