### PR TITLE
Fixes compilation-dir user-error

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3243,7 +3243,10 @@ to function `funcall's. Return value of function MUST be string to be executed a
      ((stringp command) command)
      ((functionp command)
       (if (fboundp command)
-        (funcall (symbol-function command))))
+          (funcall (symbol-function command))))
+     ((and (not command) (eq command-type 'compilation-dir))
+      ;; `compilation-dir' is special in that it is used as a fallback for the root
+      nil)
      (t
       (user-error "The value for: %s in project-type: %s was neither a function nor a string." command-type project-type)))))
 

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -706,6 +706,16 @@
 
   (should-error (projectile-default-compilation-command 'has-command-at-point)))
 
+(ert-deftest projectile-test-should-not-fail-on-bad-compilation-dir-config ()
+  (defun -compilation-test-function ()
+    1)
+  (projectile-register-project-type 'has-command-at-point '("file.txt")
+                                    :compile (-compilation-test-function))
+
+  (let ((projectile-project-type 'has-command-at-point)
+        (projectile-project-compilation-dir nil))
+    (should (equal (concat (expand-file-name ".") "/") (projectile-compilation-dir)))))
+
 (ert-deftest projectile-detect-project-type-of-rails-like-npm-test ()
   (projectile-test-with-sandbox
    (projectile-test-with-files


### PR DESCRIPTION
This fixes the case where projectile-generic-default-command is used by projectile-compilation-dir() to resolve the compilation-dir. If this is not set by the project type we throw a user-error, this isn't handled by
projectile-compilation-dir() so we need to handle this special case gracefully.

The patch adds the special case where the returned default-generic value returned by the function will purely return nil in that case for compilation-dir.

A test was added to validate the fix.

This issue was initially reported by: @velimir0xff  here: https://github.com/bbatsov/projectile/pull/1255#issuecomment-413854798


--- Checklist:
- [X] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing (`make test`)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [?] You've updated the changelog (if adding/changing user-visible functionality)
- [-] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
---
> - [?] You've updated the changelog (if adding/changing user-visible functionality)

@bbatsov It's not exactly user-visible behavior but it is an edge case. Do you want documentation for it?

@velimir0xff Would this fix your case sufficiently?