### PR TITLE
Improved support for out-of-tree compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* [#1175](https://github.com/bbatsov/projectile/pull/1175): Add a command `projectile-configure-command` for running a configuration for build systems that need that.
 * [#1168](https://github.com/bbatsov/projectile/pull/1168): Add CMake and Meson project support.
 * [#1159](https://github.com/bbatsov/projectile/pull/1159) Add [nix](http://nixos.org) project support.
 * [#1166](https://github.com/bbatsov/projectile/pull/1166): Add `-other-frame` versions of commands that had `-other-window` versions.
@@ -15,6 +16,9 @@
 
 ### Changes
 
+* [#1175](https://github.com/bbatsov/projectile/pull/1175): `projectile-register-project-type` can now set a default compilation directory for build systems that needs to build out-of-tree (eg. meson).
+* [#1175](https://github.com/bbatsov/projectile/pull/1175): `projectile-{test,run}-project` now run inside `(projectile-compilation-dir)`, just like `projectile-compile-project`.
+* [#1175](https://github.com/bbatsov/projectile/pull/1175): `projectile-{test,run}-project` now stores the default command per directory instead of per project, just like `projectile-compile-project`.
 * Cache the root of the current project to increase performance
 * [#1129](https://github.com/bbatsov/projectile/pull/1129): Fix TRAMP issues.
 * Add R DESCRIPTION file to `projectile-project-root-files`.
@@ -33,6 +37,7 @@
 
 ### Bugs fixed
 
+* [#1169](https://github.com/bbatsov/projectile/issues/1169): `projectile-compile-project` does not prompt for compilation command.
 * [#1072](https://github.com/bbatsov/projectile/issues/1072): Create test files only within the project.
 * [#1063](https://github.com/bbatsov/projectile/issues/1063): Support Fossil checkouts on Windows.
 * [#1024](https://github.com/bbatsov/projectile/issues/1024): Do not cache ignored project files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-* [#1166](https://github.com/bbatsov/projectile/pull/1168): Add CMake and Meson project support.
+* [#1168](https://github.com/bbatsov/projectile/pull/1168): Add CMake and Meson project support.
 * [#1159](https://github.com/bbatsov/projectile/pull/1159) Add [nix](http://nixos.org) project support.
 * [#1166](https://github.com/bbatsov/projectile/pull/1166): Add `-other-frame` versions of commands that had `-other-window` versions.
 * Consider Ensime configuration file as root marker, `.ensime`.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -58,6 +58,7 @@ Keybinding         | Description
 <kbd>C-c p s s</kbd> | Runs `ag` on the project. Requires the presence of `ag.el`.
 <kbd>C-c p !</kbd> | Runs `shell-command` in the root directory of the project.
 <kbd>C-c p &</kbd> | Runs `async-shell-command` in the root directory of the project.
+<kbd>C-c p C</kbd> | Runs a standard configure command for your type of project.
 <kbd>C-c p c</kbd> | Runs a standard compilation command for your type of project.
 <kbd>C-c p P</kbd> | Runs a standard test command for your type of project.
 <kbd>C-c p t</kbd> | Toggle between an implementation file and its test file.

--- a/projectile.el
+++ b/projectile.el
@@ -3248,33 +3248,6 @@ with a prefix ARG."
                                                       project-root)))
     (projectile-run-compilation compilation-cmd)))
 
-(defadvice compilation-find-file (around projectile-compilation-find-file)
-  "Try to find a buffer for FILENAME, if we cannot find it,
-fallback to the original function."
-  (let ((filename (ad-get-arg 1))
-        full-filename)
-    (ad-set-arg 1
-                (or
-                 (if (file-exists-p (expand-file-name filename))
-                     filename)
-                 ;; Try to find the filename using projectile
-                 (and (projectile-project-p)
-                      (let ((root (projectile-project-root))
-                            (dirs (cons "" (projectile-current-project-dirs))))
-                        (when (setq full-filename
-                                    (car (cl-remove-if-not
-                                          #'file-exists-p
-                                          (mapcar
-                                           (lambda (f)
-                                             (expand-file-name
-                                              filename
-                                              (expand-file-name f root)))
-                                           dirs))))
-                          full-filename)))
-                 ;; Fall back to the old argument
-                 filename))
-    ad-do-it))
-
 ;; TODO - factor this duplication out
 ;;;###autoload
 (defun projectile-test-project (arg)
@@ -3309,6 +3282,33 @@ with a prefix ARG."
          (default-directory project-root))
     (puthash project-root run-cmd projectile-run-cmd-map)
     (projectile-run-compilation run-cmd)))
+
+(defadvice compilation-find-file (around projectile-compilation-find-file)
+  "Try to find a buffer for FILENAME, if we cannot find it,
+fallback to the original function."
+  (let ((filename (ad-get-arg 1))
+        full-filename)
+    (ad-set-arg 1
+                (or
+                 (if (file-exists-p (expand-file-name filename))
+                     filename)
+                 ;; Try to find the filename using projectile
+                 (and (projectile-project-p)
+                      (let ((root (projectile-project-root))
+                            (dirs (cons "" (projectile-current-project-dirs))))
+                        (when (setq full-filename
+                                    (car (cl-remove-if-not
+                                          #'file-exists-p
+                                          (mapcar
+                                           (lambda (f)
+                                             (expand-file-name
+                                              filename
+                                              (expand-file-name f root)))
+                                           dirs))))
+                          full-filename)))
+                 ;; Fall back to the old argument
+                 filename))
+    ad-do-it))
 
 (defun projectile-open-projects ()
   "Return a list of all open projects.

--- a/projectile.el
+++ b/projectile.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/bbatsov/projectile
 ;; Keywords: project, convenience
 ;; Version: 0.15.0-cvs
-;; Package-Requires: ((emacs "24.1") (pkg-info "0.4"))
+;; Package-Requires: ((emacs "24.3") (pkg-info "0.4"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/projectile.el
+++ b/projectile.el
@@ -2243,9 +2243,9 @@ tests the project, RUN which specifies a command that runs the
 project, TEST-SUFFIX which specifies test file suffix, and
 TEST-PREFIX which specifies test file prefix."
   (let ((project-plist (list 'marker-files marker-files
-                              'compile-command compile
-                              'test-command test
-                              'run-command run)))
+                             'compile-command compile
+                             'test-command test
+                             'run-command run)))
     ;; There is no way for the function to distinguish between an
     ;; explicit argument of nil and an omitted argument. However, the
     ;; body of the function is free to consider nil an abbreviation
@@ -2585,11 +2585,11 @@ Fallback to DEFAULT-VALUE for missing attributes."
   "Find default test files prefix based on PROJECT-TYPE."
   (cl-flet ((prefix (&optional pfx)
                     (projectile-project-type-attribute project-type 'test-prefix pfx)))
-      (cond
-       ((member project-type '(django python-pip python-pkg python-tox))  (prefix "test_"))
-       ((member project-type '(emacs-cask)) (prefix "test-"))
-       ((member project-type '(lein-midje)) (prefix "t_"))
-       (t (prefix)))))
+    (cond
+     ((member project-type '(django python-pip python-pkg python-tox))  (prefix "test_"))
+     ((member project-type '(emacs-cask)) (prefix "test-"))
+     ((member project-type '(lein-midje)) (prefix "t_"))
+     (t (prefix)))))
 
 (defun projectile-test-suffix (project-type)
   "Find default test files suffix based on PROJECT-TYPE."

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -656,7 +656,8 @@
 
 (ert-deftest projectile-test-compilation-directory ()
   (defun helper (project-root rel-dir)
-    (noflet ((projectile-project-root () project-root))
+    (noflet ((projectile-project-root () project-root)
+             (projectile-project-type () 'generic))
             (let ((projectile-project-compilation-dir rel-dir))
               (projectile-compilation-dir))))
 
@@ -664,6 +665,20 @@
   (should (equal "/root/build/" (helper "/root/" "build/")))
   (should (equal "/root/build/" (helper "/root/" "./build")))
   (should (equal "/root/local/build/" (helper "/root/" "local/build"))))
+
+(ert-deftest projectile-test-compilation-directory-with-default-directory ()
+  (projectile-register-project-type 'default-dir-project '("file.txt")
+                                    :compilation-dir "build")
+  (defun helper (project-root &optional rel-dir)
+    (noflet ((projectile-project-root () project-root)
+             (projectile-project-type () 'default-dir-project))
+            (if (null rel-dir)
+                (projectile-compilation-dir)
+              (let ((projectile-project-compilation-dir rel-dir))
+                (projectile-compilation-dir)))))
+
+  (should (equal "/root/build/"       (helper "/root/")))
+  (should (equal "/root/buildings/"   (helper "/root/" "buildings"))))
 
 (ert-deftest projectile-detect-project-type-of-rails-like-npm-test ()
   (projectile-test-with-sandbox


### PR DESCRIPTION
Make it possible to enforce out-of-tree compilation for build systems that can't build in-tree (eg. meson) while also making out-of-tree or in-tree compilation a preference for the user to set for build-systems that can do both (CMake, autotools etc).

These build systems usually needs to run a configure step before building so this PR adds a new command for that too.

As part of this I factored out the common body of `projectile-{compile,test,run}-project`, but these commands were behaving differently in subtle ways so this PR also makes them work the same. 

Specifically: 
 - All these commands now run inside `(projectile-compilation-dir)`, not
   just the compile command.
 - All these commands cache the compilation command per directory
   instead of per project (again not just the compile command).
 - The extra `dir` parameter to the compile command was dropped.

There are some subtle changes in some of the commits so please
review carefully. I hope I'm not breaking anything.

Also make the CMake- and meson project types use this new functionality.

Fixes #1169 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ✓ ] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ✓ ] You've added tests (if possible) to cover your change(s)
- [ ✓ ] All tests are passing (`make test`)
- [ ✓ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ✓ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ✓ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
