### PR TITLE
Very minor grammatical fixes to projectile-indexing-method documentation

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -142,8 +142,8 @@ attention to case differences."
 There are two indexing methods - native and alien.
 
 The native method is implemented in Emacs Lisp (therefore it is
-native to Emacs).  It's advantage is that is portable and will
-work everywhere that Emacs does.  It's disadvantage is that is a
+native to Emacs).  Its advantage is that it is portable and will
+work everywhere that Emacs does.  Its disadvantage is that it is a
 bit slow (especially for large projects).  Generally it's a good
 idea to pair the native indexing method with caching.
 


### PR DESCRIPTION
Very minor grammar fix in the documentation for the projectile-indexing-method
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [N/A] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [N/A] You've updated the changelog (if adding/changing user-visible functionality)
- [N/A] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
