### PR TITLE
Ensure project-roots are directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [#987](https://github.com/bbatsov/projectile/issues/987): projectile-ag ignores ag-ignore-list when projectile-project-vcs is git
 * [#1119](https://github.com/bbatsov/projectile/issues/1119): File search ignores non-root dirs if prefixed with "*"
 * Treat members of `projectile-globally-ignored-file-suffixes` as file name suffixes (previous treat as file extensions).
+* Ensure project roots are added as directory names to avoid near-duplicate projects, e.g. "~/project/" and "~/project".
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -3635,7 +3635,7 @@ See `projectile-cleanup-known-projects'."
   (unless (projectile-ignored-project-p project-root)
     (setq projectile-known-projects
           (delete-dups
-           (cons (abbreviate-file-name project-root)
+           (cons (file-name-as-directory (abbreviate-file-name project-root))
                  projectile-known-projects)))))
 
 (defun projectile-load-known-projects ()

--- a/test/projectile-known-project-test.el
+++ b/test/projectile-known-project-test.el
@@ -5,17 +5,26 @@
 (ert-deftest projectile-test-add-known-project-adds-project-to-known-projects ()
   "An added project should be added to the list of known projects."
   (let (projectile-known-projects)
-    (projectile-add-known-project "~/my/new/project")
+    (projectile-add-known-project "~/my/new/project/")
     (should (string= (car projectile-known-projects)
-                     "~/my/new/project"))))
+                     "~/my/new/project/"))))
 
 (ert-deftest projectile-test-add-known-project-moves-projects-to-front-of-list ()
   "adding a project should move it to the front of the list of known projects, if it already
 existed."
-  (let ((projectile-known-projects (list "~/b" "~/a")))
-    (projectile-add-known-project "~/a")
+  (let ((projectile-known-projects (list "~/b/" "~/a/")))
+    (projectile-add-known-project "~/a/")
     (should (equal projectile-known-projects
-                   (list "~/a" "~/b")))))
+                   (list "~/a/" "~/b/")))))
+
+(ert-deftest projectile-test-add-known-project-no-near-duplicates ()
+  "~/project and ~/project/ should not be added
+  separately to the known projects list."
+  (let ((projectile-known-projects '("~/a/")))
+    (projectile-add-known-project "~/a")
+    (projectile-add-known-project "~/b")
+    (projectile-add-known-project "~/b/")
+    (should (equal projectile-known-projects '("~/b/" "~/a/")))))
 
 (defun projectile-mock-serialization-functions (&rest body)
   (let (projectile-serialization-calls)


### PR DESCRIPTION
Projectile adds projects as directory names, as in `~/project/`.
Manually adding a project root that is not a directory name, as
in `(projectile-add-known-project "~/project")`, works fine, but
Projectile will then add the project root as a directory name, so that
both `~/project` and `~/project/` will be in the list of known
projects.

This change converts `~/project` to `~/project/` before adding it to
the list, thereby avoiding annoying near-duplicates.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
