### PR TITLE
[Fix #1193] Add :src-dir and :test-dir to project-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Added ability to specify test files suffix and prefix at the project registration.
 * [#1154](https://github.com/bbatsov/projectile/pull/1154) Use npm install instead of build.
 * Added the ability to expire old files list caches via `projectile-projectile-files-cache-expire`.
+* [#?](https://github.com/bbatsov/projectile/pull/?): `projectile-register-project-type` can now be use to customize the source and test directory via `:src-dir` and `:test-dir` for projects with custom needs (eg. maven).
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Added ability to specify test files suffix and prefix at the project registration.
 * [#1154](https://github.com/bbatsov/projectile/pull/1154) Use npm install instead of build.
 * Added the ability to expire old files list caches via `projectile-projectile-files-cache-expire`.
-* [#?](https://github.com/bbatsov/projectile/pull/?): `projectile-register-project-type` can now be use to customize the source and test directory via `:src-dir` and `:test-dir` for projects with custom needs (eg. maven).
+* [#1204](https://github.com/bbatsov/projectile/pull/1204): `projectile-register-project-type` can now be use to customize the source and test directory via `:src-dir` and `:test-dir` for projects with custom needs (eg. maven).
 
 ### Changes
 

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -766,6 +766,29 @@
             (should (equal "test/foo/foo.service.spec.js" test-file))
             (should (equal "src/bar/bar.service.js" impl-file))))))))
 
+(ert-deftest projectile-test-find-matching-test/file-custom-project-with-dirs ()
+  (projectile-test-with-sandbox
+   (projectile-test-with-files
+     ("project/source/foo/"
+      "project/source/bar/"
+      "project/spec/foo/"
+      "project/spec/bar/"
+      "project/source/foo/foo.service.js"
+      "project/source/bar/bar.service.js"
+      "project/spec/foo/foo.service.spec.js"
+      "project/spec/bar/bar.service.spec.js")
+     (let* ((projectile-indexing-method 'native)
+            (reg (projectile-register-project-type 'npm-project '("somefile")
+                                                   :test-suffix ".spec"
+                                                   :test-dir "spec/"
+                                                   :src-dir "source/")))
+        (noflet ((projectile-project-type () 'npm-project)
+                 (projectile-project-root () (file-truename (expand-file-name "project/"))))
+          (let ((test-file (projectile-find-matching-test "source/foo/foo.service.js"))
+                (impl-file (projectile-find-matching-file "spec/bar/bar.service.spec.js")))
+            (should (equal "spec/foo/foo.service.spec.js" test-file))
+            (should (equal "source/bar/bar.service.js" impl-file))))))))
+
 (ert-deftest projectile-test-exclude-out-of-project-submodules ()
   (projectile-test-with-files
    (;; VSC root is here


### PR DESCRIPTION
Currently, the source directory and test directory are hardcoded
values ("src/" and "test/", cf. `projectile-create-test-file-for`)

This commit adds `:src-dir` and `:test-dir` as arguments to
`projectile-project-type` to make it easier to control where the tests
file are created.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
