### PR TITLE
Fix examples of ignoring files by patterns

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -134,8 +134,8 @@ Projectile also supports relative pathname ignores:
 
 ```
 -tmp
--*.rb
--*.yml
+-/*.rb
+-/*.yml
 -models
 ```
 
@@ -164,7 +164,7 @@ your project by projectile:
 
 ```
 !/src/foo
-!*.yml
+!/*.yml
 ```
 
 When a path is overridden, its contents are still subject to ignore


### PR DESCRIPTION
From https://emacs.stackexchange.com/questions/17801/projectile-grep-file-filter and personal experience, relative file ignores doesn't work as it's currently documented. I had to add a leading `/` to every file name on my .projectile file.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
