### PR TITLE
Update `projectile-detect-project-type` for detecting order.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2402,7 +2402,7 @@ Fallsback to a generic project type when the type can't be determined."
                                (if (listp marker)
                                    (and (projectile-verify-files marker) project-type)
                                  (and (funcall marker) project-type))))
-                           (projectile-hash-keys projectile-project-types))
+                           (reverse (projectile-hash-keys projectile-project-types)))
                           'generic)))
     (puthash (projectile-project-root) project-type projectile-project-type-cache)
     project-type))

--- a/projectile.el
+++ b/projectile.el
@@ -2289,12 +2289,6 @@ TEST-PREFIX which specifies test file prefix."
 
 (projectile-register-project-type 'emacs-cask '("Cask")
                                   :compile "cask install")
-(projectile-register-project-type 'rails-rspec '("Gemfile" "app" "lib" "db" "config" "spec")
-                                  :compile "bundle exec rails server"
-                                  :test "bundle exec rspec")
-(projectile-register-project-type 'rails-test '("Gemfile" "app" "lib" "db" "config" "test")
-                                  :compile "bundle exec rails server"
-                                  :test "bundle exec rake test")
 (projectile-register-project-type 'symfony '("composer.json" "app" "src" "vendor")
                                   :compile "app/console server:run"
                                   :test "phpunit -c app ")
@@ -2387,6 +2381,12 @@ TEST-PREFIX which specifies test file prefix."
 (projectile-register-project-type 'nix '("default.nix")
                                   :compile "nix-build"
                                   :test "nix-build")
+(projectile-register-project-type 'rails-test '("Gemfile" "app" "lib" "db" "config" "test")
+                                  :compile "bundle exec rails server"
+                                  :test "bundle exec rake test")
+(projectile-register-project-type 'rails-rspec '("Gemfile" "app" "lib" "db" "config" "spec")
+                                  :compile "bundle exec rails server"
+                                  :test "bundle exec rspec")
 
 (defvar-local projectile-project-type nil
   "Buffer local var for overriding the auto-detected project type.
@@ -2402,7 +2402,7 @@ Fallsback to a generic project type when the type can't be determined."
                                (if (listp marker)
                                    (and (projectile-verify-files marker) project-type)
                                  (and (funcall marker) project-type))))
-                           (reverse (projectile-hash-keys projectile-project-types)))
+                           (projectile-hash-keys projectile-project-types))
                           'generic)))
     (puthash (projectile-project-root) project-type projectile-project-type-cache)
     project-type))

--- a/projectile.el
+++ b/projectile.el
@@ -2381,6 +2381,10 @@ TEST-PREFIX which specifies test file prefix."
 (projectile-register-project-type 'nix '("default.nix")
                                   :compile "nix-build"
                                   :test "nix-build")
+
+;; Project detection goes in reverse order of registration.
+;; Rails needs to be registered after npm, otherwise `package.json` makes it `npm`.
+;; https://github.com/bbatsov/projectile/pull/1191
 (projectile-register-project-type 'rails-test '("Gemfile" "app" "lib" "db" "config" "test")
                                   :compile "bundle exec rails server"
                                   :test "bundle exec rake test")

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -645,7 +645,8 @@
      "project/db/"
      "project/config/"
      "project/spec/"
-     "project/package.json")
+     "project/package.json"
+     )
     (let ((projectile-indexing-method 'native))
       (noflet ((projectile-project-root
                 () (file-truename (expand-file-name "project/"))))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -635,6 +635,23 @@
   (should (equal "/root/build/" (helper "/root/" "./build")))
   (should (equal "/root/local/build/" (helper "/root/" "local/build"))))
 
+(ert-deftest projectile-detect-project-type-of-rails-like-npm-test ()
+  (projectile-test-with-sandbox
+   (projectile-test-with-files
+    ("project/"
+     "project/Gemfile"
+     "project/app/"
+     "project/lib/"
+     "project/db/"
+     "project/config/"
+     "project/spec/"
+     "project/package.json")
+    (let ((projectile-indexing-method 'native))
+      (noflet ((projectile-project-root
+                () (file-truename (expand-file-name "project/"))))
+              (should (equal 'rails-rspec
+                             (projectile-detect-project-type))))))))
+
 (ert-deftest projectile-test-dirname-matching-count ()
   (should (equal 2
                  (projectile-dirname-matching-count "src/food/sea.c"


### PR DESCRIPTION
This fixes `projectile-toggle-between-implementation-and-test` in recent rails apps.

Recent rails apps typically include `package.json` in the project root.
This messes up the projectile's project-type detection and sets it `npm` despite `rails-spec` or `rails-test`.

This also fixes: https://github.com/bbatsov/projectile/issues/1121#issuecomment-300851052

### Detail

Original `projectile-detect-project-type` is looking into the `projectile-project-types` hash in **reverse** order of registration.

So if the registrations go in the order of this (and currently they do):

```
(projectile-register-project-type 'rails-rspec '("Gemfile" "app" "lib" "db" "config" "spec")
                                  :compile "bundle exec rails server"
                                  :test "bundle exec rspec")
(projectile-register-project-type 'npm '("package.json")
                                  :compile "npm install"
                                  :test "npm test")
```

and  `package.json` exists, npm beats rails-rspec no matter how other files and dirs are.

Seeing the registration order of the current source code, it likely assumes that the latter, the less strict.
It seems more natural for detection to go in the order of registration.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!