### PR TITLE
Don't autoload defcustom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [#1119](https://github.com/bbatsov/projectile/issues/1119): File search ignores non-root dirs if prefixed with "*"
 * Treat members of `projectile-globally-ignored-file-suffixes` as file name suffixes (previous treat as file extensions).
 * Ensure project roots are added as directory names to avoid near-duplicate projects, e.g. "~/project/" and "~/project".
+* Don't autoload defcustoms.
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -3970,7 +3970,6 @@ is chosen."
 
 (easy-menu-change '("Tools") "--" nil "Search Files (Grep)...")
 
-;;;###autoload
 (defcustom projectile-mode-line
   '(:eval (format " Projectile[%s]"
                   (projectile-project-name)))


### PR DESCRIPTION
Remove declaration of `projectile-mode-line` as an autoload.

Fixes bbatsov/projectile#1080