### PR TITLE
Use helm-build-sync-source

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1597,12 +1597,15 @@ project-root for every file."
            ((eq projectile-completion-system 'helm)
             (if (fboundp 'helm)
                 (helm :sources
-                      `((name . ,prompt)
-                        (candidates . ,choices)
-                        (action . ,(if action
-                                       (prog1 action
-                                         (setq action nil))
-                                     #'identity))))
+                      (helm-build-sync-source "Projectile"
+                        :candidates choices
+                        :action (if action
+                                    (prog1 action
+                                      (setq action nil))
+                                  #'identity))
+                      :prompt prompt
+                      :input initial-input
+                      :buffer "*helm-projectile*")
               (user-error "Please install helm from \
 https://github.com/emacs-helm/helm")))
            ((eq projectile-completion-system 'grizzl)


### PR DESCRIPTION
This PR fixes a problem I'm having on Emacs 25 in combination with Helm from a recent Melpa installation.

The way `helm` is called in `projectile-completing-read` is apparently problematic: the `:sources` argument gets passed a plain alist instead of a `helm-source` instance, thereby missing some slots which the constructor usually initializes. This leads to unusual matching behaviour, e.g. the input is not split on spaces properly, as Helm usually does.

The PR adds calling `helm-build-sync-source` instead. Moreover, it adds passing the `:prompt`, `:input` and `:buffer` arguments to `helm`.
---

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):
- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
