### PR TITLE
Remove more JavaScript files from root file list

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -300,9 +300,6 @@ If variable `projectile-project-name' is non-nil, this function will not be used
     "requirements.txt"   ; Pip file
     "setup.py"           ; Setuptools file
     "tox.ini"            ; Tox file
-    "gulpfile.js"        ; Gulp build file
-    "Gruntfile.js"       ; Grunt project file
-    "bower.json"         ; Bower project file
     "composer.json"      ; Composer project file
     "Cargo.toml"         ; Cargo project file
     "mix.exs"            ; Elixir mix project file


### PR DESCRIPTION
Similarly to package.json, these files may exist in subfolders if repositories have JavaScript packages that aren't at the top level (see #1092).