### PR TITLE
Use expand-file-name before using magit-status-internal

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2748,7 +2748,7 @@ For hg projects `monky-status' is used if available."
     (cl-case vcs
       (git
        (cond ((fboundp 'magit-status-internal)
-              (magit-status-internal project-root))
+              (magit-status-internal (expand-file-name project-root)))
              ((fboundp 'magit-status)
               (with-no-warnings (magit-status project-root)))
              (t


### PR DESCRIPTION
`magit-status-internal` fails when is called with a relative path.

```
ELISP> (projectile-vc "relative/path/to/project/")
*** Eval error ***  Wrong type argument: stringp, nil
ELISP>
```

`expand-file-name` is used by [`magit-status`](https://github.com/magit/magit/blob/0344413a/lisp/magit-status.el#L177) before calling `magit-status-internal`

Tell me if is necessary to add tests for this change.

Thanks in advance.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
