### PR TITLE
support relative ignore for alien indexing

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -42,6 +42,7 @@
 (require 'ibuf-ext)
 (require 'compile)
 (require 'grep)
+(require 'em-glob)
 
 (eval-when-compile
   (defvar ag-ignore-list)
@@ -1292,7 +1293,8 @@ If ignored directory prefixed with '*', then ignore all
 directories/subdirectories with matching filename,
 otherwise operates relative to project root."
   (let ((ignored-files (projectile-ignored-files-rel))
-        (ignored-dirs (projectile-ignored-directories-rel)))
+        (ignored-dirs (projectile-ignored-directories-rel))
+        (filtering-regexes (mapcar #'eshell-glob-regexp (car (projectile-filtering-patterns)))))
     (cl-remove-if
      (lambda (file)
        (or (cl-some
@@ -1315,7 +1317,11 @@ otherwise operates relative to project root."
            (cl-some
             (lambda (suf)
               (projectile--stringi= suf (file-name-extension file t)))
-            projectile-globally-ignored-file-suffixes)))
+            projectile-globally-ignored-file-suffixes)
+           (cl-some
+            (lambda (regex)
+              (string-match-p regex (file-name-nondirectory file)))
+            filtering-regexes)))
      files)))
 
 (defun projectile-keep-ignored-files (files)


### PR DESCRIPTION
Projectile relative glob ignore used to work but now it does not work if indexing method is alien (native indexing still works). This PR adds support for glob ignore even if indexing is alien, which is default on non Windows machines.

fixes #1184 
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
