### PR TITLE
[Fix #1205] Add check that project directory exists when switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#1285](https://github.com/bbatsov/projectile/pull/1285): Add support for Pipenv-managed Python projects.
 * [#1232](https://github.com/bbatsov/projectile/issues/1232): Stop evaluating code dynamically in the mode-line and switch to a simpler scheme where the mode-line is updated just once using `find-file-hook`.
 * Make the mode line configurable via `projectile-dynamic-mode-line` and `projectile-mode-line-fn`.
+* [#1205](https://github.com/bbatsov/projectile/issues/1205): Check that project directory exists when switching projects.
 
 ## 1.0.0 (2018-07-21)
 

--- a/projectile.el
+++ b/projectile.el
@@ -3551,25 +3551,28 @@ With a prefix ARG invokes `projectile-commander' instead of
 Invokes the command referenced by `projectile-switch-project-action' on switch.
 With a prefix ARG invokes `projectile-commander' instead of
 `projectile-switch-project-action.'"
-  (let ((switch-project-action (if arg
-                                   'projectile-commander
-                                 projectile-switch-project-action)))
-    (run-hooks 'projectile-before-switch-project-hook)
-    (let ((default-directory project-to-switch))
-      ;; use a temporary buffer to load PROJECT-TO-SWITCH's dir-locals before calling SWITCH-PROJECT-ACTION
-      (with-temp-buffer
-        (hack-dir-local-variables-non-file-buffer))
-      ;; Normally the project name is determined from the current
-      ;; buffer. However, when we're switching projects, we want to
-      ;; show the name of the project being switched to, rather than
-      ;; the current project, in the minibuffer. This is a simple hack
-      ;; to tell the `projectile-project-name' function to ignore the
-      ;; current buffer and the caching mechanism, and just return the
-      ;; value of the `projectile-project-name' variable.
-      (let ((projectile-project-name (funcall projectile-project-name-function
-                                              project-to-switch)))
-        (funcall switch-project-action)))
-    (run-hooks 'projectile-after-switch-project-hook)))
+  (if (file-directory-p project-to-switch)
+      (let ((switch-project-action (if arg
+                                       'projectile-commander
+                                     projectile-switch-project-action)))
+        (run-hooks 'projectile-before-switch-project-hook)
+        (let ((default-directory project-to-switch))
+          ;; use a temporary buffer to load PROJECT-TO-SWITCH's dir-locals before calling SWITCH-PROJECT-ACTION
+          (with-temp-buffer
+            (hack-dir-local-variables-non-file-buffer))
+          ;; Normally the project name is determined from the current
+          ;; buffer. However, when we're switching projects, we want to
+          ;; show the name of the project being switched to, rather than
+          ;; the current project, in the minibuffer. This is a simple hack
+          ;; to tell the `projectile-project-name' function to ignore the
+          ;; current buffer and the caching mechanism, and just return the
+          ;; value of the `projectile-project-name' variable.
+          (let ((projectile-project-name (funcall projectile-project-name-function
+                                                  project-to-switch)))
+            (funcall switch-project-action)))
+        (run-hooks 'projectile-after-switch-project-hook))
+    (progn (projectile-remove-known-project project-to-switch)
+	   (error "Directory %s does not exist" project-to-switch))))
 
 ;;;###autoload
 (defun projectile-find-file-in-directory (&optional directory)


### PR DESCRIPTION
**This change adds a check that the project directory exists when attempting to switch to it.  If it doesn't exist then the project is removed from known projects and an error is reported.**


-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
