### PR TITLE
Fix GH issue #1150

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3169,8 +3169,12 @@ With a prefix ARG invokes `projectile-commander' instead of
       ;; the current project, in the minibuffer. This is a simple hack
       ;; to tell the `projectile-project-name' function to ignore the
       ;; current buffer and the caching mechanism, and just return the
-      ;; value of the `projectile-project-name' variable.
-      (let ((projectile-project-name (funcall projectile-project-name-function
+      ;; value of the `projectile-project-name' variable.  We also
+      ;; need to ignore the cached project-root value otherwise we end
+      ;; up still showing files from the current project rather than
+      ;; the new project
+      (let ((projectile-cached-project-root nil)
+            (projectile-project-name (funcall projectile-project-name-function
                                               project-to-switch)))
         (funcall switch-project-action)))
     (run-hooks 'projectile-after-switch-project-hook)))


### PR DESCRIPTION
When switching projects need to ignore the cached value of the project root otherwise the old project is shown, not the new project.

I wonder if a similar approach could be taken for projectile-project-name here as well but I left it so as to keep the changeset as minimal as possible.