### PR TITLE
Add support for a prefix argument to projectile-vc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* [#1228](https://github.com/bbatsov/projectile/pull/1228): Add support for a prefix argument to `projectile-vc`.
 * [#1221](https://github.com/bbatsov/projectile/pull/1221): Modify Ruby and Elixir project settings.
 * [#1175](https://github.com/bbatsov/projectile/pull/1175): Add a command `projectile-configure-command` for running a configuration for build systems that need that.
 * [#1168](https://github.com/bbatsov/projectile/pull/1168): Add CMake and Meson project support.

--- a/projectile.el
+++ b/projectile.el
@@ -3129,8 +3129,15 @@ to run the replacement."
   "Open `vc-dir' at the root of the project.
 
 For git projects `magit-status-internal' is used if available.
-For hg projects `monky-status' is used if available."
-  (interactive)
+For hg projects `monky-status' is used if available.
+
+If PROJECT-ROOT is given, it is opened instead of the project
+root directory of the current buffer file.  If interactively
+called with a prefix argument, the user is prompted for a project
+directory to open."
+  (interactive (list (projectile-completing-read
+                      "Open project VC in: "
+                      projectile-known-projects)))
   (or project-root (setq project-root (projectile-project-root)))
   (let ((vcs (projectile-project-vcs project-root)))
     (cl-case vcs


### PR DESCRIPTION
This makes `C-u M-x projectile-vc` prompt you for a project directory to open.

It currently simply ignores a prefix argument that is interactively given.

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
