### PR TITLE
Avoid ":nil" project type string in mode line when not in a project

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3959,10 +3959,12 @@ thing shown in the mode line otherwise."
   "Report project name and type in the modeline."
   (let ((project-name (projectile-project-name))
         (project-type (projectile-project-type)))
-    (format "%s[%s:%s]"
+    (format "%s[%s%s]"
             projectile-mode-line-prefix
             project-name
-            project-type)))
+            (if project-type
+                (format ":%s" project-type)
+              ""))))
 
 (defun projectile-update-mode-line ()
   "Update the Projectile mode-line."


### PR DESCRIPTION
Fixes a little quirk in the mode line when (gasp!) not working in a recognised project.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] ~You've updated the changelog (if adding/changing user-visible functionality)~
- [ ] ~You've updated the readme (if adding/changing user-visible functionality)~
