### PR TITLE
Prefer xref to find-tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Ignore Ensime cache directory, `.ensime_cache`.
 * [#364](https://github.com/bbatsov/projectile/issues/364): `projectile-add-known-project` can now be used interactively.
 * `projectile-mode` is now a global mode.
+* `projectile-find-tag` now defaults to xref on Emacs 25.1+.
 
 ### Bugs fixed
 


### PR DESCRIPTION
As of Emacs 25.1, `find-tag` is deprecated in favour of `xref-find-definitions`, so favour that command if it's defined.

Since `etags-select` has not been maintained since 2013, and xref offers all the same functionality (as far as I'm aware), I've set `'auto` to prefer xref over etags-seelct.

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
