### PR TITLE
Document options to projectile-register-project-type

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -248,6 +248,20 @@ What this does is:
 5. add *run-command*, in this case it is `npm start`.
 6. add test files suffix for toggling between implementation/test files, in this case it is `.spec`, so the implementation/test file pair could be `service.js`/`service.spec.js` for example.
 
+The available options are:
+
+Option           | Documentation
+---------------- | -------------------------------------------------------------------------------------------
+:compilation-dir | A path, relative to the project root, from where to run the tests and compilation commands.
+:compile         | A command to compile the project.
+:configure       | A command to configure the project. `%s` will be substituted with the project root.
+:run             | A command to run the project.
+:src-dir         | A path, relative to the project root, where the source code lives.
+:test            | A command to test the project.
+:test-dir        | A path, relative to the project root, where the test code lives.
+:test-prefix     | A prefix to generate test files names.
+:test-suffix     | A suffix to generate test files names.
+
 ### Customizing project root files
 
 You can set the values of `projectile-project-root-files`,


### PR DESCRIPTION
Following https://github.com/bbatsov/projectile/pull/1204, add documentation for `projectile-register-project-type` options.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
