### PR TITLE
Simplify default projectile-mode-line value to avoid slowdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#364](https://github.com/bbatsov/projectile/issues/364): `projectile-add-known-project` can now be used interactively.
 * `projectile-mode` is now a global mode.
 * `projectile-find-tag` now defaults to xref on Emacs 25.1+.
+* `projectile-mode-line` now defaults to just "Projectile" to avoid potential performance problems when mode line must be redisplayed.
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -3425,9 +3425,7 @@ is chosen."
 
 ;;;###autoload
 (defcustom projectile-mode-line
-  '(:eval (if (file-remote-p default-directory)
-              " Projectile"
-            (format " Projectile[%s]" (projectile-project-name))))
+  " Projectile"
   "Mode line lighter for Projectile.
 
 The value of this variable is a mode line template as in


### PR DESCRIPTION
Scrolling in projectile enabled buffers is very slow for me. Profiler shows:

```
- command-execute                                      13,429,332,051  99%
 - call-interactively                                  13,429,332,051  99%
  - next-line                                          13,401,238,930  99%
   - funcall                                           13,401,238,930  99%
    - #<compiled 0x181cb29>                            13,401,238,930  99%
     - line-move                                       13,401,238,930  99%
      - line-move-partial                              13,326,806,098  98%
       - pos-visible-in-window-p                       11,771,693,162  87%
        - eval                                         11,771,690,058  87%
         - if                                          11,758,234,443  86%
          - format                                     11,758,209,879  86%
           - projectile-project-name                   11,758,209,879  86%
            - funcall                                  11,758,209,879  86%
             - #<compiled 0xa90a37>                    11,758,209,879  86%
              + projectile-project-root                11,758,209,879  86%
```

Turns out deep down in C code `pos-visible-in-window-p` calls `pos-visible-p` C function which in turn redisplays mode line ([here](https://github.com/emacs-mirror/emacs/blob/master/src/xdisp.c#L1331)). This evaluates `projectile-mode-line` sexp and calls very slow `projectile-project-name`.

I suggest keeping `projectile-mode-line` as simple as possible until issue #1003 is fixed.

I use:
* `GNU Emacs 24.5.1 (x86_64-pc-linux-gnu, GTK+ Version 3.18.9) of 2016-04-25 on lgw01-10, modified by Debian`
* projectile `20161108.729`
