### PR TITLE
Improve documentation for projectile-git-submodule-command

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1024,7 +1024,8 @@ Files are returned as relative paths to the project root."
   :type 'string)
 
 (defcustom projectile-git-submodule-command "git submodule --quiet foreach 'echo $path' | tr '\\n' '\\0'"
-  "Command used by projectile to get the files in git submodules."
+  "Command used by projectile to list submodules of a given git repository.
+Set to nil to disable listing submodules contents."
   :group 'projectile
   :type 'string)
 


### PR DESCRIPTION
This commit 

 - fixes what I think is an error in the documentation of `projectile-git-submodule-command`: the default value doesn't list *files* in submodules, but submodule paths.
 - explains how to deactivate listing submodule contents in `projectile-find-files`, solving #1174.  

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] (**N/A**) You've added tests (if possible) to cover your change(s) 
- [ ] (**N/A**) All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] (**N/A**) You've updated the changelog (if adding/changing user-visible functionality)
- [ ] (**N/A**) You've updated the readme (if adding/changing user-visible functionality)

Thanks!
