### PR TITLE
escape % when calling ivy-read

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1741,7 +1741,8 @@ https://github.com/emacs-helm/helm")))
 https://github.com/d11wtq/grizzl")))
            ((eq projectile-completion-system 'ivy)
             (if (fboundp 'ivy-read)
-                (ivy-read prompt choices
+                (ivy-read (concat "%d " (replace-regexp-in-string "%" "%%" prompt))
+                          choices
                           :initial-input initial-input
                           :action (prog1 action
                                     (setq action nil))


### PR DESCRIPTION
`ivy-read' treats the prompt as a format string. If the prompt contains percentage
signs, like in my case, then very likely that the `format' ends up in error.

This commit also adds %d to the beginning of the prompt, which is replaced by the
number of candidates.