### PR TITLE
Helm build sync source

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1598,7 +1598,7 @@ project-root for every file."
            ((eq projectile-completion-system 'helm)
             (if (fboundp 'helm)
                 (helm :sources
-                      (helm-build-sync-source "Projectile"
+                      (helm-make-source "Projectile" 'helm-source-sync
                         :candidates choices
                         :action (if action
                                     (prog1 action


### PR DESCRIPTION
After today's Melpa update containing  #1076, I noticed a mistake in the PR: `helm-build-sync-source` is a macro and might not be available at byte compile time. I fixed that by inlining the rather trivial expansion of the macro.

Sorry, should have noticed that before. It still generates a bytecode warning ("`helm-make-source` not known to be defined"); I'm not sure how to fix that properly.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
