### PR TITLE
Treat members of projectile-globally-ignored-file-suffixes as file name suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Don't treat `package.json` as a project marker.
 * [#987](https://github.com/bbatsov/projectile/issues/987): projectile-ag ignores ag-ignore-list when projectile-project-vcs is git
 * [#1119](https://github.com/bbatsov/projectile/issues/1119): File search ignores non-root dirs if prefixed with "*"
+* Treat members of `projectile-globally-ignored-file-suffixes` as file name suffixes (previous treat as file extensions).
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -1299,10 +1299,6 @@ function is executing."
   "First remove ignored files from FILES, then add back unignored files."
   (projectile-add-unignored (projectile-remove-ignored files)))
 
-(defun projectile--stringi= (string1 string2)
-  "Match STRING1 and STRING2 case insensitively."
-  (equal (compare-strings string1 nil nil string2 nil nil t) t))
-
 (defun projectile-remove-ignored (files)
   "Remove ignored files and folders from FILES.
 
@@ -1332,7 +1328,7 @@ otherwise operates relative to project root."
             ignored-dirs)
            (cl-some
             (lambda (suf)
-              (projectile--stringi= suf (file-name-extension file t)))
+              (string-suffix-p suf file t))
             projectile-globally-ignored-file-suffixes)))
      files)))
 

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -116,9 +116,9 @@
            (projectile-project-name () "project")
            (projectile-ignored-files-rel () ())
            (projectile-ignored-directories-rel () ()))
-          (let* ((file-names '("foo.c" "foo.o" "foo.so" "foo.o.gz"))
+          (let* ((file-names '("foo.c" "foo.o" "foo.so" "foo.o.gz" "foo.tar.gz" "foo.tar.GZ"))
                  (files (mapcar 'projectile-expand-root file-names)))
-            (let ((projectile-globally-ignored-file-suffixes '(".o" ".so")))
+            (let ((projectile-globally-ignored-file-suffixes '(".o" ".so" ".tar.gz")))
               (should (equal (projectile-remove-ignored files)
                              (mapcar 'projectile-expand-root
                                      '("foo.c" "foo.o.gz"))))))))


### PR DESCRIPTION
Treat members of `projectile-globally-ignored-file-suffixes` as file name suffixes. Previous treat as file extensions. By example, ignore ".min.js" in web project.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
