### PR TITLE
Don't check if unavailable projects are dirty

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1182,14 +1182,12 @@ If PROJECT-PATH is a project, check this one instead."
 The list is composed of sublists~: (project-path, project-status).
 Raise an error if their is no dirty project."
   (let ((projects projectile-known-projects)
-        (status ())
-        (tmp-status nil))
+        (status ()))
     (dolist (project projects)
-      (condition-case nil
-          (setq tmp-status (projectile-check-vcs-status project))
-        (error nil))
-      (when tmp-status
-        (setq status (cons (list project tmp-status) status))))
+      (when (and (projectile-keep-project-p project) (not (string= 'none (projectile-project-vcs project))))
+        (let ((tmp-status (projectile-check-vcs-status project)))
+          (when tmp-status
+            (setq status (cons (list project tmp-status) status))))))
     (when (= (length status) 0)
       (message "No dirty projects have been found"))
     status))


### PR DESCRIPTION
If a known projectile repository is unavailable or if projectile can't find the version control backend to use, `projectile-browse-dirty-projets` can run into an error.
This pull request fix this by doing some verifications (that the project folder is accessible and that a backend can be identified) before searching for modifications in projects.


-----------------



- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

