### PR TITLE
Add support for test files with a different extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Add `projectile-project-search-path`, which is auto-searched for projects when `projectile-mode` starts.
 * Add `projectile-discover-projects-in-search-path` command which searches for projects in `projectile-project-search-path`.
 * Auto-cleanup missing known-projects on `projectile-mode` start.
+* [#1263](https://github.com/bbatsov/projectile/pull/1263): `projectile-register-project-type` can now be used to customize `:test-extension` and `:src-extension` (eg. for elixir).
 
 ### Changes
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -266,6 +266,8 @@ Option           | Documentation
 :test-dir        | A path, relative to the project root, where the test code lives.
 :test-prefix     | A prefix to generate test files names.
 :test-suffix     | A suffix to generate test files names.
+:test-extension  | A file extension to generate test file names.
+:src-extension   | A file extension to generate source file names.
 
 ## Customizing project root files
 

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -789,6 +789,24 @@
             (should (equal "spec/foo/foo.service.spec.js" test-file))
             (should (equal "source/bar/bar.service.js" impl-file))))))))
 
+(ert-deftest projectile-test-find-matching-file/extensions ()
+  (projectile-test-with-sandbox
+    (projectile-test-with-files
+        ("project/app/models/weed/"
+         "project/app/models/food/"
+         "project/test/models/weed/"
+         "project/test/models/food/"
+         "project/app/models/weed/sea.ex"
+         "project/app/models/food/sea.ex"
+         "project/test/models/weed/sea_test.exs"
+         "project/test/models/food/sea_test.exs")
+      (let ((projectile-indexing-method 'native))
+        (noflet ((projectile-project-type () 'elixir)
+                 (projectile-project-root () (file-truename (expand-file-name "project/"))))
+          (should (equal "app/models/food/sea.ex"
+                         (projectile-find-matching-file
+                          "test/models/food/sea_test.exs"))))))))
+
 (ert-deftest projectile-test-exclude-out-of-project-submodules ()
   (projectile-test-with-files
    (;; VSC root is here


### PR DESCRIPTION
Hi!

This PR adds support for projects where the test files' extension is not the same as the source files' extension. For example, Elixir uses `.ex` for source files and `.exs` for test files.

I don't expect this PR to be merged as is for a couple of reasons, but I wanted to scratch my own itch. Here are a couple of remarks:
- I haven't run the tests, sorry. The code is currently in "works on my machine" state.
- I don't like `:test-extension` and `:src-extension`, one without the other does not make sense, otherwise it is not possible to switch between test and implementation, maybe I should use some sort of mapping?
- I'm not even sure it is projectile's business to deal with file extensions, this seems fairly orthogonal to what a project is.

Anyway, WDYT?

-----------------

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!