### PR TITLE
Fix TRAMP issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changes
 
+* [#1129](https://github.com/bbatsov/projectile/pull/1129): Fix TRAMP issues.
 * Add R DESCRIPTION file to `projectile-project-root-files`.
 * Ignore backup files in `projectile-get-other-files`.
 * Ignore Ensime cache directory, `.ensime_cache`.


### PR DESCRIPTION
This should fix #523 and #835.

Don't merge this yet (it lacks changelogs, etc). Right now the idea is for people having the same problem to test if my fix actually fixes all scenarios.

The idea is pretty simple: only resolve project-root for local files, or when the remote files are _connected_.

So far this seems to resolve all the issues for me, but I only tested emacs `25.1`.

Things to test:

- `/scpx:user@host:somefile`
- `/sudo:root@localhost:somefile`

Note: by me, the issues only happened when `projectile-rails-global-mode` was turned on. Projectile alone worked pretty well. This is because `projectile-rails-mode` uses `projectile` to determine wether it'd turn on or not, and this was just too much for TRAMP.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
