### PR TITLE
Fix get-immediate-sub-projects

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1206,7 +1206,7 @@ they are excluded from the results of this function."
          ;; search for sub-projects under current project `project'
          (submodules (mapcar
                       (lambda (s)
-                        (file-name-as-directory (expand-file-name s default-directory)))
+                        (file-name-as-directory (expand-file-name s path)))
                       (projectile-files-via-ext-command path (projectile-get-sub-projects-command vcs))))
          (project-child-folder-regex
           (concat "\\`"


### PR DESCRIPTION
The call to `projectile-files-ext-command` returns filenames relative
to the project root, not to the current directory.

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
