### PR TITLE
Update other-file-alist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#364](https://github.com/bbatsov/projectile/issues/364): `projectile-add-known-project` can now be used interactively.
 * `projectile-mode` is now a global mode.
 * `projectile-find-tag` now defaults to xref on Emacs 25.1+.
+* Add relation between `.h` and `.cc` files in `projectile-other-file-alist`.
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -1681,8 +1681,8 @@ https://github.com/abo-abo/swiper")))
     ("c" . ("h"))
     ("m" . ("h"))
     ("mm" . ("h"))
-    ("h" . ("c" "cpp" "ipp" "hpp" "cxx" "ixx" "hxx" "m" "mm"))
-    ("cc" . ("hh" "hpp"))
+    ("h" . ("c" "cc" "cpp" "ipp" "hpp" "cxx" "ixx" "hxx" "m" "mm"))
+    ("cc" . ("h" "hh" "hpp"))
     ("hh" . ("cc"))
 
     ;; vertex shader and fragment shader extensions in glsl


### PR DESCRIPTION
Some big projects use `.cc` for implementation files and `.h` for headers, notably Chromium and WebRTC. This commit updates the defaults to support this.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
