### PR TITLE
Add R DESCRIPTION file to `projectile-project-root-files`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changes
 
+* Add R DESCRIPTION file to `projectile-project-root-files`.
 * Ignore backup files in `projectile-get-other-files`.
 * Ignore Ensime cache directory, `.ensime_cache`.
 * [#364](https://github.com/bbatsov/projectile/issues/364): `projectile-add-known-project` can now be used interactively.

--- a/projectile.el
+++ b/projectile.el
@@ -307,6 +307,7 @@ If variable `projectile-project-name' is non-nil, this function will not be used
     "mix.exs"            ; Elixir mix project file
     "stack.yaml"         ; Haskell's stack tool based project
     "info.rkt"           ; Racket package description file
+    "DESCRIPTION"        ; R package description file
     "TAGS"               ; etags/ctags are usually in the root of project
     "GTAGS"              ; GNU Global tags
     )


### PR DESCRIPTION
Without this, a GTAGS index in a parent directory takes precendence, which is generally undesirable.
