### PR TITLE
Added ability to specify test suffix and test prefix during project registration

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -229,6 +229,22 @@ should install and add to the PATH
 [Exuberant Ctags](http://ctags.sourceforge.net/) instead of a plain ctags, which
 ships with Emacs distribution.
 
+### Adding Custom Project Types
+If a project you are working on is recognized incorrectly or you want to add your own type of projects you can add following to your Emacs initialization code
+
+```el
+(projectile-register-project-type 'npm '("package.json") "npm build" "npm test" "npm start" ".spec" nil)
+```
+What this does is:
+1. add your own type of project, in this case `npm` package.
+2. add a file in a root of the project that helps to identify the type, in this case it is `package.json`.
+3. add *compile-command*, in this case it is `npm build`.
+4. add *test-command*, in this case it is `npm test`.
+5. add *run-command*, in this case it is `npm start`.
+6. add test files suffix for toggling between implementation/test files, in this case it is `.spec`, so the implementation/test file pair could be `service.js`/`service.spec.js` for example.
+7. add test files prefix for toggling between implementation/test files, in this case it is `nil`. 
+
+
 ### Customizing project root files
 
 You can set the values of `projectile-project-root-files`,

--- a/projectile.el
+++ b/projectile.el
@@ -2061,16 +2061,22 @@ With a prefix ARG invalidates the cache first."
   "A hash table holding all project types that are known to Projectile.")
 
 (defun projectile-register-project-type
-    (project-type marker-files &optional compile-cmd test-cmd run-cmd)
+    (project-type marker-files &optional compile-cmd test-cmd run-cmd spec-suffix spec-prefix)
   "Register a project type with projectile.
 
 A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
-a COMPILE-CMD, a TEST-CMD, and a RUN-CMD."
-  (puthash project-type (list 'marker-files marker-files
+a COMPILE-CMD, a TEST-CMD, a RUN-CMD, SPEC-SUFFIX and a SPEC-PREFIX."
+  (let ((project-plist (list 'marker-files marker-files
                               'compile-command compile-cmd
                               'test-command test-cmd
-                              'run-command run-cmd)
-           projectile-project-types))
+                              'run-command run-cmd)))
+    ;; There is no way for the function to distinguish between an explicit argument of nil and an omitted argument. However, the body of the function is free to consider nil an abbreviation for some other meaningful value
+    (when spec-suffix
+      (plist-put project-plist 'spec-suffix spec-suffix))
+    (when spec-prefix
+      (plist-put project-plist 'spec-prefix spec-prefix))
+    (puthash project-type project-plist
+             projectile-project-types)))
 
 (defun projectile-cabal ()
   "Check if a project contains *.cabal files but no stack.yaml file."
@@ -2119,6 +2125,7 @@ a COMPILE-CMD, a TEST-CMD, and a RUN-CMD."
 (projectile-register-project-type 'go projectile-go-function "go build ./..." "go test ./...")
 (projectile-register-project-type 'racket '("info.rkt") nil "raco test .")
 (projectile-register-project-type 'elixir '("mix.exs") "mix compile" "mix test")
+(projectile-register-project-type 'npm '("package.json") "npm build" "npm test")
 
 (defvar-local projectile-project-type nil
   "Buffer local var for overriding the auto-detected project type.
@@ -2248,24 +2255,36 @@ It assumes the test/ folder is at the same level as src/."
   (find-file
    (projectile-find-implementation-or-test (buffer-file-name))))
 
+
+(defun projectile--registration-value-or-default (project-type key &optional default-value)
+  "Returs project registration value for a KEY for a project PROJECT-TYPE or if nothing DEFAULT-VALUE"
+  (let ((project (gethash project-type projectile-project-types)))
+    (if (and project (plist-member project key))
+        (plist-get project key)
+      default-value)))
+
 (defun projectile-test-prefix (project-type)
   "Find default test files prefix based on PROJECT-TYPE."
-  (cond
-   ((member project-type '(django python-pip python-pkg python-tox)) "test_")
-   ((member project-type '(emacs-cask)) "test-")
-   ((member project-type '(lein-midje)) "t_")))
+  (cl-flet ((prefix (apply-partially #'projectile--registration-value-or-default project-type 'spec-prefix)))
+      (cond
+       ((member project-type '(django python-pip python-pkg python-tox))  (prefix "test_"))
+       ((member project-type '(emacs-cask)) (prefix "test-"))
+       ((member project-type '(lein-midje)) (prefix "t_"))
+       (t (prefix)))))
 
 (defun projectile-test-suffix (project-type)
   "Find default test files suffix based on PROJECT-TYPE."
-  (cond
-   ((member project-type '(rebar)) "_SUITE")
-   ((member project-type '(emacs-cask)) "-test")
-   ((member project-type '(rails-rspec ruby-rspec)) "_spec")
-   ((member project-type '(rails-test ruby-test lein-test boot-clj go elixir)) "_test")
-   ((member project-type '(scons)) "test")
-   ((member project-type '(maven symfony)) "Test")
-   ((member project-type '(gradle gradlew grails)) "Spec")
-   ((member project-type '(sbt)) "Spec")))
+  (cl-flet ((suffix (apply-partially #'projectile--registration-value-or-default project-type 'spec-suffix)))
+    (cond
+     ((member project-type '(rebar)) (suffix "_SUITE"))
+     ((member project-type '(emacs-cask)) (suffix "-test"))
+     ((member project-type '(rails-rspec ruby-rspec)) (suffix "_spec"))
+     ((member project-type '(rails-test ruby-test lein-test boot-clj go elixir)) (suffix "_test"))
+     ((member project-type '(scons)) (suffix "test"))
+     ((member project-type '(maven symfony)) (suffix "Test"))
+     ((member project-type '(gradle gradlew grails)) (suffix "Spec"))
+     ((member project-type '(sbt)) (suffix "Spec"))
+     (t (suffix)))))
 
 (defun projectile-dirname-matching-count (a b)
   "Count matching dirnames ascending file paths."


### PR DESCRIPTION
Added ability to add test files prefix and suffix during project type registration. Should improve toggling between implementation and test files functionality. 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [x ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
