### PR TITLE
tests for add-known-project, configure-command, get-all-sub-projects

### DIFF
--- a/test/projectile-legacy-test.el
+++ b/test/projectile-legacy-test.el
@@ -820,63 +820,6 @@
           (should (equal "spec/foo/foo.service.spec.js" test-file))
           (should (equal "source/bar/bar.service.js" impl-file))))))))
 
-(ert-deftest projectile-test-exclude-out-of-project-submodules ()
-  (projectile-test-with-files
-   (;; VSC root is here
-    "project/"
-    "project/.git/"
-    "project/.gitmodules"
-    ;; Current project root is here:
-    "project/web-ui/"
-    "project/web-ui/.projectile"
-    ;; VCS git submodule will return the following submodules,
-    ;; relative to current project root, 'project/web-ui/':
-    "project/web-ui/vendor/client-submodule/"
-    "project/server/vendor/server-submodule/")
-   (let ((project (file-truename (expand-file-name "project/web-ui"))))
-     (noflet ((projectile-files-via-ext-command
-               (dir vcs) (when (string= default-directory project)
-                       '("vendor/client-submodule"
-                         "../server/vendor/server-submodule")))
-              (projectile-project-root
-               () project))
-
-       ;; assert that it only returns the submodule 'project/web-ui/vendor/client-submodule/'
-       (should (equal (list (expand-file-name "vendor/client-submodule/" project))
-                      (projectile-get-all-sub-projects project 'git)))))))
-
-(ert-deftest projectile-test-configure-command-for-generic-project-type ()
-  (noflet ((projectile-default-configure-command (x) nil)
-           (projectile-project-type () 'generic))
-    (let ((configure-command (projectile-configure-command "fsdf")))
-      (should (equal nil configure-command)))))
-
-;;; known projects tests
-
-(ert-deftest projectile-test-add-known-project-adds-project-to-known-projects ()
-  "An added project should be added to the list of known projects."
-  (let (projectile-known-projects)
-    (projectile-add-known-project "~/my/new/project/")
-    (should (string= (car projectile-known-projects)
-                     "~/my/new/project/"))))
-
-(ert-deftest projectile-test-add-known-project-moves-projects-to-front-of-list ()
-  "adding a project should move it to the front of the list of known projects, if it already
-existed."
-  (let ((projectile-known-projects (list "~/b/" "~/a/")))
-    (projectile-add-known-project "~/a/")
-    (should (equal projectile-known-projects
-                   (list "~/a/" "~/b/")))))
-
-(ert-deftest projectile-test-add-known-project-no-near-duplicates ()
-  "~/project and ~/project/ should not be added
-  separately to the known projects list."
-  (let ((projectile-known-projects '("~/a/")))
-    (projectile-add-known-project "~/a")
-    (projectile-add-known-project "~/b")
-    (projectile-add-known-project "~/b/")
-    (should (equal projectile-known-projects '("~/b/" "~/a/")))))
-
 (defun projectile-test-tmp-file-path ()
   "Return a filename suitable to save data to in the
 test temp directory"

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -87,6 +87,63 @@ test temp directory"
     (expect (projectile-expand-root "foo/bar") :to-equal "/path/to/project/foo/bar")
     (expect (projectile-expand-root "./foo/bar") :to-equal "/path/to/project/foo/bar")))
 
+(describe "projectile-get-all-sub-projects"
+  (it "excludes out-of-project submodules"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      (;; VCS root is here
+       "project/"
+       "project/.git/"
+       "project/.gitmodules"
+       ;; Current project root is here:
+       "project/web-ui/"
+       "project/web-ui/.projectile"
+       ;; VCS git submodule will return the following submodules,
+       ;; relative to current project root, 'project/web-ui/':
+       "project/web-ui/vendor/client-submodule/"
+       "project/server/vendor/server-submodule/")
+      (let ((project (file-truename (expand-file-name "project/web-ui"))))
+        (spy-on 'projectile-files-via-ext-command :and-call-fake
+                (lambda (dir vcs)
+                  (when (string= dir project)
+                    '("vendor/client-submodule"
+                      "../server/vendor/server-submodule"))))
+        (spy-on 'projectile-project-root :and-return-value project)
+        ;; assert that it only returns the submodule 'project/web-ui/vendor/client-submodule/'
+        (expect (projectile-get-all-sub-projects project) :to-equal
+                (list (expand-file-name "vendor/client-submodule/" project))))))))
+
+(describe "projectile-configure-command"
+  (it "configure command for generic project type"
+    (spy-on 'projectile-default-configure-command :and-return-value nil)
+    (spy-on 'projectile-project-type :and-return-value 'generic)
+    (expect (projectile-configure-command "fsdf") :to-equal nil)))
+
+;;; known projects tests
+
+(describe "projectile-add-known-project"
+  (it "an added project should be added to the list of known projects"
+    (let ((projectile-known-projects-file (projectile-test-tmp-file-path))
+          (projectile-known-projects nil))
+      (projectile-add-known-project "~/my/new/project/")
+      (expect projectile-known-projects :to-equal '("~/my/new/project/"))
+      (delete-file projectile-known-projects-file nil)))
+  (it "adding a project should move it to the front of the list of known projects, if it already existed."
+    (let ((projectile-known-projects-file (projectile-test-tmp-file-path))
+          (projectile-known-projects '("~/b/" "~/a/")))
+      (projectile-add-known-project "~/a/")
+      (expect projectile-known-projects :to-equal '("~/a/" "~/b/"))
+      (delete-file projectile-known-projects-file nil)))
+  (it "~/project and ~/project/ should not be added separately to the known projects list"
+    (let ((projectile-known-projects-file (projectile-test-tmp-file-path))
+          (projectile-known-projects '("~/project/")))
+      (projectile-add-known-project "~/project")
+      (expect projectile-known-projects :to-equal '("~/project/"))
+      (projectile-add-known-project "~/b")
+      (projectile-add-known-project "~/b/")
+      (expect projectile-known-projects :to-equal '("~/b/" "~/project/"))
+      (delete-file projectile-known-projects-file nil))))
+
 (describe "projectile-load-known-projects"
   (it "loads known projects through serialization functions"
     (let ((projectile-known-projects-file (projectile-test-tmp-file-path)))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -122,27 +122,28 @@ test temp directory"
 ;;; known projects tests
 
 (describe "projectile-add-known-project"
+  :var (projectile-known-projects-file)
+  (before-each
+   (setq projectile-known-projects-file (projectile-test-tmp-file-path)))
+
+  (after-each
+   (delete-file projectile-known-projects-file nil))
+
   (it "an added project should be added to the list of known projects"
-    (let ((projectile-known-projects-file (projectile-test-tmp-file-path))
-          (projectile-known-projects nil))
+    (let ((projectile-known-projects nil))
       (projectile-add-known-project "~/my/new/project/")
-      (expect projectile-known-projects :to-equal '("~/my/new/project/"))
-      (delete-file projectile-known-projects-file nil)))
+      (expect projectile-known-projects :to-equal '("~/my/new/project/"))))
   (it "adding a project should move it to the front of the list of known projects, if it already existed."
-    (let ((projectile-known-projects-file (projectile-test-tmp-file-path))
-          (projectile-known-projects '("~/b/" "~/a/")))
+    (let ((projectile-known-projects '("~/b/" "~/a/")))
       (projectile-add-known-project "~/a/")
-      (expect projectile-known-projects :to-equal '("~/a/" "~/b/"))
-      (delete-file projectile-known-projects-file nil)))
+      (expect projectile-known-projects :to-equal '("~/a/" "~/b/"))))
   (it "~/project and ~/project/ should not be added separately to the known projects list"
-    (let ((projectile-known-projects-file (projectile-test-tmp-file-path))
-          (projectile-known-projects '("~/project/")))
+    (let ((projectile-known-projects '("~/project/")))
       (projectile-add-known-project "~/project")
       (expect projectile-known-projects :to-equal '("~/project/"))
       (projectile-add-known-project "~/b")
       (projectile-add-known-project "~/b/")
-      (expect projectile-known-projects :to-equal '("~/b/" "~/project/"))
-      (delete-file projectile-known-projects-file nil))))
+      (expect projectile-known-projects :to-equal '("~/b/" "~/project/")))))
 
 (describe "projectile-load-known-projects"
   (it "loads known projects through serialization functions"


### PR DESCRIPTION
The test case `~/project and ~/project/ should not be added separately to the known projects list` (L140) is kinda brittle, I had to change the test folder name from `~/a/` to `~/project/` otherwise the test would fail whenever the prior test on L136 was run as well. Let me know if this sounds like a problem 😃 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
