### PR TITLE
Add command project-ag-regexp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Consider Ensime configuration file as root marker, `.ensime`.
 * [#1057](https://github.com/bbatsov/projectile/issues/1057): Make it possible to disable automatic project tracking via `projectile-track-known-projects-automatically`.
 * Added ability to specify test files suffix and prefix at the project registration.
+* [#1140](https://github.com/bbatsov/projectile/pull/1140): Add command `projectile-ag-regexp`.
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -2535,6 +2535,28 @@ regular expression."
         (funcall ag-command search-term (projectile-project-root)))
     (error "Package 'ag' is not available")))
 
+;;;###autoload
+(defun projectile-ag-regexp (search-term)
+  "Run an ag search with SEARCH-TERM in the project.
+
+SEARCH-TERM is interpreted as a regular expression."
+  (interactive
+   (list (projectile--read-search-string-with-default
+          (format "Ag %ssearch for" (if current-prefix-arg "regexp " "")))
+         current-prefix-arg))
+  (if (require 'ag nil 'noerror)
+      (let ((ag-ignore-list (unless (eq (projectile-project-vcs) 'git)
+                              ;; ag supports git ignore files
+                              (cl-union ag-ignore-list
+                                        (append
+                                         (projectile-ignored-files-rel) (projectile-ignored-directories-rel)
+                                         (projectile--globally-ignored-file-suffixes-glob)
+                                         grep-find-ignored-files grep-find-ignored-directories))))
+            ;; reset the prefix arg, otherwise it will affect ag-regexp
+            (current-prefix-arg nil))
+        (ag-regexp search-term (projectile-project-root)))
+    (error "Package 'ag' is not available")))
+
 (defun projectile-tags-exclude-patterns ()
   "Return a string with exclude patterns for ctags."
   (mapconcat (lambda (pattern) (format "--exclude=\"%s\""


### PR DESCRIPTION
This simply adds a command named `project-ag-regexp`.  This is nice because it allows the user to map this command to a keypress instead of having to remember to C-u to get regular expression behavior.