### PR TITLE
Fixed projectile-discover-projects-in-directory command

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -779,7 +779,7 @@ The cache is created both in memory and on the hard drive."
 (defun projectile-maybe-invalidate-cache (force)
   "Invalidate if FORCE or project's dirconfig newer than cache."
   (when (or force (file-newer-than-file-p (projectile-dirconfig-file)
-                                          projectile-cache-file))
+                    projectile-cache-file))
     (projectile-invalidate-cache nil)))
 
 ;;;###autoload
@@ -788,16 +788,17 @@ The cache is created both in memory and on the hard drive."
 This function is not recursive and only adds projects with roots
 at the top level of DIRECTORY."
   (interactive
-   (list (read-directory-name "Starting directory: ")))
+    (list (read-directory-name "Starting directory: ")))
   (let ((subdirs (directory-files directory t)))
     (mapcar
-     (lambda (dir)
-       (when (and (file-directory-p dir)
-                  (not (member (file-name-nondirectory dir) '(".." "."))))
-         (let ((default-directory dir))
-           (when (projectile-project-p)
-             (projectile-add-known-project (projectile-project-root))))))
-     subdirs)))
+      (lambda (dir)
+        (when (and (file-directory-p dir)
+                (not (member (file-name-nondirectory dir) '(".." "."))))
+          (let ((default-directory dir)
+                 (projectile-cached-project-root dir))
+            (when (projectile-project-p)
+              (projectile-add-known-project (projectile-project-root))))))
+      subdirs)))
 
 
 (defadvice delete-file (before purge-from-projectile-cache (filename &optional trash))


### PR DESCRIPTION
Fixes #1165 

Mac users, inc. myself, seemed unable to discover new projects. Root
cause seemed to be a 'sticky' projectile-cached-project-root
dynamically-scoped variable.

Setting this to the dir variable, along with default-directory, fixes
the issue.

Can't seem to test - I get an error:

`Cannot open load file: No such file or directory, noflet`

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] All tests are passing (`make test`)

Thanks!
