### PR TITLE
Add -other-frame versions of commands that had -other-window versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* [#1166](https://github.com/bbatsov/projectile/pull/1166): Add `-other-frame` versions of commands that had `-other-window` versions.
 * Consider Ensime configuration file as root marker, `.ensime`.
 * [#1057](https://github.com/bbatsov/projectile/issues/1057): Make it possible to disable automatic project tracking via `projectile-track-known-projects-automatically`.
 * Added ability to specify test files suffix and prefix at the project registration.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -28,7 +28,6 @@ Keybinding         | Description
 <kbd>C-c p 4 g</kbd> | Jump to a project's file based on context at point and show it in another window.
 <kbd>C-c p d</kbd> | Display a list of all directories in the project. With a prefix argument it will clear the cache first.
 <kbd>C-c p 4 d</kbd> | Switch to a project directory and show it in another window.
-<kbd>C-c p 4 a</kbd> | Switch between files with the same name but different extensions in other window.
 <kbd>C-c p T</kbd> | Display a list of all test files(specs, features, etc) in the project.
 <kbd>C-c p l</kbd> | Display a list of all files in a directory (that's not necessarily a project)
 <kbd>C-c p s g</kbd> | Run grep on the files in the project.
@@ -39,6 +38,8 @@ Keybinding         | Description
 <kbd>C-c p 4 b</kbd> | Switch to a project buffer and show it in another window.
 <kbd>C-c p 4 C-o</kbd> | Display a project buffer in another window without selecting it.
 <kbd>C-c p a</kbd> | Switch between files with the same name but different extensions.
+<kbd>C-c p 4 a</kbd> | Switch between files with the same name but different extensions in other window.
+<kbd>C-c p 5 a</kbd> | Switch between files with the same name but different extensions in other frame.
 <kbd>C-c p o</kbd> | Runs `multi-occur` on all project buffers currently open.
 <kbd>C-c p r</kbd> | Runs interactive query-replace on all files in the projects.
 <kbd>C-c p i</kbd> | Invalidates the project cache (if existing).

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -60,6 +60,7 @@ Keybinding         | Description
 <kbd>C-c p P</kbd> | Runs a standard test command for your type of project.
 <kbd>C-c p t</kbd> | Toggle between an implementation file and its test file.
 <kbd>C-c p 4 t</kbd> | Jump to implementation or test file in other window.
+<kbd>C-c p 5 t</kbd> | Jump to implementation or test file in other frame.
 <kbd>C-c p z</kbd> | Adds the currently visited file to the cache.
 <kbd>C-c p p</kbd> | Display a list of known projects you can switch to.
 <kbd>C-c p S</kbd> | Save all project buffers.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -27,6 +27,7 @@ Keybinding         | Description
 <kbd>C-c p 4 f</kbd> | Jump to a project's file using completion and show it in another window.
 <kbd>C-c p 4 g</kbd> | Jump to a project's file based on context at point and show it in another window.
 <kbd>C-c p 5 f</kbd> | Jump to a project's file using completion and show it in another frame.
+<kbd>C-c p 5 g</kbd> | Jump to a project's file based on context at point and show it in another frame.
 <kbd>C-c p d</kbd> | Display a list of all directories in the project. With a prefix argument it will clear the cache first.
 <kbd>C-c p 4 d</kbd> | Switch to a project directory and show it in another window.
 <kbd>C-c p 5 d</kbd> | Switch to a project directory and show it in another frame.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -26,6 +26,7 @@ Keybinding         | Description
 <kbd>C-c p g</kbd> | Display a list of all files at point in the project. With a prefix argument it will clear the cache first.
 <kbd>C-c p 4 f</kbd> | Jump to a project's file using completion and show it in another window.
 <kbd>C-c p 4 g</kbd> | Jump to a project's file based on context at point and show it in another window.
+<kbd>C-c p 5 f</kbd> | Jump to a project's file using completion and show it in another frame.
 <kbd>C-c p d</kbd> | Display a list of all directories in the project. With a prefix argument it will clear the cache first.
 <kbd>C-c p 4 d</kbd> | Switch to a project directory and show it in another window.
 <kbd>C-c p 5 d</kbd> | Switch to a project directory and show it in another frame.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -51,6 +51,8 @@ Keybinding         | Description
 <kbd>C-c p j</kbd> | Find tag in project's `TAGS` file.
 <kbd>C-c p k</kbd> | Kills all project buffers.
 <kbd>C-c p D</kbd> | Opens the root of the project in `dired`.
+<kbd>C-c p 4 D</kbd> | Opens the root of the project in `dired` in another window.
+<kbd>C-c p 5 D</kbd> | Opens the root of the project in `dired` in another frame.
 <kbd>C-c p e</kbd> | Shows a list of recently visited project files.
 <kbd>C-c p E</kbd> | Opens the root `dir-locals-file` of the project.
 <kbd>C-c p s s</kbd> | Runs `ag` on the project. Requires the presence of `ag.el`.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -36,6 +36,7 @@ Keybinding         | Description
 <kbd>C-c p V</kbd> | Browse dirty version controlled projects.
 <kbd>C-c p b</kbd> | Display a list of all project buffers currently open.
 <kbd>C-c p 4 b</kbd> | Switch to a project buffer and show it in another window.
+<kbd>C-c p 5 b</kbd> | Switch to a project buffer and show it in another frame.
 <kbd>C-c p 4 C-o</kbd> | Display a project buffer in another window without selecting it.
 <kbd>C-c p a</kbd> | Switch between files with the same name but different extensions.
 <kbd>C-c p 4 a</kbd> | Switch between files with the same name but different extensions in other window.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -28,6 +28,7 @@ Keybinding         | Description
 <kbd>C-c p 4 g</kbd> | Jump to a project's file based on context at point and show it in another window.
 <kbd>C-c p d</kbd> | Display a list of all directories in the project. With a prefix argument it will clear the cache first.
 <kbd>C-c p 4 d</kbd> | Switch to a project directory and show it in another window.
+<kbd>C-c p 5 d</kbd> | Switch to a project directory and show it in another frame.
 <kbd>C-c p T</kbd> | Display a list of all test files(specs, features, etc) in the project.
 <kbd>C-c p l</kbd> | Display a list of all files in a directory (that's not necessarily a project)
 <kbd>C-c p s g</kbd> | Run grep on the files in the project.

--- a/projectile.el
+++ b/projectile.el
@@ -2102,6 +2102,14 @@ With a prefix ARG invalidates the cache first."
   (interactive "P")
   (projectile--find-dir arg #'dired-other-window))
 
+;;;###autoload
+(defun projectile-find-dir-other-frame (&optional arg)
+  "Jump to a project's directory in other window using completion.
+
+With a prefix ARG invalidates the cache first."
+  (interactive "P")
+  (projectile--find-dir arg #'dired-other-frame))
+
 (defun projectile-complete-dir ()
   (projectile-completing-read
    "Find dir: "
@@ -3557,6 +3565,7 @@ is chosen."
     (define-key map (kbd "4 t") #'projectile-find-implementation-or-test-other-window)
     (define-key map (kbd "5 a") #'projectile-find-other-file-other-frame)
     (define-key map (kbd "5 b") #'projectile-switch-to-buffer-other-frame)
+    (define-key map (kbd "5 d") #'projectile-find-dir-other-frame)
     (define-key map (kbd "!") #'projectile-run-shell-command-in-root)
     (define-key map (kbd "&") #'projectile-run-async-shell-command-in-root)
     (define-key map (kbd "a") #'projectile-find-other-file)

--- a/projectile.el
+++ b/projectile.el
@@ -1445,6 +1445,13 @@ choices."
    (projectile-read-buffer-to-switch "Switch to buffer: ")))
 
 ;;;###autoload
+(defun projectile-switch-to-buffer-other-frame ()
+  "Switch to a project buffer and show it in another window."
+  (interactive)
+  (switch-to-buffer-other-frame
+   (projectile-read-buffer-to-switch "Switch to buffer: ")))
+
+;;;###autoload
 (defun projectile-display-buffer ()
   "Display a project buffer in another window without selecting it."
   (interactive)
@@ -3544,6 +3551,7 @@ is chosen."
     (define-key map (kbd "4 g") #'projectile-find-file-dwim-other-window)
     (define-key map (kbd "4 t") #'projectile-find-implementation-or-test-other-window)
     (define-key map (kbd "5 a") #'projectile-find-other-file-other-frame)
+    (define-key map (kbd "5 b") #'projectile-switch-to-buffer-other-frame)
     (define-key map (kbd "!") #'projectile-run-shell-command-in-root)
     (define-key map (kbd "&") #'projectile-run-async-shell-command-in-root)
     (define-key map (kbd "a") #'projectile-find-other-file)

--- a/projectile.el
+++ b/projectile.el
@@ -2445,6 +2445,13 @@ It assumes the test/ folder is at the same level as src/."
    (projectile-find-implementation-or-test (buffer-file-name))))
 
 ;;;###autoload
+(defun projectile-find-implementation-or-test-other-frame ()
+  "Open matching implementation or test file in other frame."
+  (interactive)
+  (find-file-other-frame
+   (projectile-find-implementation-or-test (buffer-file-name))))
+
+;;;###autoload
 (defun projectile-toggle-between-implementation-and-test ()
   "Toggle between an implementation file and its test file."
   (interactive)
@@ -3614,6 +3621,7 @@ is chosen."
     (define-key map (kbd "5 d") #'projectile-find-dir-other-frame)
     (define-key map (kbd "5 f") #'projectile-find-file-other-frame)
     (define-key map (kbd "5 g") #'projectile-find-file-dwim-other-frame)
+    (define-key map (kbd "5 t") #'projectile-find-implementation-or-test-other-frame)
     (define-key map (kbd "!") #'projectile-run-shell-command-in-root)
     (define-key map (kbd "&") #'projectile-run-async-shell-command-in-root)
     (define-key map (kbd "a") #'projectile-find-other-file)

--- a/projectile.el
+++ b/projectile.el
@@ -1973,13 +1973,13 @@ file in project:
 if the filename is incomplete, but there's only a single file in the current project
 that matches the filename at point.  For example, if there's only a single file named
 \"projectile/projectile.el\" but the current filename is \"projectile/proj\" (incomplete),
-`projectile-find-file' still switches to \"projectile/projectile.el\" immediately
+`projectile-find-file-dwim' still switches to \"projectile/projectile.el\" immediately
  because this is the only filename that matches.
 
 - If it finds a list of files, the list is displayed for selecting.  A list of
 files is displayed when a filename appears more than one in the project or the
 filename at point is a prefix of more than two files in a project.  For example,
-if `projectile-find-file' is executed on a filepath like \"projectile/\", it lists
+if `projectile-find-file-dwim' is executed on a filepath like \"projectile/\", it lists
 the content of that directory.  If it is executed on a partial filename like
  \"projectile/a\", a list of files with character 'a' in that directory is presented.
 
@@ -2000,13 +2000,13 @@ file in project:
 if the filename is incomplete, but there's only a single file in the current project
 that matches the filename at point.  For example, if there's only a single file named
 \"projectile/projectile.el\" but the current filename is \"projectile/proj\" (incomplete),
-`projectile-find-file' still switches to \"projectile/projectile.el\"
+`projectile-find-file-dwim-other-window' still switches to \"projectile/projectile.el\"
 immediately because this is the only filename that matches.
 
 - If it finds a list of files, the list is displayed for selecting.  A list of
 files is displayed when a filename appears more than one in the project or the
 filename at point is a prefix of more than two files in a project.  For example,
-if `projectile-find-file' is executed on a filepath like \"projectile/\", it lists
+if `projectile-find-file-dwim-other-window' is executed on a filepath like \"projectile/\", it lists
 the content of that directory.  If it is executed on a partial filename
 like \"projectile/a\", a list of files with character 'a' in that directory
 is presented.

--- a/projectile.el
+++ b/projectile.el
@@ -2074,16 +2074,25 @@ With a prefix ARG invalidates the cache first."
              (file2-atime (nth 4 (file-attributes file2))))
          (not (time-less-p file1-atime file2-atime)))))))
 
+(defun projectile--find-dir (invalidate-cache &optional dired-variant)
+  "Jump to a project's directory using completion.
+
+With INVALIDATE-CACHE invalidates the cache first.  With DIRED-VARIANT set to a
+defun, use that instead of `dired'.  A typical example of such a defun would be
+`dired-other-window' or `dired-other-frame'"
+  (projectile-maybe-invalidate-cache invalidate-cache)
+  (let ((dir (projectile-complete-dir))
+        (dired-v (or dired-variant #'dired)))
+    (funcall dired-v (expand-file-name dir (projectile-project-root)))
+    (run-hooks 'projectile-find-dir-hook)))
+
 ;;;###autoload
 (defun projectile-find-dir (&optional arg)
   "Jump to a project's directory using completion.
 
 With a prefix ARG invalidates the cache first."
   (interactive "P")
-  (projectile-maybe-invalidate-cache arg)
-  (let ((dir (projectile-complete-dir)))
-    (dired (expand-file-name dir (projectile-project-root)))
-    (run-hooks 'projectile-find-dir-hook)))
+  (projectile--find-dir arg))
 
 ;;;###autoload
 (defun projectile-find-dir-other-window (&optional arg)
@@ -2091,11 +2100,7 @@ With a prefix ARG invalidates the cache first."
 
 With a prefix ARG invalidates the cache first."
   (interactive "P")
-  (when arg
-    (projectile-invalidate-cache nil))
-  (let ((dir (projectile-complete-dir)))
-    (dired-other-window (expand-file-name dir (projectile-project-root)))
-    (run-hooks 'projectile-find-dir-hook)))
+  (projectile--find-dir arg #'dired-other-window))
 
 (defun projectile-complete-dir ()
   (projectile-completing-read

--- a/projectile.el
+++ b/projectile.el
@@ -2015,6 +2015,33 @@ is presented.
   (interactive "P")
   (projectile--find-file-dwim arg #'find-file-other-window))
 
+;;;###autoload
+(defun projectile-find-file-dwim-other-frame (&optional arg)
+  "Jump to a project's files using completion based on context in other frame.
+
+With a prefix ARG invalidates the cache first.
+
+If point is on a filename, Projectile first tries to search for that
+file in project:
+
+- If it finds just a file, it switches to that file instantly.  This works even
+if the filename is incomplete, but there's only a single file in the current project
+that matches the filename at point.  For example, if there's only a single file named
+\"projectile/projectile.el\" but the current filename is \"projectile/proj\" (incomplete),
+`projectile-find-file-dwim-other-frame' still switches to \"projectile/projectile.el\"
+immediately because this is the only filename that matches.
+
+- If it finds a list of files, the list is displayed for selecting.  A list of
+files is displayed when a filename appears more than one in the project or the
+filename at point is a prefix of more than two files in a project.  For example,
+if `projectile-find-file-dwim-other-frame' is executed on a filepath like \"projectile/\", it lists
+the content of that directory.  If it is executed on a partial filename
+like \"projectile/a\", a list of files with character 'a' in that directory
+is presented.
+
+- If it finds nothing, display a list of all files in project for selecting."
+  (interactive "P")
+  (projectile--find-file-dwim arg #'find-file-other-frame))
 
 (defun projectile--find-file (invalidate-cache &optional ff-variant)
   "Jump to a project's file using completion.
@@ -3586,6 +3613,7 @@ is chosen."
     (define-key map (kbd "5 b") #'projectile-switch-to-buffer-other-frame)
     (define-key map (kbd "5 d") #'projectile-find-dir-other-frame)
     (define-key map (kbd "5 f") #'projectile-find-file-other-frame)
+    (define-key map (kbd "5 g") #'projectile-find-file-dwim-other-frame)
     (define-key map (kbd "!") #'projectile-run-shell-command-in-root)
     (define-key map (kbd "&") #'projectile-run-async-shell-command-in-root)
     (define-key map (kbd "a") #'projectile-find-other-file)

--- a/projectile.el
+++ b/projectile.el
@@ -2037,6 +2037,14 @@ With a prefix ARG invalidates the cache first."
   (interactive "P")
   (projectile--find-file arg #'find-file-other-window))
 
+;;;###autoload
+(defun projectile-find-file-other-frame (&optional arg)
+  "Jump to a project's file using completion and show it in another frame.
+
+With a prefix ARG invalidates the cache first."
+  (interactive "P")
+  (projectile--find-file arg #'find-file-other-frame))
+
 (defun projectile-sort-files (files)
   "Sort FILES according to `projectile-sort-order'."
   (cl-case projectile-sort-order
@@ -3570,6 +3578,7 @@ is chosen."
     (define-key map (kbd "5 a") #'projectile-find-other-file-other-frame)
     (define-key map (kbd "5 b") #'projectile-switch-to-buffer-other-frame)
     (define-key map (kbd "5 d") #'projectile-find-dir-other-frame)
+    (define-key map (kbd "5 f") #'projectile-find-file-other-frame)
     (define-key map (kbd "!") #'projectile-run-shell-command-in-root)
     (define-key map (kbd "&") #'projectile-run-async-shell-command-in-root)
     (define-key map (kbd "a") #'projectile-find-other-file)

--- a/projectile.el
+++ b/projectile.el
@@ -1831,6 +1831,15 @@ Other file extensions can be customized with the variable `projectile-other-file
   (projectile--find-other-file flex-matching
                                #'find-file-other-window))
 
+;;;###autoload
+(defun projectile-find-other-file-other-frame (&optional flex-matching)
+  "Switch between files with the same name but different extensions in other window.
+With FLEX-MATCHING, match any file that contains the base name of current file.
+Other file extensions can be customized with the variable `projectile-other-file-alist'."
+  (interactive "P")
+  (projectile--find-other-file flex-matching
+                               #'find-file-other-frame))
+
 (defun projectile--file-name-sans-extensions (file-name)
   "Return FILE-NAME sans any extensions.
 The extensions, in a filename, are what follows the first '.', with the exception of a leading '.'"
@@ -3534,6 +3543,7 @@ is chosen."
     (define-key map (kbd "4 f") #'projectile-find-file-other-window)
     (define-key map (kbd "4 g") #'projectile-find-file-dwim-other-window)
     (define-key map (kbd "4 t") #'projectile-find-implementation-or-test-other-window)
+    (define-key map (kbd "5 a") #'projectile-find-other-file-other-frame)
     (define-key map (kbd "!") #'projectile-run-shell-command-in-root)
     (define-key map (kbd "&") #'projectile-run-async-shell-command-in-root)
     (define-key map (kbd "a") #'projectile-find-other-file)

--- a/projectile.el
+++ b/projectile.el
@@ -2965,6 +2965,18 @@ to run the replacement."
   (dired (projectile-project-root)))
 
 ;;;###autoload
+(defun projectile-dired-other-window ()
+  "Open `dired'  at the root of the project in another window."
+  (interactive)
+  (dired-other-window (projectile-project-root)))
+
+;;;###autoload
+(defun projectile-dired-other-frame ()
+  "Open `dired' at the root of the project in another frame."
+  (interactive)
+  (dired-other-frame (projectile-project-root)))
+
+;;;###autoload
 (defun projectile-vc (&optional project-root)
   "Open `vc-dir' at the root of the project.
 
@@ -3613,12 +3625,14 @@ is chosen."
     (define-key map (kbd "4 b") #'projectile-switch-to-buffer-other-window)
     (define-key map (kbd "4 C-o") #'projectile-display-buffer)
     (define-key map (kbd "4 d") #'projectile-find-dir-other-window)
+    (define-key map (kbd "4 D") #'projectile-dired-other-window)
     (define-key map (kbd "4 f") #'projectile-find-file-other-window)
     (define-key map (kbd "4 g") #'projectile-find-file-dwim-other-window)
     (define-key map (kbd "4 t") #'projectile-find-implementation-or-test-other-window)
     (define-key map (kbd "5 a") #'projectile-find-other-file-other-frame)
     (define-key map (kbd "5 b") #'projectile-switch-to-buffer-other-frame)
     (define-key map (kbd "5 d") #'projectile-find-dir-other-frame)
+    (define-key map (kbd "5 D") #'projectile-dired-other-frame)
     (define-key map (kbd "5 f") #'projectile-find-file-other-frame)
     (define-key map (kbd "5 g") #'projectile-find-file-dwim-other-frame)
     (define-key map (kbd "5 t") #'projectile-find-implementation-or-test-other-frame)

--- a/projectile.el
+++ b/projectile.el
@@ -2008,18 +2008,26 @@ is presented.
      (t (find-file-other-window (expand-file-name (projectile-completing-read "Switch to: " project-files) (projectile-project-root)))))
     (run-hooks 'projectile-find-file-hook)))
 
+
+(defun projectile--find-file (invalidate-cache &optional ff-variant)
+  "Jump to a project's file using completion.
+With INVALIDATE-CACHE invalidates the cache first.  With FF-VARIANT set to a
+defun, use that instead of `find-file'.   A typical example of such a defun
+would be `find-file-other-window' or `find-file-other-frame'"
+  (interactive "P")
+  (projectile-maybe-invalidate-cache invalidate-cache)
+  (let ((file (projectile-completing-read "Find file: "
+                                          (projectile-current-project-files)))
+        (ff (or ff-variant #'find-file)))
+    (funcall ff (expand-file-name file (projectile-project-root)))
+    (run-hooks 'projectile-find-file-hook)))
+
 ;;;###autoload
 (defun projectile-find-file (&optional arg)
   "Jump to a project's file using completion.
 With a prefix ARG invalidates the cache first."
   (interactive "P")
-  (projectile-maybe-invalidate-cache arg)
-  (projectile-completing-read
-   "Find file: "
-   (projectile-current-project-files)
-   :action `(lambda (file)
-              (find-file (expand-file-name file ,(projectile-project-root)))
-              (run-hooks 'projectile-find-file-hook))))
+  (projectile--find-file arg))
 
 ;;;###autoload
 (defun projectile-find-file-other-window (&optional arg)
@@ -2027,11 +2035,7 @@ With a prefix ARG invalidates the cache first."
 
 With a prefix ARG invalidates the cache first."
   (interactive "P")
-  (projectile-maybe-invalidate-cache arg)
-  (let ((file (projectile-completing-read "Find file: "
-                                          (projectile-current-project-files))))
-    (find-file-other-window (expand-file-name file (projectile-project-root)))
-    (run-hooks 'projectile-find-file-hook)))
+  (projectile--find-file arg #'find-file-other-window))
 
 (defun projectile-sort-files (files)
   "Sort FILES according to `projectile-sort-order'."


### PR DESCRIPTION
Some commands in projectile comes with an `-other-window` version with keybindings under the `4` prefix.
Sometimes I want to open a `dired` instance or a file in another frame and wonder why there is not `5`-prefix for frames. Well now there is, if this PR is merged. :)

-----------------

- [ x ] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ - ] You've added tests (if possible) to cover your change(s)
  - I don't believe it applies here. No new units to tests really.
- [ x ] All tests are passing (`make test`)
- [ x ] The new code is not generating bytecode or `M-x checkdoc` warnings
  - No, but the old code sure is. ;)
- [ x ] You've updated the changelog (if adding/changing user-visible functionality)
- [ x ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
