### PR TITLE
fix incorrect hyperlink for command map binding

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -82,7 +82,7 @@ commands. Here's an example that adds `super-p` as the extra prefix:
 
 You can also bind the `projectile-command-map` to any other map you'd
 like (including the global keymap).  Prelude does this for its
-[prelude-mode-map](https://github.com/bbatsov/prelude/blob/master/core/prelude-mode.el#L68).
+[prelude-mode-map](https://github.com/bbatsov/prelude/blob/master/core/prelude-mode.el#L71).
 
 For some common commands you might want to take a little shortcut and
 leverage the fairly unused `Super` key (by default `Command` on Mac


### PR DESCRIPTION
This is a simple typo change in the docs that points to the proper example of binding projectile command map.


Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

