### PR TITLE
Copy grep-find-ignored-directories in projectile-ag

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2711,15 +2711,16 @@ regular expression."
       (let ((ag-command (if arg 'ag-regexp 'ag))
             (ag-ignore-list (delq nil
                                   (delete-dups
-                                   (append
-                                    ag-ignore-list
-                                    (projectile--globally-ignored-file-suffixes-glob)
-                                    ;; ag supports git ignore files directly
-                                    (unless (eq (projectile-project-vcs) 'git)
-                                      (append (projectile-ignored-files-rel)
-                                              (projectile-ignored-directories-rel)
-                                              grep-find-ignored-files
-                                              grep-find-ignored-directories))))))
+                                   (copy-sequence
+                                    (append
+                                     ag-ignore-list
+                                     (projectile--globally-ignored-file-suffixes-glob)
+                                     ;; ag supports git ignore files directly
+                                     (unless (eq (projectile-project-vcs) 'git)
+                                       (append (projectile-ignored-files-rel)
+                                               (projectile-ignored-directories-rel)
+                                               grep-find-ignored-files
+                                               grep-find-ignored-directories)))))))
             ;; reset the prefix arg, otherwise it will affect the ag-command
             (current-prefix-arg nil))
         (funcall ag-command search-term (projectile-project-root)))

--- a/projectile.el
+++ b/projectile.el
@@ -2711,16 +2711,15 @@ regular expression."
       (let ((ag-command (if arg 'ag-regexp 'ag))
             (ag-ignore-list (delq nil
                                   (delete-dups
-                                   (copy-sequence
-                                    (append
-                                     ag-ignore-list
-                                     (projectile--globally-ignored-file-suffixes-glob)
-                                     ;; ag supports git ignore files directly
-                                     (unless (eq (projectile-project-vcs) 'git)
-                                       (append (projectile-ignored-files-rel)
-                                               (projectile-ignored-directories-rel)
-                                               grep-find-ignored-files
-                                               grep-find-ignored-directories)))))))
+                                   (append
+                                    ag-ignore-list
+                                    (projectile--globally-ignored-file-suffixes-glob)
+                                    ;; ag supports git ignore files directly
+                                    (unless (eq (projectile-project-vcs) 'git)
+                                      (append (projectile-ignored-files-rel)
+                                              (projectile-ignored-directories-rel)
+                                              grep-find-ignored-files
+                                              (copy-sequence grep-find-ignored-directories)))))))
             ;; reset the prefix arg, otherwise it will affect the ag-command
             (current-prefix-arg nil))
         (funcall ag-command search-term (projectile-project-root)))


### PR DESCRIPTION
The call to `delete-dups` in `projectile-ag` throws an error if it tries to modify the read-only object `grep-find-ignored-directories`.  This only happens on non-Git projects, since `projectile-ag` only references `grep-find-ignored-directories` if `projectile-project-vcs` does not return `git`.  This PR wraps the reference to `grep-find-ignored-directories` with a call to `copy-sequence`, which prevents `delete-dups` from modifying `grep-find-ignored-directories`.

I'm not sure if this is the best way to solve the problem.  Please let me know if there is a better solution!

Fixes #1162 