### PR TITLE
[Fix #1171 #1157] Don't use cached values when buffer-file-name is nil

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -909,7 +909,8 @@ will return the current directory, otherwise it'd raise an error."
   ;; cl-subst to replace this 'none value with nil so a nil value is used
   ;; instead
   (or (cl-subst nil 'none
-                (or (and (equal projectile-cached-buffer-file-name buffer-file-name)
+                (or (and projectile-cached-buffer-file-name
+                         (equal projectile-cached-buffer-file-name buffer-file-name)
                          projectile-cached-project-root)
                     (progn
                       (setq projectile-cached-buffer-file-name buffer-file-name)
@@ -988,7 +989,8 @@ function `projectile-project-name' is called."
 (defun projectile-project-name ()
   "Return project name."
   (or projectile-project-name
-      (and (equal projectile-cached-buffer-file-name buffer-file-name)
+      (and projectile-cached-buffer-file-name
+           (equal projectile-cached-buffer-file-name buffer-file-name)
            projectile-cached-project-name)
       (progn
         (setq projectile-cached-buffer-file-name buffer-file-name)


### PR DESCRIPTION
Only use cached values if non nil (otherwise they match buffer's
buffer-file-name nil value in shell-mode).

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
