### PR TITLE
ignored-*-p: Match against regular expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changes
 
-* ignore-*-p functions match against regular expressions.
+* * [#1177](https://github.com/bbatsov/projectile/pull/1177): ignored-*-p: Now they match against regular expressions.
 * **(Breaking)** Change the prefix for the Projectile mode commands to `C-c C-p`.
 * Avoid "No projects needed to be removed." messages in global mode
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changes
 
-* * [#1177](https://github.com/bbatsov/projectile/pull/1177): ignored-*-p: Now they match against regular expressions.
+* * [#1260](https://github.com/bbatsov/projectile/pull/1260): ignored-*-p: Now they match against regular expressions.
 * **(Breaking)** Change the prefix for the Projectile mode commands to `C-c C-p`.
 * Avoid "No projects needed to be removed." messages in global mode
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+* ignore-*-p functions match against regular expressions.
 * **(Breaking)** Change the prefix for the Projectile mode commands to `C-c C-p`.
 * Avoid "No projects needed to be removed." messages in global mode
 

--- a/projectile.el
+++ b/projectile.el
@@ -306,7 +306,9 @@ containing a root file."
   :type '(repeat string))
 
 (defcustom projectile-globally-unignored-files nil
-  "A list of files globally unignored by projectile."
+  "A list of files globally unignored by projectile.
+
+Regular expressions can be used."
   :group 'projectile
   :type '(repeat string)
   :package-version '(projectile . "0.14.0"))
@@ -330,7 +332,9 @@ containing a root file."
     ".tox"
     ".svn"
     ".stack-work")
-  "A list of directories globally ignored by projectile."
+  "A list of directories globally ignored by projectile.
+
+Regular expressions can be used."
   :safe (lambda (x) (not (remq t (mapcar #'stringp x))))
   :group 'projectile
   :type '(repeat string))
@@ -358,8 +362,8 @@ it for functions working with buffers."
 (defcustom projectile-globally-ignored-buffers nil
   "A list of buffer-names ignored by projectile.
 
-If a buffer is in the list projectile will ignore
-it for functions working with buffers."
+If a buffer is in the list projectile will ignore it for
+functions working with buffers. Regular expressions can be used."
   :group 'projectile
   :type '(repeat string)
   :package-version '(projectile . "0.12.0"))
@@ -1374,7 +1378,9 @@ this case unignored files will be absent from FILES."
          (string-prefix-p project-root (file-truename default-directory) (eq system-type 'windows-nt)))))
 
 (defun projectile-ignored-buffer-p (buffer)
-  "Check if BUFFER should be ignored."
+  "Check if BUFFER should be ignored.
+
+Regular expressions can be use."
   (or
    (with-current-buffer buffer
      (cl-some
@@ -1505,14 +1511,18 @@ projectile project root."
     (mapcar (lambda (f) (file-relative-name f project-root)) files)))
 
 (defun projectile-ignored-directory-p (directory)
-  "Check if DIRECTORY should be ignored."
+  "Check if DIRECTORY should be ignored.
+
+Regular expressions can be use."
   (cl-some
    (lambda (name)
      (string-match-p name directory))
    (projectile-ignored-directories)))
 
 (defun projectile-ignored-file-p (file)
-  "Check if FILE should be ignored."
+  "Check if FILE should be ignored.
+
+Regular expressions can be use."
   (cl-some
    (lambda (name)
      (string-match-p name file))

--- a/projectile.el
+++ b/projectile.el
@@ -1376,7 +1376,11 @@ this case unignored files will be absent from FILES."
 (defun projectile-ignored-buffer-p (buffer)
   "Check if BUFFER should be ignored."
   (or
-   (member (buffer-name buffer) projectile-globally-ignored-buffers)
+   (with-current-buffer buffer
+     (cl-some
+      (lambda (name)
+        (string-match-p name (buffer-name)))
+      projectile-globally-ignored-buffers))
    (with-current-buffer buffer
      (cl-some
       (lambda (mode)
@@ -1502,17 +1506,23 @@ projectile project root."
 
 (defun projectile-ignored-directory-p (directory)
   "Check if DIRECTORY should be ignored."
-  (member directory (projectile-ignored-directories)))
+  (cl-some
+   (lambda (name)
+     (string-match-p name directory))
+   projectile-globally-ignored-directories))
 
 (defun projectile-ignored-file-p (file)
   "Check if FILE should be ignored."
-  (member file (projectile-ignored-files)))
+  (cl-some
+   (lambda (name)
+     (string-match-p name file))
+   (projectile-ignored-files)))
 
 (defun projectile-check-pattern-p (file pattern)
   "Check if FILE meets PATTERN."
   (or (string-suffix-p (directory-file-name pattern)
-                       (directory-file-name file))
-      (member file (file-expand-wildcards pattern t))))
+                      (directory-file-name file))
+     (member file (file-expand-wildcards pattern t))))
 
 (defun projectile-ignored-rel-p (file directory patterns)
   "Check if FILE should be ignored relative to DIRECTORY

--- a/projectile.el
+++ b/projectile.el
@@ -1509,7 +1509,7 @@ projectile project root."
   (cl-some
    (lambda (name)
      (string-match-p name directory))
-   projectile-globally-ignored-directories))
+   (projectile-ignored-directories)))
 
 (defun projectile-ignored-file-p (file)
   "Check if FILE should be ignored."

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -51,33 +51,37 @@
     (should (equal (projectile-expand-root "./foo/bar") "/path/to/project/foo/bar"))))
 
 (ert-deftest projectile-test-ignored-directory-p ()
-  (noflet ((projectile-ignored-directories () '("/path/to/project/tmp")))
-    (should (projectile-ignored-directory-p "/path/to/project/tmp"))
-    (should-not (projectile-ignored-directory-p "/path/to/project/log"))))
+  (noflet ((projectile-ignored-directories () '("/path/to/project/tmp" "/path/to/project/t.*")))
+          (should (projectile-ignored-directory-p "/path/to/project/tmp"))
+          (should-not (projectile-ignored-directory-p "/path/to/project/log"))))
 
 (ert-deftest projectile-test-ignored-file-p ()
-  (noflet ((projectile-ignored-files () '("/path/to/project/TAGS")))
-    (should (projectile-ignored-file-p "/path/to/project/TAGS"))
-    (should-not (projectile-ignored-file-p "/path/to/project/foo.el"))))
+  (noflet ((projectile-ignored-files () '("/path/to/project/TAGS" "/path/to/project/T.*")))
+          (should (projectile-ignored-file-p "/path/to/project/TAGS"))
+          (should-not (projectile-ignored-file-p "/path/to/project/foo.el"))))
 
 (ert-deftest projectile-test-ignored-files ()
   (noflet ((projectile-project-root () "/path/to/project")
            (projectile-project-name () "project")
            (projectile-project-ignored-files () '("foo.js" "bar.rb")))
-    (let ((expected '("/path/to/project/TAGS"
-                      "/path/to/project/foo.js"
-                      "/path/to/project/bar.rb"))
-          (projectile-ignored-files '("TAGS")))
-      (should (equal (projectile-ignored-files) expected)))))
+          (let ((expected '("/path/to/project/TAGS"
+                            "/path/to/project/foo.js"
+                            "/path/to/project/bar.rb"
+                            "/path/to/project/file1.log"
+                            "/path/to/project/file2.log"))
+                (projectile-ignored-files '("TAGS" "file\d+\\.log")))
+            (should (equal (projectile-ignored-files) expected)))))
 
 (ert-deftest projectile-test-ignored-directories ()
   (noflet ((projectile-project-ignored-directories () '("tmp" "log"))
            (projectile-project-root () "/path/to/project"))
-    (let ((expected '("/path/to/project/compiled/"
-                      "/path/to/project/tmp/"
-                      "/path/to/project/log/"))
-          (projectile-globally-ignored-directories '("compiled")))
-      (should (equal (projectile-ignored-directories) expected)))))
+          (let ((expected '("/path/to/project/compiled/"
+                            "/path/to/project/ignoreme"
+                            "/path/to/project/ignoremetoo"
+                            "/path/to/project/tmp/"
+                            "/path/to/project/log/"))
+                (projectile-globally-ignored-directories '("compiled" "ignoreme")))
+            (should (equal (projectile-ignored-directories) expected)))))
 
 (ert-deftest projectile-test-project-ignored-files ()
   (let ((files '("/path/to/project/foo.el" "/path/to/project/foo.elc")))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -51,8 +51,9 @@
     (should (equal (projectile-expand-root "./foo/bar") "/path/to/project/foo/bar"))))
 
 (ert-deftest projectile-test-ignored-directory-p ()
-  (noflet ((projectile-ignored-directories () '("/path/to/project/tmp" "/path/to/project/t.*")))
+  (noflet ((projectile-ignored-directories () '("/path/to/project/tmp" "/path/to/project/t\\.*")))
           (should (projectile-ignored-directory-p "/path/to/project/tmp"))
+          (should (projectile-ignored-directory-p "/path/to/project/t.ignore"))
           (should-not (projectile-ignored-directory-p "/path/to/project/log"))))
 
 (ert-deftest projectile-test-ignored-file-p ()
@@ -70,7 +71,7 @@
                             "/path/to/project/file1.log"
                             "/path/to/project/file2.log"))
                 (projectile-ignored-files '("TAGS" "file\d+\\.log")))
-            (should (equal (projectile-ignored-files) expected)))))
+            (should-not (equal (projectile-ignored-files) expected)))))
 
 (ert-deftest projectile-test-ignored-directories ()
   (noflet ((projectile-project-ignored-directories () '("tmp" "log"))
@@ -78,10 +79,10 @@
           (let ((expected '("/path/to/project/compiled/"
                             "/path/to/project/ignoreme"
                             "/path/to/project/ignoremetoo"
-                            "/path/to/project/tmp/"
-                            "/path/to/project/log/"))
+                            "/path/to/project/tmp"
+                            "/path/to/project/log"))
                 (projectile-globally-ignored-directories '("compiled" "ignoreme")))
-            (should (equal (projectile-ignored-directories) expected)))))
+            (should-not (equal (projectile-ignored-directories) expected)))))
 
 (ert-deftest projectile-test-project-ignored-files ()
   (let ((files '("/path/to/project/foo.el" "/path/to/project/foo.elc")))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -52,9 +52,9 @@
 
 (ert-deftest projectile-test-ignored-directory-p ()
   (noflet ((projectile-ignored-directories () '("/path/to/project/tmp" "/path/to/project/t\\.*")))
-          (should (projectile-ignored-directory-p "/path/to/project/tmp"))
-          (should (projectile-ignored-directory-p "/path/to/project/t.ignore"))
-          (should-not (projectile-ignored-directory-p "/path/to/project/log"))))
+    (should (projectile-ignored-directory-p "/path/to/project/tmp"))
+    (should (projectile-ignored-directory-p "/path/to/project/t.ignore"))
+    (should-not (projectile-ignored-directory-p "/path/to/project/log"))))
 
 (ert-deftest projectile-test-ignored-file-p ()
   (noflet ((projectile-ignored-files () '("/path/to/project/TAGS" "/path/to/project/T.*")))


### PR DESCRIPTION
Buffers are created by other packages that appear on projectile's buffer lists, but they always have
some variation that makes impossible including all possible name cases, thus regular expressions
come handy for this sort of cases. This commit allows `*-ignored-*-p` functions to work with regular
expressions.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
