### PR TITLE
Fix get-other-files: mask potentially nil directory

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1949,7 +1949,8 @@ With FLEX-MATCHING, match any file that contains the base name of current file"
          (candidates
           (cl-sort (copy-sequence candidates)
                    (lambda (file _)
-                     (let ((candidate-dirname (file-name-nondirectory (directory-file-name (file-name-directory file)))))
+                     (let ((candidate-dirname (file-name-nondirectory
+                                               (directory-file-name (or (file-name-directory file) "./")))))
                        (unless (equal fulldirname (file-name-directory file))
                          (equal dirname candidate-dirname)))))))
     candidates))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -623,6 +623,10 @@
                        "include2/test2.h"
                        "include2/test2.hpp"
 
+                       "root.h"
+                       "root.c"
+                       "root.cpp"
+
                        "src/test1.service.js"
                        "src/test2.service.spec.js"
                        "include1/test1.service.spec.js"
@@ -630,6 +634,8 @@
                        "include1/test2.js"
                        "include2/test2.js")))
 
+    (should (equal '("root.cpp" "root.c")
+                   (projectile-get-other-files "root.h" source-tree)))
     (should (equal '("include1/test1.h" "include2/test1.h")
                    (projectile-get-other-files "src/test1.c" source-tree)))
     (should (equal '("include1/test1.h" "include2/test1.h" "include1/test1.hpp")


### PR DESCRIPTION
This is a potential fix for #1283.

* [x]  The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
* [x]  You've added tests (if possible) to cover your change(s)
* [x]  All tests are passing (`make test`)
* [x]  The new code is not generating bytecode or `M-x checkdoc` warnings
* [x]  You've updated the changelog (if adding/changing user-visible functionality)
* [x]  You've updated the readme (if adding/changing user-visible functionality)