### PR TITLE
Silence byte-compiler

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1598,7 +1598,8 @@ project-root for every file."
            ((eq projectile-completion-system 'default)
             (completing-read prompt choices nil nil initial-input))
            ((eq projectile-completion-system 'helm)
-            (if (fboundp 'helm)
+            (if (and (fboundp 'helm)
+                     (fboundp 'helm-make-source))
                 (helm :sources
                       (helm-make-source "Projectile" 'helm-source-sync
                         :candidates choices


### PR DESCRIPTION
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings

On the contrary, it's fixing a bytecode warning ;-)