### PR TITLE
ignored-*-p: Match regular expressions with strings

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1393,7 +1393,11 @@ this case unignored files will be absent from FILES."
 (defun projectile-ignored-buffer-p (buffer)
   "Check if BUFFER should be ignored."
   (or
-   (member (buffer-name buffer) projectile-globally-ignored-buffers)
+   (with-current-buffer buffer
+     (cl-some
+      (lambda (name)
+        (string-match-p name (buffer-name)))
+      projectile-globally-ignored-buffers))
    (with-current-buffer buffer
      (cl-some
       (lambda (mode)
@@ -1519,17 +1523,23 @@ projectile project root."
 
 (defun projectile-ignored-directory-p (directory)
   "Check if DIRECTORY should be ignored."
-  (member directory (projectile-ignored-directories)))
+  (cl-some
+   (lambda (name)
+     (string-match-p name directory))
+   projectile-globally-ignored-directories))
 
 (defun projectile-ignored-file-p (file)
   "Check if FILE should be ignored."
-  (member file (projectile-ignored-files)))
+  (cl-some
+   (lambda (name)
+     (string-match-p name file))
+   (projectile-ignored-files)))
 
 (defun projectile-check-pattern-p (file pattern)
   "Check if FILE meets PATTERN."
   (or (string-suffix-p (directory-file-name pattern)
-                       (directory-file-name file))
-      (member file (file-expand-wildcards pattern t))))
+                      (directory-file-name file))
+     (member file (file-expand-wildcards pattern t))))
 
 (defun projectile-ignored-rel-p (file directory patterns)
   "Check if FILE should be ignored relative to DIRECTORY


### PR DESCRIPTION
Buffers are created by other packages that appear on projectile's buffer lists, but they always have
some variation that makes impossible including all possible name cases, thus regular expressions
come handy for this sort of cases. This commit allows `*-ignored-*-p` functions to work with regular
expressions.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
