### PR TITLE
projectile-after-switch-project-hook with arg PROJECT-TO-SWITCH

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3021,7 +3021,8 @@ With a prefix ARG invokes `projectile-commander' instead of
       (with-temp-buffer
         (hack-dir-local-variables-non-file-buffer))
       (funcall switch-project-action))
-    (run-hooks 'projectile-after-switch-project-hook)))
+    (run-hooks 'projectile-after-switch-project-hook)
+    (run-hook-with-args 'projectile-after-switch-which-project-hook project-to-switch)))
 
 ;;;###autoload
 (defun projectile-find-file-in-directory (&optional directory)
@@ -3060,6 +3061,11 @@ This command will first prompt for the directory the file is in."
 
 (defcustom projectile-after-switch-project-hook nil
   "Hooks run right after project is switched."
+  :group 'projectile
+  :type 'hook)
+
+(defcustom projectile-after-switch-which-project-hook nil
+  "Hooks run right after project is switched with arg PROJECT-TO-SWITCH."
   :group 'projectile
   :type 'hook)
 


### PR DESCRIPTION
Here is my situation: I want to set `flycheck-javascript-eslint-executable` to project local `eslint` after switching project, so I need to know the target project dir to check the existence of `PROJECT-TO-SWITCH/node_modules/.bin/eslint`, while I can't work it out by `projectile-after-switch-project-hook` and `default-directory`.

My solution is: add a hook `projectile-after-switch-which-project-hook` which is passed an arg PROJECT-TO-SWITCH.