### PR TITLE
Use npm install instead of build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Consider Ensime configuration file as root marker, `.ensime`.
 * [#1057](https://github.com/bbatsov/projectile/issues/1057): Make it possible to disable automatic project tracking via `projectile-track-known-projects-automatically`.
 * Added ability to specify test files suffix and prefix at the project registration.
+* [#1154](https://github.com/bbatsov/projectile/pull/1154) Use npm install instead of build.
 
 ### Changes
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -235,7 +235,7 @@ If a project you are working on is recognized incorrectly or you want to add you
 
 ```el
 (projectile-register-project-type 'npm '("package.json")
-				  :compile "npm build"
+				  :compile "npm install"
 				  :test "npm test"
 				  :run "npm start"
 				  :test-suffix ".spec")
@@ -243,7 +243,7 @@ If a project you are working on is recognized incorrectly or you want to add you
 What this does is:
 1. add your own type of project, in this case `npm` package.
 2. add a file in a root of the project that helps to identify the type, in this case it is `package.json`.
-3. add *compile-command*, in this case it is `npm build`.
+3. add *compile-command*, in this case it is `npm install`.
 4. add *test-command*, in this case it is `npm test`.
 5. add *run-command*, in this case it is `npm start`.
 6. add test files suffix for toggling between implementation/test files, in this case it is `.spec`, so the implementation/test file pair could be `service.js`/`service.spec.js` for example.

--- a/projectile.el
+++ b/projectile.el
@@ -2253,7 +2253,7 @@ TEST-PREFIX which specifies test file prefix."
                                   :compile "mix compile"
                                   :test "mix test")
 (projectile-register-project-type 'npm '("package.json")
-                                  :compile "npm build"
+                                  :compile "npm install"
                                   :test "npm test")
 
 (defvar-local projectile-project-type nil


### PR DESCRIPTION
The build script for `npm` is currently `npm build`, which is invalid without arguments. Also, most npm users would expect the typical install hooks like `prepare` and `pre/postinstall` to be executed when building a project, and `install` also installs dependencies.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
