### PR TITLE
ag-ignore-list properly loaded with projectile-specific ignores

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2570,15 +2570,17 @@ regular expression."
          current-prefix-arg))
   (if (require 'ag nil 'noerror)
       (let ((ag-command (if arg 'ag-regexp 'ag))
-            (ag-ignore-list (cl-union ag-ignore-list
-                                      (projectile--globally-ignored-file-suffixes-glob)
-                                      ;; ag supports git ignore files directly
-                                      (unless (eq (projectile-project-vcs) 'git)
-                                        (append
-                                         (projectile-ignored-files-rel)
-                                         (projectile-ignored-directories-rel)
-                                         grep-find-ignored-files
-                                         grep-find-ignored-directories))))
+            (ag-ignore-list (delq nil
+                                  (delete-dups
+                                   (append
+                                    ag-ignore-list
+                                    (projectile--globally-ignored-file-suffixes-glob)
+                                    ;; ag supports git ignore files directly
+                                    (unless (eq (projectile-project-vcs) 'git)
+                                      (append (projectile-ignored-files-rel)
+                                              (projectile-ignored-directories-rel)
+                                              grep-find-ignored-files
+                                              grep-find-ignored-directories))))))
             ;; reset the prefix arg, otherwise it will affect the ag-command
             (current-prefix-arg nil))
         (funcall ag-command search-term (projectile-project-root)))


### PR DESCRIPTION
fix bug in `ag-ignore-list` usage (https://github.com/bbatsov/projectile/pull/1145#issuecomment-317276272)

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
