### PR TITLE
Make find-file prompt for a project if not in one

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2098,12 +2098,21 @@ With INVALIDATE-CACHE invalidates the cache first.  With FF-VARIANT set to a
 defun, use that instead of `find-file'.   A typical example of such a defun
 would be `find-file-other-window' or `find-file-other-frame'"
   (interactive "P")
-  (projectile-maybe-invalidate-cache invalidate-cache)
-  (let ((file (projectile-completing-read "Find file: "
-                                          (projectile-current-project-files)))
-        (ff (or ff-variant #'find-file)))
-    (funcall ff (expand-file-name file (projectile-project-root)))
-    (run-hooks 'projectile-find-file-hook)))
+  (let (projectile-cached-project-root-temp)
+    (when (eq projectile-cached-project-root 'none)
+      (setq projectile-cached-project-root
+            (projectile-completing-read "Switch to project: "
+                                        (projectile-relevant-known-projects)
+                                        :action #'identity))
+      (setq projectile-cached-project-root-temp
+            projectile-cached-project-root))
+    (projectile-maybe-invalidate-cache invalidate-cache)
+    (let ((file (projectile-completing-read "Find file: "
+                                            (projectile-current-project-files)))
+          (ff (or ff-variant #'find-file)))
+      (funcall ff (expand-file-name file (or projectile-cached-project-root-temp
+                                             (projectile-project-root))))
+      (run-hooks 'projectile-find-file-hook))))
 
 ;;;###autoload
 (defun projectile-find-file (&optional arg)


### PR DESCRIPTION
This PR presents a partial, hacky solution to https://github.com/bbatsov/projectile/issues/850. Currently, executing `projectile-find-file` outside of a project buffer results in an error message saying "You're not in a project". This is annoying, and invariably my next steps are to switch into a project and then rerun the file command. With this change, if `projectile-find-file` is run outside of a project buffer (say, in the scratch buffer on Emacs startup), it will first prompt for a project (using the same prompt as `projectile-switch-project`) and then prompt for files in that project as usual.

The solution, as I said, is hacky: the desired project root is set in a temporary variable, which is saved and then substituted in for the nonexistent real project root at the last minute. It won't do to set `projectile-cached-project-root` directly, since it will immediately get reset by some call to `projectile-project-root` (by my count, this function is called 81 times in the course of a single call to `projectile-find-file`). I don't know if there is a more elegant way to achieve this, but I've been using it without any issue for a few months now.

I say the solution is partial because similar behavior should be implemented for other commands like `projectile-vc` and `projectile-find-dir`.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
