### PR TITLE
Autoload `(projectile-project-root)`

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -860,6 +860,7 @@ topmost sequence of matched directories.  Nil otherwise."
                  (not (projectile-file-exists-p (expand-file-name f (projectile-parent dir)))))))))
    (or list projectile-project-root-files-top-down-recurring)))
 
+;;;###autoload
 (defun projectile-project-root ()
   "Retrieves the root directory of a project if available.
 The current directory is assumed to be the project's root otherwise."


### PR DESCRIPTION
Apparently some packages like such as some spaceline themes rely on `(projectile-project-root)` to be forward declarable, but if it isn't autoloaded, the packages will result in all kinds of errors. This function is also quite useful for external elisp configs. I suggest you autoload it, since it doesn't look like it's very heavy anyway.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
