### PR TITLE
[Fix #1252] Switch to unconnected remote projects

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3479,7 +3479,8 @@ Invokes the command referenced by `projectile-switch-project-action' on switch.
 With a prefix ARG invokes `projectile-commander' instead of
 `projectile-switch-project-action.'"
   (interactive "P")
-  (let ((projects (projectile-relevant-known-projects)))
+  (let ((projects (projectile-relevant-known-projects))
+        (projectile-require-project-root nil))
     (if projects
         (projectile-completing-read
          "Switch to project: " projects


### PR DESCRIPTION
Fixes "You're not in a project" error when remote is not connected yet.

- [X] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
