### PR TITLE
Use regexp-quote in projectile-get-other-files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+* Handle files with special characters in `projectile-get-other-files`
 * * [#1260](https://github.com/bbatsov/projectile/pull/1260): ignored-*-p: Now they match against regular expressions.
 * **(Breaking)** Change the prefix for the Projectile mode commands to `C-c C-p`.
 * Avoid "No projects needed to be removed." messages in global mode

--- a/projectile.el
+++ b/projectile.el
@@ -1901,7 +1901,7 @@ With FLEX-MATCHING, match any file that contains the base name of current file"
          (fulldirname (if (file-name-directory current-file)
                           (file-name-directory current-file) "./"))
          (dirname (file-name-nondirectory (directory-file-name fulldirname)))
-         (filename (projectile--file-name-sans-extensions current-file))
+         (filename (regexp-quote (projectile--file-name-sans-extensions current-file)))
          (file-list (mapcar (lambda (ext)
                               (if flex-matching
                                   (concat ".*" filename ".*" "\." ext "\\'")

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -604,6 +604,7 @@
                                        ))
         (source-tree '("src/test1.c"
                        "src/test2.c"
+                       "src/test+copying.m"
                        "src/test1.cpp"
                        "src/test2.cpp"
                        "src/Makefile"
@@ -615,6 +616,7 @@
                        "include1/test1.h"
                        "include1/test1.h~"
                        "include1/test2.h"
+                       "include1/test+copying.h"
                        "include1/test1.hpp"
                        "include2/some_module/same_name.h"
                        "include2/test1.h"
@@ -652,6 +654,8 @@
     ;; fallback to outer extensions if no rule for nested extension defined
     (should (equal '("include1/test2.js" "include2/test2.js")
                    (projectile-get-other-files "src/test2.service.spec.js" source-tree)))
+    (should (equal '("include1/test+copying.h")
+                   (projectile-get-other-files "src/test+copying.m" source-tree)))
     ))
 
 (ert-deftest projectile-test-compilation-directory ()


### PR DESCRIPTION
to handle files with characters like "+" in them correctly.  Such characters should be matched
literally instead of ending up as part of a regexp.  This happens for example with Objective-C,
where it's common to have two files of the form Class+Protocol.{m,h}.

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
