### PR TITLE
[Fix #1067] Added hook that "knows" the current project name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Consider Ensime configuration file as root marker, `.ensime`.
 * [#1057](https://github.com/bbatsov/projectile/issues/1057): Make it possible to disable automatic project tracking via `projectile-track-known-projects-automatically`.
+* [#1067](https://github.com/bbatsov/projectile/issues/1067): Add a hook that runs right before `switch-project-action` within the new project directory.
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -3020,6 +3020,7 @@ With a prefix ARG invokes `projectile-commander' instead of
     (with-temp-buffer
       (let ((default-directory project-to-switch))
         (hack-dir-local-variables-non-file-buffer)
+        (run-hooks 'projectile-before-project-action-hook)
         (funcall switch-project-action)))
     (run-hooks 'projectile-after-switch-project-hook)))
 


### PR DESCRIPTION
Added the `projectile-before-project-action-hook` hook that is triggered right before running `switch-project-action`. This hook is aware of the new `default-directory` and therefore is aware of the new project directory.