### PR TITLE
[Fix #1222] Don't pass nil format string to `format`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### Bugs fixed
 
+* [#1222](https://github.com/bbatsov/projectile/issues/1222): `projectile-configure-project` fails for generic project type
 * [#1162](https://github.com/bbatsov/projectile/issues/1162): `projectile-ag` causes "Attempt to modify read-only object" error.
 * [#1169](https://github.com/bbatsov/projectile/issues/1169): `projectile-compile-project` does not prompt for compilation command.
 * [#1072](https://github.com/bbatsov/projectile/issues/1072): Create test files only within the project.

--- a/projectile.el
+++ b/projectile.el
@@ -3227,8 +3227,9 @@ Should be set via .dir-locals.el.")
   "Retrieve the configure command for COMPILE-DIR."
   (or (gethash compile-dir projectile-configure-cmd-map)
       projectile-project-configure-cmd
-      (format (projectile-default-configure-command (projectile-project-type))
-              (projectile-project-root))))
+      (let ((cmd-format-string (projectile-default-configure-command (projectile-project-type))))
+        (when cmd-format-string
+          (format cmd-format-string (projectile-project-root))))))
 
 (defun projectile-compilation-command (compile-dir)
   "Retrieve the compilation command for COMPILE-DIR."

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -814,6 +814,12 @@
        (should (equal (list (expand-file-name "vendor/client-submodule/" project))
                       (projectile-get-all-sub-projects project)))))))
 
+(ert-deftest projectile-test-configure-command-for-generic-project-type ()
+  (noflet ((projectile-default-configure-command (x) nil)
+           (projectile-project-type () 'generic))
+    (let ((configure-command (projectile-configure-command "fsdf")))
+      (should (equal nil configure-command)))))
+
 ;; Local Variables:
 ;; indent-tabs-mode: nil
 ;; End:


### PR DESCRIPTION
The return value of `projectile-default-configure-command` is checked
for nil, since `format` doesn't accept nil format strings.

- [X] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)