### PR TITLE
Add `nix' project type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 * [#1166](https://github.com/bbatsov/projectile/pull/1168): Add CMake and Meson project support.
+* [#1159](https://github.com/bbatsov/projectile/pull/1159) Add [nix](http://nixos.org) project support.
 * [#1166](https://github.com/bbatsov/projectile/pull/1166): Add `-other-frame` versions of commands that had `-other-window` versions.
 * Consider Ensime configuration file as root marker, `.ensime`.
 * [#1057](https://github.com/bbatsov/projectile/issues/1057): Make it possible to disable automatic project tracking via `projectile-track-known-projects-automatically`.

--- a/projectile.el
+++ b/projectile.el
@@ -2375,6 +2375,9 @@ TEST-PREFIX which specifies test file prefix."
 (projectile-register-project-type 'cmake '("CMakeLists.txt")
                                   :compile #'projectile-cmake-compile
                                   :test #'projectile-cmake-test)
+(projectile-register-project-type 'nix '("default.nix")
+                                  :compile "nix-build"
+                                  :test "nix-build")
 
 (defvar-local projectile-project-type nil
   "Buffer local var for overriding the auto-detected project type.


### PR DESCRIPTION
I've been using this personally for a while but I think it makes sense to go in Projectile. This just registers "nix" projects as anything containing a "default.nix" file. "nix-build" actually both compiles and tests (if doCheck=true), should it be set for both?

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
