### PR TITLE
Improve performance of unignore directive for directories.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1138,6 +1138,12 @@ they are excluded from the results of this function."
     (when cmd
       (projectile-files-via-ext-command cmd))))
 
+(defun projectile-get-repo-ignored-directory (dir)
+  "Get a list of the files ignored in the project in the directory DIR."
+  (let ((cmd (projectile-get-ext-ignored-command)))
+    (when cmd
+      (projectile-files-via-ext-command (concat cmd " " dir)))))
+
 (defun projectile-call-process-to-string (program &rest args)
   "Invoke the executable PROGRAM with ARGS and return the output as a string."
   (with-temp-buffer
@@ -1266,6 +1272,15 @@ SUBDIRECTORIES to a non-nil value."
        (cl-some (lambda (f) (string-prefix-p f file)) files))
      (projectile-get-repo-ignored-files))))
 
+(defun projectile-keep-ignored-directories (directories)
+  "Get ignored files within each of DIRECTORIES."
+  (when directories
+    (let (result)
+      (dolist (dir directories result)
+        (setq result (append result
+                             (projectile-get-repo-ignored-directory dir))))
+      result)))
+
 (defun projectile-add-unignored (files)
   "This adds unignored files to FILES.
 
@@ -1274,7 +1289,7 @@ this case unignored files will be absent from FILES."
   (let ((unignored-files (projectile-keep-ignored-files
                           (projectile-unignored-files-rel)))
         (unignored-paths (projectile-remove-ignored
-                          (projectile-keep-ignored-files
+                          (projectile-keep-ignored-directories
                            (projectile-unignored-directories-rel))
                           'subdirectories)))
     (append files unignored-files unignored-paths)))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -142,7 +142,8 @@
 
 (ert-deftest projectile-add-unignored-directories ()
   (noflet ((projectile-project-vcs () 'git)
-           (projectile-get-repo-ignored-files () '("path/unignored-file")))
+           (projectile-get-repo-ignored-files () '("path/unignored-file"))
+           (projectile-get-repo-ignored-directory (dir) (list (concat dir "unignored-file"))))
     (let ((projectile-globally-unignored-directories '("path")))
       (should (equal (projectile-add-unignored '("file"))
                      '("file" "path/unignored-file")))


### PR DESCRIPTION
I have changed the way unignored directories are handled to make use of the optional directory argument provided by 'git ls-files'. This improves performance in the case where there are many files ignored by git in other directories (note that most of the gain is lost if a specific file is unignored since the entire list of ignored files must be retrieved in that case).

No user-visible functionality has been changed, and tests are passing after a tweak to support the new projectile-get-repo-ignored-directory function.

Feedback on this PR would be welcome, as this is my first attempt at contributing :-)

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
