### PR TITLE
Cmake and meson project support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* [#1166](https://github.com/bbatsov/projectile/pull/1168): Add CMake and Meson project support.
 * [#1166](https://github.com/bbatsov/projectile/pull/1166): Add `-other-frame` versions of commands that had `-other-window` versions.
 * Consider Ensime configuration file as root marker, `.ensime`.
 * [#1057](https://github.com/bbatsov/projectile/issues/1057): Make it possible to disable automatic project tracking via `projectile-track-known-projects-automatically`.

--- a/projectile.el
+++ b/projectile.el
@@ -2219,6 +2219,29 @@ TEST-PREFIX which specifies test file prefix."
     (puthash project-type project-plist
              projectile-project-types)))
 
+(defun projectile-cmake-run-target (target)
+  "Run CMake TARGET, generating build dir if needed."
+  (interactive "sTarget: ")
+  (let ((configure-cmd (format "cmake -E chdir %s cmake .."
+                               projectile-build-dir))
+        (build-cmd (format "cmake --build %s --target %s"
+                           projectile-build-dir
+                           target)))
+    (compile (if (file-accessible-directory-p projectile-build-dir)
+                 build-cmd
+               (mkdir projectile-build-dir)
+               (format "%s && %s" configure-cmd build-cmd)))))
+
+(defun projectile-cmake-compile ()
+  "Compile the current cmake project."
+  (interactive)
+  (projectile-cmake-run-target ""))
+
+(defun projectile-cmake-test ()
+  "Run the current cmake projects test suite."
+  (interactive)
+  (projectile-cmake-run-target "test"))
+
 (defun projectile-meson-run-target (target)
   "Run meson TARGET, generating build dir if needed."
   (interactive "sTarget: ")
@@ -2349,6 +2372,9 @@ TEST-PREFIX which specifies test file prefix."
 (projectile-register-project-type 'meson '("meson.build")
                                   :compile #'projectile-meson-compile
                                   :test #'projectile-meson-test)
+(projectile-register-project-type 'cmake '("CMakeLists.txt")
+                                  :compile #'projectile-cmake-compile
+                                  :test #'projectile-cmake-test)
 
 (defvar-local projectile-project-type nil
   "Buffer local var for overriding the auto-detected project type.


### PR DESCRIPTION
Add support for building and testing CMake- and Meson projects.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [✓] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
   - With caveat that this PR adds support for two similar project types in one go. I can easily split this up if wanted.
- [✓] You've added tests (if possible) to cover your change(s)
   - Does not apply I believe (?)
- [✓] All tests are passing (`make test`)
- [✓] The new code is not generating bytecode or `M-x checkdoc` warnings
    - Not the new code no.
- [✓] You've updated the changelog (if adding/changing user-visible functionality)
- [✓] You've updated the readme (if adding/changing user-visible functionality)
    - Not applicable

Thanks!
