### PR TITLE
Allow to cache status of dirty projects

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1248,18 +1248,19 @@ If PROJECT-PATH is a project, check this one instead."
   "Return the list of dirty projects.
 The list is composed of sublists~: (project-path, project-status).
 Raise an error if their is no dirty project."
-  (message "Checking for modifications in known projects...")
-  (let ((projects projectile-known-projects)
-        (status ()))
-    (dolist (project projects)
-      (when (and (projectile-keep-project-p project) (not (string= 'none (projectile-project-vcs project))))
-        (let ((tmp-status (projectile-check-vcs-status project)))
-          (when tmp-status
-            (setq status (cons (list project tmp-status) status))))))
-    (when (= (length status) 0)
-      (message "No dirty projects have been found"))
-    (setq projectile-cached-dirty-projects-status status)
-    status))
+  (save-window-excursion
+    (message "Checking for modifications in known projects...")
+    (let ((projects projectile-known-projects)
+          (status ()))
+      (dolist (project projects)
+        (when (and (projectile-keep-project-p project) (not (string= 'none (projectile-project-vcs project))))
+          (let ((tmp-status (projectile-check-vcs-status project)))
+            (when tmp-status
+              (setq status (cons (list project tmp-status) status))))))
+      (when (= (length status) 0)
+        (message "No dirty projects have been found"))
+      (setq projectile-cached-dirty-projects-status status)
+      status)))
 
 (defun projectile-browse-dirty-projects (&optional cached)
   "Browse dirty version controlled projects.


### PR DESCRIPTION
### Motivation
With a long list of known projects, `projectile-browse-dirty-projects` (`C-c p V`) can take a while.

### Modifications proposed
Dirty projects status is now cached and can be retrieved using prefix argument (`C-u C-c p V`).

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
