### PR TITLE
Cache the name of the current Projectile project

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -912,9 +912,10 @@ buffer. This is used to detect a change in `buffer-file-name',
 which triggers a reset of `projectile-cached-project-name'.")
 
 (defun projectile-reset-cached-project-name ()
-  "Resets the value of `projectile-cached-project-name' to nil,
-so that it is automatically recalculated the next time
-`projectile-project-name' is called."
+  "Reset the value of `projectile-cached-project-name' to nil.
+
+This means that it is automatically recalculated the next time
+function `projectile-project-name' is called."
   (interactive)
   (setq projectile-cached-project-name nil))
 


### PR DESCRIPTION
This improves performance slightly in many cases, and massively in a
few cases. The cache is invalidated whenever `buffer-file-name`
changes, so it should be pretty safe.

From #893:

> I've disabled the dynamic modeline for remote buffers as a temporary
  workaround. I don't use tramp and I don't plan to fix this, so it's
  up to someone else.

How does this solution look?