### PR TITLE
return nil for undefined commands

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3243,9 +3243,7 @@ to function `funcall's. Return value of function MUST be string to be executed a
      ((stringp command) command)
      ((functionp command)
       (if (fboundp command)
-        (funcall (symbol-function command))))
-     (t
-      (user-error "The value for: %s in project-type: %s was neither a function nor a string." command-type project-type)))))
+        (funcall (symbol-function command)))))))
 
 (defun projectile-default-configure-command (project-type)
   "Retrieve default configure command for PROJECT-TYPE."


### PR DESCRIPTION
revert behaviour introduced in bbatsov/projectile/pull/1255

Seems like it broke compile command for all projects w/o `:compilation-dir` defined. At least for me on attempt to compile project, command fails with a message:

```
user-error: The value for: compilation-dir in project-type: rebar was neither a function nor a string.
```

`projectile-compilation-dir` function has a fallback to `projectile-project-root` as a default compilation directory, but new behaviour of `projectile-default-generic-command` throws an error on attempt to a get command-type from a hash, which is not defined for some project type (most of them).
