### PR TITLE
[Fix #1246] Give clear-known-projects test temp project file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * [#1011](https://github.com/bbatsov/projectile/issues/1011): Save project files before running project tests.
 * [#1099](https://github.com/bbatsov/projectile/issues/1099): Fix the behaviour of `projectile-purge-dir-from-cache`.
 * [#1067](https://github.com/bbatsov/projectile/issues/1067): Don't mess up `default-directory` after switching projects.
+* [#1246](https://github.com/bbatsov/projectile/issues/1246): Don't blow away real project file during tests.
 
 ## 0.14.0 (2016-07-08)
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,1 +1,2 @@
 sandbox/
+tmp/

--- a/test/projectile-known-project-test.el
+++ b/test/projectile-known-project-test.el
@@ -125,6 +125,12 @@ test temp directory"
       (when (file-exists-p this-test-file)
         (delete-file this-test-file)))))
 
+(ert-deftest projectile-clear-known-projects ()
+  (let ((projectile-known-projects '("one" "two" "three"))
+        (projectile-known-projects-file (projectile-test-tmp-file-path)))
+    (projectile-clear-known-projects)
+    (should (null projectile-known-projects))))
+
 ;; Local Variables:
 ;; indent-tabs-mode: nil
 ;; End:

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -557,13 +557,6 @@
 		(re-search-forward sym)
 		(projectile-grep nil ?-)))))))))
 
-;;;;;;;;; fresh tests
-
-(ert-deftest projectile-clear-known-projects ()
-  (let ((projectile-known-projects '("one" "two" "three")))
-    (projectile-clear-known-projects)
-    (should (null projectile-known-projects))))
-
 (ert-deftest projectile-switch-project-no-projects ()
   (let ((projectile-known-projects nil))
     (should-error (projectile-switch-project))))


### PR DESCRIPTION
This test was blowing away the actual project file, rather than a test
file. To fix this, move the test to the known-project-test file and
give it test-tmp-file-path.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
