### PR TITLE
Added ability to specify test suffix and test prefix during project registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Consider Ensime configuration file as root marker, `.ensime`.
 * [#1057](https://github.com/bbatsov/projectile/issues/1057): Make it possible to disable automatic project tracking via `projectile-track-known-projects-automatically`.
+* Added ability to specify test files suffix and prefix at the project registration.
 
 ### Changes
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -229,6 +229,25 @@ should install and add to the PATH
 [Exuberant Ctags](http://ctags.sourceforge.net/) instead of a plain ctags, which
 ships with Emacs distribution.
 
+### Adding Custom Project Types
+
+If a project you are working on is recognized incorrectly or you want to add your own type of projects you can add following to your Emacs initialization code
+
+```el
+(projectile-register-project-type 'npm '("package.json")
+				  :compile "npm build"
+				  :test "npm test"
+				  :run "npm start"
+				  :test-suffix ".spec")
+```
+What this does is:
+1. add your own type of project, in this case `npm` package.
+2. add a file in a root of the project that helps to identify the type, in this case it is `package.json`.
+3. add *compile-command*, in this case it is `npm build`.
+4. add *test-command*, in this case it is `npm test`.
+5. add *run-command*, in this case it is `npm start`.
+6. add test files suffix for toggling between implementation/test files, in this case it is `.spec`, so the implementation/test file pair could be `service.js`/`service.spec.js` for example.
+
 ### Customizing project root files
 
 You can set the values of `projectile-project-root-files`,

--- a/projectile.el
+++ b/projectile.el
@@ -2060,17 +2060,27 @@ With a prefix ARG invalidates the cache first."
 (defvar projectile-project-types (make-hash-table)
   "A hash table holding all project types that are known to Projectile.")
 
-(defun projectile-register-project-type
-    (project-type marker-files &optional compile-cmd test-cmd run-cmd)
+(cl-defun projectile-register-project-type
+    (project-type marker-files &key compile test run test-suffix test-prefix)
   "Register a project type with projectile.
 
-A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
-a COMPILE-CMD, a TEST-CMD, and a RUN-CMD."
-  (puthash project-type (list 'marker-files marker-files
-                              'compile-command compile-cmd
-                              'test-command test-cmd
-                              'run-command run-cmd)
-           projectile-project-types))
+A project type is defined by PROJECT-TYPE, a set of MARKER-FILES, and optional keyword arguments
+COMPILE which specifies a command that builds the project,
+TEST which specified a command that tests the project,
+RUN which specifies a command that runs the project,
+TEST-SUFFIX which specifies test file suffix, and
+TEST-PREFIX which specifies test file prefix."
+  (let ((project-plist (list 'marker-files marker-files
+                              'compile-command compile
+                              'test-command test
+                              'run-command run)))
+    ;; There is no way for the function to distinguish between an explicit argument of nil and an omitted argument. However, the body of the function is free to consider nil an abbreviation for some other meaningful value
+    (when test-suffix
+      (plist-put project-plist 'test-suffix test-suffix))
+    (when test-prefix
+      (plist-put project-plist 'test-prefix test-prefix))
+    (puthash project-type project-plist
+             projectile-project-types)))
 
 (defun projectile-cabal ()
   "Check if a project contains *.cabal files but no stack.yaml file."
@@ -2089,36 +2099,97 @@ a COMPILE-CMD, a TEST-CMD, and a RUN-CMD."
   :group 'projectile
   :type 'function)
 
-(projectile-register-project-type 'emacs-cask '("Cask") "cask install")
-(projectile-register-project-type 'rails-rspec '("Gemfile" "app" "lib" "db" "config" "spec") "bundle exec rails server" "bundle exec rspec")
-(projectile-register-project-type 'rails-test '("Gemfile" "app" "lib" "db" "config" "test") "bundle exec rails server" "bundle exec rake test")
-(projectile-register-project-type 'symfony '("composer.json" "app" "src" "vendor") "app/console server:run" "phpunit -c app ")
-(projectile-register-project-type 'ruby-rspec '("Gemfile" "lib" "spec") "bundle exec rake" "bundle exec rspec")
-(projectile-register-project-type 'ruby-test '("Gemfile" "lib" "test") "bundle exec rake" "bundle exec rake test")
-(projectile-register-project-type 'django '("manage.py") "python manage.py runserver" "python manage.py test")
-(projectile-register-project-type 'python-pip '("requirements.txt") "python setup.by build" "python -m unittest discover")
-(projectile-register-project-type 'python-pkg '("setup.py") "python setup.py build" "python -m unittest discover")
-(projectile-register-project-type 'python-tox '("tox.ini") "tox -r --notest" "tox")
-(projectile-register-project-type 'scons '("SConstruct") "scons" "scons test")
-(projectile-register-project-type 'maven '("pom.xml") "mvn clean install" "mvn test")
-(projectile-register-project-type 'gradle '("build.gradle") "gradle build" "gradle test")
-(projectile-register-project-type 'gradlew '("gradlew") "./gradlew build" "./gradlew test")
-(projectile-register-project-type 'grails '("application.properties" "grails-app") "grails package" "grails test-app")
-(projectile-register-project-type 'lein-test '("project.clj") "lein compile" "lein test")
-(projectile-register-project-type 'lein-midje '("project.clj" ".midje.clj") "lein compile" "lein midje")
-(projectile-register-project-type 'boot-clj '("build.boot") "boot aot" "boot test")
-(projectile-register-project-type 'rebar '("rebar.config") "rebar" "rebar eunit")
-(projectile-register-project-type 'sbt '("build.sbt") "sbt compile" "sbt test")
-(projectile-register-project-type 'make '("Makefile") "make" "make test")
-(projectile-register-project-type 'grunt '("Gruntfile.js") "grunt" "grunt test")
-(projectile-register-project-type 'gulp '("gulpfile.js") "gulp" "gulp test")
-(projectile-register-project-type 'haskell-stack '("stack.yaml") "stack build" "stack build --test")
-(projectile-register-project-type 'haskell-cabal #'projectile-cabal "cabal build" "cabal test")
-(projectile-register-project-type 'rust-cargo '("Cargo.toml") "cargo build" "cargo test")
-(projectile-register-project-type 'r '("DESCRIPTION") "R CMD INSTALL --with-keep.source ." (concat "R CMD check -o " temporary-file-directory " ."))
-(projectile-register-project-type 'go projectile-go-function "go build ./..." "go test ./...")
-(projectile-register-project-type 'racket '("info.rkt") nil "raco test .")
-(projectile-register-project-type 'elixir '("mix.exs") "mix compile" "mix test")
+(projectile-register-project-type 'emacs-cask '("Cask")
+                                  :compile "cask install")
+(projectile-register-project-type 'rails-rspec '("Gemfile" "app" "lib" "db" "config" "spec")
+                                  :compile "bundle exec rails server"
+                                  :test "bundle exec rspec")
+(projectile-register-project-type 'rails-test '("Gemfile" "app" "lib" "db" "config" "test")
+                                  :compile "bundle exec rails server"
+                                  :test "bundle exec rake test")
+(projectile-register-project-type 'symfony '("composer.json" "app" "src" "vendor")
+                                  :compile "app/console server:run"
+                                  :test "phpunit -c app ")
+(projectile-register-project-type 'ruby-rspec '("Gemfile" "lib" "spec")
+                                  :compile "bundle exec rake"
+                                  :test "bundle exec rspec")
+(projectile-register-project-type 'ruby-test '("Gemfile" "lib" "test")
+                                  :compile"bundle exec rake"
+                                  :test "bundle exec rake test")
+(projectile-register-project-type 'django '("manage.py")
+                                  :compile "python manage.py runserver"
+                                  :test "python manage.py test")
+(projectile-register-project-type 'python-pip '("requirements.txt")
+                                  :compile "python setup.by build"
+                                  :test "python -m unittest discover")
+(projectile-register-project-type 'python-pkg '("setup.py")
+                                  :compile "python setup.py build"
+                                  :test "python -m unittest discover")
+(projectile-register-project-type 'python-tox '("tox.ini")
+                                  :compile "tox -r --notest"
+                                  :test "tox")
+(projectile-register-project-type 'scons '("SConstruct")
+                                  :compile "scons"
+                                  :test "scons test")
+(projectile-register-project-type 'maven '("pom.xml")
+                                  :compile "mvn clean install"
+                                  :test "mvn test")
+(projectile-register-project-type 'gradle '("build.gradle")
+                                  :compile "gradle build"
+                                  :test "gradle test")
+(projectile-register-project-type 'gradlew '("gradlew")
+                                  :compile "./gradlew build"
+                                  :test "./gradlew test")
+(projectile-register-project-type 'grails '("application.properties" "grails-app")
+                                  :compile "grails package"
+                                  :test "grails test-app")
+(projectile-register-project-type 'lein-test '("project.clj")
+                                  :compile "lein compile"
+                                  :test "lein test")
+(projectile-register-project-type 'lein-midje '("project.clj" ".midje.clj")
+                                  :compile "lein compile"
+                                  :test "lein midje")
+(projectile-register-project-type 'boot-clj '("build.boot")
+                                  :compile "boot aot"
+                                  :test "boot test")
+(projectile-register-project-type 'rebar '("rebar.config")
+                                  :compile "rebar"
+                                  :test "rebar eunit")
+(projectile-register-project-type 'sbt '("build.sbt")
+                                  :compile "sbt compile"
+                                  :test "sbt test")
+(projectile-register-project-type 'make '("Makefile")
+                                  :compile "make"
+                                  :test "make test")
+(projectile-register-project-type 'grunt '("Gruntfile.js")
+                                  :compile "grunt"
+                                  :test "grunt test")
+(projectile-register-project-type 'gulp '("gulpfile.js")
+                                  :compile "gulp"
+                                  :test "gulp test")
+(projectile-register-project-type 'haskell-stack '("stack.yaml")
+                                  :compile "stack build"
+                                  :test "stack build --test")
+(projectile-register-project-type 'haskell-cabal #'projectile-cabal
+                                  :compile "cabal build"
+                                  :test "cabal test")
+(projectile-register-project-type 'rust-cargo '("Cargo.toml")
+                                  :compile "cargo build"
+                                  :test "cargo test")
+(projectile-register-project-type 'r '("DESCRIPTION")
+                                  :compile "R CMD INSTALL --with-keep.source ."
+                                  :test (concat "R CMD check -o " temporary-file-directory " ."))
+(projectile-register-project-type 'go projectile-go-function
+                                  :compile "go build ./..."
+                                  :test "go test ./...")
+(projectile-register-project-type 'racket '("info.rkt")
+                                  :test "raco test .")
+(projectile-register-project-type 'elixir '("mix.exs")
+                                  :compile "mix compile"
+                                  :test "mix test")
+(projectile-register-project-type 'npm '("package.json")
+                                  :compile "npm build"
+                                  :test "npm test")
 
 (defvar-local projectile-project-type nil
   "Buffer local var for overriding the auto-detected project type.
@@ -2248,24 +2319,38 @@ It assumes the test/ folder is at the same level as src/."
   (find-file
    (projectile-find-implementation-or-test (buffer-file-name))))
 
+
+(defun projectile--registration-value-or-default (project-type key &optional default-value)
+  "Returs project registration value for a KEY for a project PROJECT-TYPE or if nothing DEFAULT-VALUE"
+  (let ((project (gethash project-type projectile-project-types)))
+    (if (and project (plist-member project key))
+        (plist-get project key)
+      default-value)))
+
 (defun projectile-test-prefix (project-type)
   "Find default test files prefix based on PROJECT-TYPE."
-  (cond
-   ((member project-type '(django python-pip python-pkg python-tox)) "test_")
-   ((member project-type '(emacs-cask)) "test-")
-   ((member project-type '(lein-midje)) "t_")))
+  (cl-flet ((prefix (&optional pfx)
+                    (projectile--registration-value-or-default project-type 'test-prefix pfx)))
+      (cond
+       ((member project-type '(django python-pip python-pkg python-tox))  (prefix "test_"))
+       ((member project-type '(emacs-cask)) (prefix "test-"))
+       ((member project-type '(lein-midje)) (prefix "t_"))
+       (t (prefix)))))
 
 (defun projectile-test-suffix (project-type)
   "Find default test files suffix based on PROJECT-TYPE."
-  (cond
-   ((member project-type '(rebar)) "_SUITE")
-   ((member project-type '(emacs-cask)) "-test")
-   ((member project-type '(rails-rspec ruby-rspec)) "_spec")
-   ((member project-type '(rails-test ruby-test lein-test boot-clj go elixir)) "_test")
-   ((member project-type '(scons)) "test")
-   ((member project-type '(maven symfony)) "Test")
-   ((member project-type '(gradle gradlew grails)) "Spec")
-   ((member project-type '(sbt)) "Spec")))
+  (cl-flet ((suffix (&optional sfx)
+                    (projectile--registration-value-or-default project-type 'test-suffix sfx)))
+    (cond
+     ((member project-type '(rebar)) (suffix "_SUITE"))
+     ((member project-type '(emacs-cask)) (suffix "-test"))
+     ((member project-type '(rails-rspec ruby-rspec)) (suffix "_spec"))
+     ((member project-type '(rails-test ruby-test lein-test boot-clj go elixir)) (suffix "_test"))
+     ((member project-type '(scons)) (suffix "test"))
+     ((member project-type '(maven symfony)) (suffix "Test"))
+     ((member project-type '(gradle gradlew grails)) (suffix "Spec"))
+     ((member project-type '(sbt)) (suffix "Spec"))
+     (t (suffix)))))
 
 (defun projectile-dirname-matching-count (a b)
   "Count matching dirnames ascending file paths."

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -676,11 +676,30 @@
          "project/spec/models/food/sea_spec.rb")
       (let ((projectile-indexing-method 'native))
         (noflet ((projectile-project-type () 'rails-rspec)
-                 (projectile-project-root
-                  () (file-truename (expand-file-name "project/"))))
+                 (projectile-project-root () (file-truename (expand-file-name "project/"))))
           (should (equal "app/models/food/sea.rb"
                          (projectile-find-matching-file
                           "spec/models/food/sea_spec.rb"))))))))
+
+(ert-deftest projectile-test-find-matching-test/file-custom-project ()
+  (projectile-test-with-sandbox
+   (projectile-test-with-files
+     ("project/src/foo/"
+      "project/src/bar/"
+      "project/test/foo/"
+      "project/test/bar/"
+      "project/src/foo/foo.service.js"
+      "project/src/bar/bar.service.js"
+      "project/test/foo/foo.service.spec.js"
+      "project/test/bar/bar.service.spec.js")
+     (let* ((projectile-indexing-method 'native)
+            (reg (projectile-register-project-type 'npm-project '("somefile") :test-suffix ".spec")))
+        (noflet ((projectile-project-type () 'npm-project)
+                 (projectile-project-root () (file-truename (expand-file-name "project/"))))
+          (let ((test-file (projectile-find-matching-test "src/foo/foo.service.js"))
+                (impl-file (projectile-find-matching-file "test/bar/bar.service.spec.js")))
+            (should (equal "test/foo/foo.service.spec.js" test-file))
+            (should (equal "src/bar/bar.service.js" impl-file))))))))
 
 (ert-deftest projectile-test-exclude-out-of-project-submodules ()
   (projectile-test-with-files


### PR DESCRIPTION
Added ability to add test files prefix and suffix during project type registration. Should improve toggling between implementation and test files functionality.
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
