### PR TITLE
Add support for Pipenv projects, python test suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 * Deprecate `projectile-keymap-prefix`.
 * Avoid "No projects needed to be removed." messages in global mode
 * [#1278](https://github.com/bbatsov/projectile/issues/1278): Add default `test-suffix` to `npm` project
+* [#1285](https://github.com/bbatsov/projectile/pull/1285): Add default `test-suffix` to Python projects
+* [#1285](https://github.com/bbatsov/projectile/pull/1285): Add support for Pipenv-managed Python projects
 
 ## 1.0.0 (2018-07-21)
 

--- a/projectile.el
+++ b/projectile.el
@@ -2383,19 +2383,28 @@ TEST-DIR which specifies the path to the tests relative to the project root."
 (projectile-register-project-type 'django '("manage.py")
                                   :compile "python manage.py runserver"
                                   :test "python manage.py test"
-                                  :test-prefix "test_")
+                                  :test-prefix "test_"
+                                  :test-suffix"_test")
 (projectile-register-project-type 'python-pip '("requirements.txt")
                                   :compile "python setup.by build"
                                   :test "python -m unittest discover"
-                                  :test-prefix "test_")
+                                  :test-prefix "test_"
+                                  :test-suffix"_test")
 (projectile-register-project-type 'python-pkg '("setup.py")
                                   :compile "python setup.py build"
                                   :test "python -m unittest discover"
-                                  :test-prefix "test_")
+                                  :test-prefix "test_"
+                                  :test-suffix"_test")
 (projectile-register-project-type 'python-tox '("tox.ini")
                                   :compile "tox -r --notest"
                                   :test "tox"
-                                  :test-prefix "test_")
+                                  :test-prefix "test_"
+                                  :test-suffix"_test")
+(projectile-register-project-type 'python-pipenv '("Pipfile")
+                                  :compile "pipenv run build"
+                                  :test "pipenv run test"
+                                  :test-prefix "test_"
+                                  :test-suffix "_test")
 ;; Java & friends
 (projectile-register-project-type 'maven '("pom.xml")
                                   :compile "mvn clean install"


### PR DESCRIPTION
- Adds a  "_test" `:test-suffix` for Python projects.
- Adds support for [Pipenv](https://pipenv.readthedocs.io/en/latest/) projects

Resolves #1237 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
