### PR TITLE
projectile-ag now respects ag-ignore-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Cache the name of the current project for mode-line display of the project name.
 * [#1078](https://github.com/bbatsov/projectile/issues/1078): For projectile-grep/ag use default value like grep/rgrep/ag.
 * Don't treat `package.json` as a project marker.
+* [#987](https://github.com/bbatsov/projectile/issues/987): projectile-ag ignores ag-ignore-list when projectile-project-vcs is git
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -2523,13 +2523,15 @@ regular expression."
          current-prefix-arg))
   (if (require 'ag nil 'noerror)
       (let ((ag-command (if arg 'ag-regexp 'ag))
-            (ag-ignore-list (unless (eq (projectile-project-vcs) 'git)
-                              ;; ag supports git ignore files
-                              (cl-union ag-ignore-list
+            (ag-ignore-list (cl-union ag-ignore-list
+                                      (projectile--globally-ignored-file-suffixes-glob)
+                                      ;; ag supports git ignore files directly
+                                      (unless (eq (projectile-project-vcs) 'git)
                                         (append
-                                         (projectile-ignored-files-rel) (projectile-ignored-directories-rel)
-                                         (projectile--globally-ignored-file-suffixes-glob)
-                                         grep-find-ignored-files grep-find-ignored-directories))))
+                                         (projectile-ignored-files-rel)
+                                         (projectile-ignored-directories-rel)
+                                         grep-find-ignored-files
+                                         grep-find-ignored-directories))))
             ;; reset the prefix arg, otherwise it will affect the ag-command
             (current-prefix-arg nil))
         (funcall ag-command search-term (projectile-project-root)))


### PR DESCRIPTION
fixes #987

This is very hard to test (there are no existing `projectile-ag` tests).

-----------------

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
