### PR TITLE
Cache projectile-project-root for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changes
 
+* Cache the root of the current project to increase performance
 * [#1129](https://github.com/bbatsov/projectile/pull/1129): Fix TRAMP issues.
 * Add R DESCRIPTION file to `projectile-project-root-files`.
 * Ignore backup files in `projectile-get-other-files`.

--- a/projectile.el
+++ b/projectile.el
@@ -880,6 +880,10 @@ which triggers a reset of `projectile-cached-project-root' and
 (defun projectile-project-root ()
   "Retrieves the root directory of a project if available.
 The current directory is assumed to be the project's root otherwise."
+  ;; the cached value will be 'none in the case of no project root (this is to
+  ;; ensure it is not reevaluated each time when not inside a project) so use
+  ;; cl-subst to replace this 'none value with nil so a nil value is used
+  ;; instead
   (or (cl-subst nil 'none
                 (or (and (equal projectile-cached-buffer-file-name buffer-file-name)
                          projectile-cached-project-root)

--- a/projectile.el
+++ b/projectile.el
@@ -880,15 +880,19 @@ which triggers a reset of `projectile-cached-project-root' and
 (defun projectile-project-root ()
   "Retrieves the root directory of a project if available.
 The current directory is assumed to be the project's root otherwise."
-  ;; The `is-local' and `is-connected' variables are used to fix the behavior where Emacs hangs
-  ;; because of Projectile when you open a file over TRAMP. It basically prevents Projectile from trying
-  ;; to find information about files for which it's not possible to get that information right now.
   (or (cl-subst nil 'none
                 (or (and (equal projectile-cached-buffer-file-name buffer-file-name)
                          projectile-cached-project-root)
                     (progn
                       (setq projectile-cached-buffer-file-name buffer-file-name)
                       (setq projectile-cached-project-root
+                            ;; The `is-local' and `is-connected' variables are
+                            ;; used to fix the behavior where Emacs hangs
+                            ;; because of Projectile when you open a file over
+                            ;; TRAMP. It basically prevents Projectile from
+                            ;; trying to find information about files for which
+                            ;; it's not possible to get that information right
+                            ;; now.
                             (or (let* ((dir default-directory)
                                        (is-local (not (file-remote-p dir)))      ;; `true' if the file is local
                                        (is-connected (file-remote-p dir nil t))) ;; `true' if the file is remote AND we are connected to the remote

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -28,7 +28,8 @@
           ,@body))
 
 (defun projectile-test-should-root-in (root directory)
-  (let ((projectile-project-root-cache (make-hash-table :test 'equal)))
+  (let ((projectile-project-root-cache (make-hash-table :test 'equal))
+        (projectile-cached-project-root nil))
     (should (equal (file-truename (file-name-as-directory root))
                    (let ((default-directory
                            (expand-file-name


### PR DESCRIPTION
Cache the result of (projectile-project-root) as a buffer local variable to
increase performance - this is implemented the same as was done
for (projectile-project-name) in PR 1906.

Should help resolve issue #1003
