### PR TITLE
Allow the project files to list to expire after a time period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#1057](https://github.com/bbatsov/projectile/issues/1057): Make it possible to disable automatic project tracking via `projectile-track-known-projects-automatically`.
 * Added ability to specify test files suffix and prefix at the project registration.
 * [#1154](https://github.com/bbatsov/projectile/pull/1154) Use npm install instead of build.
+* Added the ability to expire old files list caches via `projectile-projectile-files-cache-expire`.
 
 ### Changes
 


### PR DESCRIPTION
`projectile-enable-caching` is important for performance for commands like `projectile-find-file`. However, the cache lives indefinitely (even across Emacs restarts) and can go stale if files are added/removed outside of Emacs.

Instead, allow the user to specify how long the cache may live by setting `projectile-files-cache-expire`, similar to `projectile-file-exists-local-cache-expire`.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
