### PR TITLE
Fix projectile-vc calling projectile-completing-read regardless of the prefix argument

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3135,9 +3135,11 @@ If PROJECT-ROOT is given, it is opened instead of the project
 root directory of the current buffer file.  If interactively
 called with a prefix argument, the user is prompted for a project
 directory to open."
-  (interactive (list (projectile-completing-read
+  (interactive (and current-prefix-arg
+                    (list
+                     (projectile-completing-read
                       "Open project VC in: "
-                      projectile-known-projects)))
+                      projectile-known-projects))))
   (or project-root (setq project-root (projectile-project-root)))
   (let ((vcs (projectile-project-vcs project-root)))
     (cl-case vcs


### PR DESCRIPTION
This fixes a bug in #1228.

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
