### PR TITLE
Remove package.json from root file list

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -300,7 +300,6 @@ If variable `projectile-project-name' is non-nil, this function will not be used
     "requirements.txt"   ; Pip file
     "setup.py"           ; Setuptools file
     "tox.ini"            ; Tox file
-    "package.json"       ; npm package file
     "gulpfile.js"        ; Gulp build file
     "Gruntfile.js"       ; Grunt project file
     "bower.json"         ; Bower project file


### PR DESCRIPTION
`package.json` should not be a part of the root files list because;

* A lot of projects keep JS code in a subfolder. [example 1](https://github.com/olebedev/go-starter-kit) [example 2](https://github.com/olebedev/go-starter-kit)
* A lot of projects have multiple packages. See [learna](https://github.com/lerna/lerna)

I think `package.json` is not needed in the root file list. People could either initialize a version system or add a projectile file.