### PR TITLE
Allow regexp in globally ignored buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added ability to specify test files suffix and prefix at the project registration.
 * [#1154](https://github.com/bbatsov/projectile/pull/1154) Use npm install instead of build.
 * Added the ability to expire old files list caches via `projectile-projectile-files-cache-expire`.
+* [#949](https://github.com/bbatsov/projectile/issues/949) Allow regular expressions in `projectile-globally-ignored-buffers` defcustom.
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -419,7 +419,7 @@ it for functions working with buffers."
   :type '(repeat string))
 
 (defcustom projectile-globally-ignored-buffers nil
-  "A list of buffer-names ignored by projectile.
+  "A list of regular expressions for buffer-names ignored by projectile.
 
 If a buffer is in the list projectile will ignore
 it for functions working with buffers."
@@ -1415,7 +1415,11 @@ this case unignored files will be absent from FILES."
 (defun projectile-ignored-buffer-p (buffer)
   "Check if BUFFER should be ignored."
   (or
-   (member (buffer-name buffer) projectile-globally-ignored-buffers)
+   (cl-some
+    (lambda (ignore-buffer)
+      (string-match-p (concat "^" ignore-buffer "$")
+                      (buffer-name buffer)))
+    projectile-globally-ignored-buffers)
    (with-current-buffer buffer
      (cl-some
       (lambda (mode)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -569,10 +569,12 @@
     (should-error (projectile-switch-project))))
 
 (ert-deftest projectile-ignored-buffer-p-by-name ()
-  (let ((projectile-globally-ignored-buffers '("*nrepl messages*" "*something*")))
+  (let ((projectile-globally-ignored-buffers '("\\*nrepl messages\\*" "\\*something\\*" "TAGS|.*")))
     (should (projectile-ignored-buffer-p (get-buffer-create "*nrepl messages*")))
     (should (projectile-ignored-buffer-p (get-buffer-create "*something*")))
-    (should-not (projectile-ignored-buffer-p (get-buffer-create "test")))))
+    (should (projectile-ignored-buffer-p (get-buffer-create "TAGS|project-name")))
+    (should-not (projectile-ignored-buffer-p (get-buffer-create "test")))
+    ))
 
 (ert-deftest projectile-test-get-other-files ()
   (let ((projectile-other-file-alist '(;; handle C/C++ extensions


### PR DESCRIPTION
Not sure if this is the right way, but anyway..)

This allows the `projectile-globally-ignored-buffers` customization to contain regular expressions works pretty much the same as with `projectile-globally-ignored-modes`. Is there a reason, why it wasn't implemented the same way from the beginning?

I'm aware of the fact, that all previously defined values which contain any *regex* chars like `*` etc. would have to be escaped.

This would fix: https://github.com/bbatsov/projectile/issues/949

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
