### PR TITLE
Correctly set the dir-local variable indent-tabs-mode to nil

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,7 +1,7 @@
 ((emacs-lisp-mode
   (bug-reference-url-format . "https://github.com/bbatsov/projectile/issues/%s")
   (bug-reference-bug-regexp . "#\\(?2:[[:digit:]]+\\)")
-  (indent-tabs-mode)
+  (indent-tabs-mode . nil)
   (fill-column . 80)
   (sentence-end-double-space . t)
   (emacs-lisp-docstring-fill-column . 75)


### PR DESCRIPTION
Disable `indent-tabs-mode` correctly.

The previous settings will turn on `indent-tabs-mode`.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] ~~You've updated the changelog (if adding/changing user-visible functionality)~~
- [ ] ~~You've updated the readme (if adding/changing user-visible functionality)~~

Thanks!