### PR TITLE
Remember explicitly added projects

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -722,12 +722,7 @@ The cache is created both in memory and on the hard drive."
 (defun projectile-track-known-projects-find-file-hook ()
   "Function for caching projects with `find-file-hook'."
   (when (and projectile-track-known-projects-automatically (projectile-project-p))
-    (let ((known-projects (and (sequencep projectile-known-projects)
-                               (copy-sequence projectile-known-projects))))
-      (projectile-add-known-project (projectile-project-root))
-      (unless (equal known-projects projectile-known-projects)
-        (projectile-merge-known-projects)))))
-
+    (projectile-add-known-project (projectile-project-root))))
 
 (defun projectile-maybe-invalidate-cache (force)
   "Invalidate if FORCE or project's dirconfig newer than cache."
@@ -3673,7 +3668,8 @@ See `projectile--cleanup-known-projects'."
     (setq projectile-known-projects
           (delete-dups
            (cons (file-name-as-directory (abbreviate-file-name project-root))
-                 projectile-known-projects)))))
+                 projectile-known-projects)))
+    (projectile-merge-known-projects)))
 
 (defun projectile-load-known-projects ()
   "Load saved projects from `projectile-known-projects-file'.


### PR DESCRIPTION
When `projectile-track-known-projects-automatically` is nil, we have to add new projects explicitly with `projectile-add-known-project`. But if I do this and then restart emacs, the newly added project is not remembered. To fix this, an optional argument `MERGE` is added to `projectile-add-known-project`. When it is non-nil (which is the case in interactive calls), `projectile-merge-known-projects` is called at the end of the function.

I didn't add the `projectile-merge-known-projects` call unconditionally because I see that `projectile-add-known-project` is called by `projectile-discover-projects-in-search-path` and it seems to me that we don't want to store these projects persistently. But if that's not the case, then it would perhaps be simpler to remove the optional argument and add the `projectile-merge-known-projects` call unconditionally (and remove it from `projectile-track-known-projects-find-file-hook`).

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
