### PR TITLE
Implementing #972: Add toggle for project read only mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Add toggle for project read only mode: `projectile-toggle-project-read-only`.
 * New interactive command `projectile-run-ielm`.
 * Add [crystal](https://crystal-lang.org) project type.
 * [#850](https://github.com/bbatsov/projectile/issues/850): Make it possible to prompt for a project, when you're not in a project, instead of raising an error. (see `projectile-require-project-root`).

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ it. Some of Projectile's features:
 * visit project in dired
 * run make in a project with a single key chord
 * check for dirty repositories
+* toggle read-only mode for the entire project
 
 Here's a glimpse of Projectile in action:
 

--- a/projectile.el
+++ b/projectile.el
@@ -2093,6 +2093,20 @@ With a prefix arg INVALIDATE-CACHE invalidates the cache first."
   (interactive "P")
   (projectile--find-file invalidate-cache #'find-file-other-frame))
 
+;;;###autoload
+(defun projectile-toggle-project-read-only ()
+  "Toggle project read only"
+  (interactive)
+  (let ((inhibit-read-only t)
+        (val (not buffer-read-only))
+        (default-directory (projectile-project-root)))
+    (add-dir-local-variable nil 'buffer-read-only val)
+    (save-buffer)
+    (kill-buffer)
+    (when buffer-file-name
+      (read-only-mode (if val +1 -1))
+      (message "Projectile: project read-only-mode is %s" (if val "on" "off")))))
+
 
 ;;;; Sorting project files
 (defun projectile-sort-files (files)
@@ -4025,6 +4039,7 @@ is chosen."
    ["Replace in project" projectile-replace]
    ["Multi-occur in project" projectile-multi-occur]
    ["Browse dirty projects" projectile-browse-dirty-projects]
+   ["Toggle project wide read-only" projectile-toggle-project-read-only]
    "--"
    ["Run shell" projectile-run-shell]
    ["Run eshell" projectile-run-eshell]


### PR DESCRIPTION
- it generates a `.dir-locals.el' file which controls the read-only behavior.
- logic is copied from ggtags.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)



