### PR TITLE
Avoid "No projects needed to be removed." messages in global mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * **(Breaking)** Change the prefix for the Projectile mode commands to `C-c C-p`.
+* Avoid "No projects needed to be removed." messages in global mode
 
 ## 1.0.0 (2018-07-21)
 

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -196,7 +196,7 @@
       (should (equal '("a/b/c" "a/d/e") (projectile-dir-files "a/"))))))
 
 (ert-deftest projectile-test-setup-hook-functions-projectile-mode ()
-  (noflet ((projectile-cleanup-known-projects () nil)
+  (noflet ((projectile--cleanup-known-projects () nil)
            (projectile-discover-projects-in-search-path () nil))
     (projectile-mode 1)
     (should (memq 'projectile-find-file-hook-function find-file-hook))
@@ -214,10 +214,10 @@
          (projectile-known-projects directories))
     (unwind-protect
         (progn
-          (projectile-cleanup-known-projects)
+          (projectile--cleanup-known-projects)
           (should (equal projectile-known-projects directories))
           (delete-directory (car directories))
-          (projectile-cleanup-known-projects)
+          (projectile--cleanup-known-projects)
           (should (equal projectile-known-projects (cdr directories))))
       (--each directories (ignore-errors (delete-directory it)))
       (delete-file projectile-known-projects-file nil))))


### PR DESCRIPTION
When enabling projectile-global-mode every time a new file buffer is
opened, a "No projects needed to be removed." message is triggered.
These messages are not helpful to the user, clutter the messages buffer,
may obscure other more informative messages in the mini buffer, and are
rather annoying.