### PR TITLE
Add support for function symbols as project default commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ## 1.0.0 (2018-07-21)
 
 ### New Features
-
+* [#1255](https://github.com/bbatsov/projectile/pull/1255): Add support for function symbols as project default commands
 * [#1243](https://github.com/bbatsov/projectile/pull/1243) Add [angular](https://angular.io) project support.
 * [#1228](https://github.com/bbatsov/projectile/pull/1228): Add support for a prefix argument to `projectile-vc`.
 * [#1221](https://github.com/bbatsov/projectile/pull/1221): Modify Ruby and Elixir project settings.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -267,6 +267,46 @@ Option           | Documentation
 :test-prefix     | A prefix to generate test files names.
 :test-suffix     | A suffix to generate test files names.
 
+#### Returning Projectile Commands from a function
+
+You can also pass a symbolic reference to a function into your project type definition if you wish to define the compile command dynamically:
+
+```el
+(defun my/compile-command ()
+  "Returns a String representing the compile command to run for the given context"
+  (cond
+   ((and (eq major-mode 'java-mode)
+         (not (string-match-p (regexp-quote "\\.*/test/\\.*") (buffer-file-name (current-buffer)))))
+    "./gradlew build")
+   ((eq major-mode 'web-mode)
+    "./gradlew compile-templates")
+   ))
+
+(defun my/test-command ()
+  "Returns a String representing the test command to run for the given context"
+  (cond
+   ((eq major-mode 'js-mode) "grunt test") ;; Test the JS of the project
+   ((eq major-mode 'java-mode) "./gradlew test") ;; Test the Java code of the project
+   ((eq major-mode 'my-mode) "special-command.sh") ;; Even Special conditions/test-sets can be covered
+   ))
+
+(projectile-register-project-type 'has-command-at-point '("file.txt")
+                                  :compile 'my/compile-command
+                                  :test 'my/test-command)
+```
+
+If you would now navigate to a file that has the `*.java` extension under the `./tests/` directory and hit `C-c c p` you
+will see `./gradlew build` as the suggestion. If you were to navigate to a HTML file the compile command will have switched
+to `./gradlew compile-templates`.
+
+This works for:
+- `:configure`
+- `:compile`
+- `:compilation-dir`
+- `:run`
+
+Note that your function has to return a string to work properly.
+
 ## Customizing project root files
 
 You can set the values of `projectile-project-root-files`,

--- a/projectile.el
+++ b/projectile.el
@@ -3245,7 +3245,7 @@ to function `funcall's. Return value of function MUST be string to be executed a
       (if (fboundp command)
         (funcall (symbol-function command))))
      (t
-      (error (format "The value for: %s in project-type: %s was neither a function nor a string." command-type project-type))))))
+      (user-error "The value for: %s in project-type: %s was neither a function nor a string." command-type project-type)))))
 
 (defun projectile-default-configure-command (project-type)
   "Retrieve default configure command for PROJECT-TYPE."

--- a/projectile.el
+++ b/projectile.el
@@ -3233,25 +3233,38 @@ Should be set via .dir-locals.el.")
 It takes precedence over the default command for the project type when set.
 Should be set via .dir-locals.el.")
 
+(defun projectile-default-generic-command (project-type command-type)
+  "Generic retrieval of COMMAND-TYPEs default cmd-value for PROJECT-TYPE.
+
+If found, checks if value is symbol or string. In case of symbol resolves
+to function `funcall's. Return value of function MUST be string to be executed as command."
+  (let ((plist-retrieved-generic-command (plist-get (gethash project-type projectile-project-types) command-type)))
+    (cond
+     ((stringp plist-retrieved-generic-command) plist-retrieved-generic-command)
+     ((symbolp 'plist-retrieved-generic-command)
+      (if (fboundp plist-retrieved-generic-command)
+          (funcall (symbol-function plist-retrieved-generic-command))))
+     )))
+
 (defun projectile-default-configure-command (project-type)
   "Retrieve default configure command for PROJECT-TYPE."
-  (plist-get (gethash project-type projectile-project-types) 'configure-command))
+  (projectile-default-generic-command project-type 'configure-command))
 
 (defun projectile-default-compilation-command (project-type)
   "Retrieve default compilation command for PROJECT-TYPE."
-  (plist-get (gethash project-type projectile-project-types) 'compile-command))
+  (projectile-default-generic-command project-type 'compile-command))
 
 (defun projectile-default-compilation-dir (project-type)
   "Retrieve default compilation directory for PROJECT-TYPE."
-  (plist-get (gethash project-type projectile-project-types) 'compilation-dir))
+  (projectile-default-generic-command project-type 'compilation-dir))
 
 (defun projectile-default-test-command (project-type)
   "Retrieve default test command for PROJECT-TYPE."
-  (plist-get (gethash project-type projectile-project-types) 'test-command))
+  (projectile-default-generic-command project-type 'test-command))
 
 (defun projectile-default-run-command (project-type)
   "Retrieve default run command for PROJECT-TYPE."
-  (plist-get (gethash project-type projectile-project-types) 'run-command))
+  (projectile-default-generic-command project-type 'run-command))
 
 (defun projectile-configure-command (compile-dir)
   "Retrieve the configure command for COMPILE-DIR.

--- a/projectile.el
+++ b/projectile.el
@@ -3238,13 +3238,14 @@ Should be set via .dir-locals.el.")
 
 If found, checks if value is symbol or string. In case of symbol resolves
 to function `funcall's. Return value of function MUST be string to be executed as command."
-  (let ((plist-retrieved-generic-command (plist-get (gethash project-type projectile-project-types) command-type)))
+  (let ((command (plist-get (gethash project-type projectile-project-types) command-type)))
     (cond
-     ((stringp plist-retrieved-generic-command) plist-retrieved-generic-command)
-     ((symbolp 'plist-retrieved-generic-command)
-      (if (fboundp plist-retrieved-generic-command)
-          (funcall (symbol-function plist-retrieved-generic-command))))
-     )))
+     ((stringp command) command)
+     ((functionp command)
+      (if (fboundp command)
+        (funcall (symbol-function command))))
+     (t
+      (error (format "The value for: %s in project-type: %s was neither a function nor a string." command-type project-type))))))
 
 (defun projectile-default-configure-command (project-type)
   "Retrieve default configure command for PROJECT-TYPE."

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -684,6 +684,20 @@
   (should (equal "/root/build/"       (helper "/root/")))
   (should (equal "/root/buildings/"   (helper "/root/" "buildings"))))
 
+(ert-deftest projectile-test-compilation-command-at-point ()
+  (defun -compilation-test-function ()
+    (if (= (point) 1)
+        "my-make"
+      "./run-extra"))
+  (projectile-register-project-type 'has-command-at-point '("file.txt")
+                                    :compile '-compilation-test-function)
+
+  (should (equal "my-make" (projectile-default-compilation-command 'has-command-at-point)))
+  (with-temp-buffer
+    (insert "ABCDE")
+    (goto-char 2)
+    (should (equal "./run-extra" (projectile-default-compilation-command 'has-command-at-point)))))
+
 (ert-deftest projectile-detect-project-type-of-rails-like-npm-test ()
   (projectile-test-with-sandbox
    (projectile-test-with-files

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -698,6 +698,14 @@
     (goto-char 2)
     (should (equal "./run-extra" (projectile-default-compilation-command 'has-command-at-point)))))
 
+(ert-deftest projectile-test-failed-on-bad-project-type-config ()
+  (defun -compilation-test-function ()
+    1)
+  (projectile-register-project-type 'has-command-at-point '("file.txt")
+                                    :compile (-compilation-test-function))
+
+  (should-error (projectile-default-compilation-command 'has-command-at-point)))
+
 (ert-deftest projectile-detect-project-type-of-rails-like-npm-test ()
   (projectile-test-with-sandbox
    (projectile-test-with-files


### PR DESCRIPTION
This allows for the implementation of IDE-like features where projectile could context-sensitively change the value of the command to execute for a given command type.

An example usage of this feature would go as follows:

```elisp
(defun my/compile-command ()
  "Returns a String representing the compile command to run for the given context"
  (cond
   ((and (eq major-mode 'java-mode)
         (not (string-match-p (regexp-quote "\\.*/test/\\.*") (buffer-file-name (current-buffer)))))
    "./gradlew build")
   ((eq major-mode 'web-mode)
    "./gradlew compile-templates")
   ))

(defun my/test-command ()
  "Returns a String representing the test command to run for the given context"
  (cond
   ((eq major-mode 'js-mode) "grunt test") ;; Test the JS of the project
   ((eq major-mode 'java-mode) "./gradlew test") ;; Test the Java code of the project
   ((eq major-mode 'my-mode) "special-command.sh") ;; Even Special conditions/test-sets can be covered
   ))

(projectile-register-project-type 'has-command-at-point '("file.txt")
                                  :compile 'my/compile-command
                                  :test 'my/test-command)
```

In cases where one projectile project covers multiple different build types and commands to run
subdivisions of the testset this is a major improvement.

I added a subsection in the documentation regarding this option when defining a new project-type.

The CHANGELOG.md now references this changeset as well.