### PR TITLE
Disregard STDERR in results from executing shell commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Make the mode line configurable via `projectile-dynamic-mode-line` and `projectile-mode-line-function`.
 * [#1205](https://github.com/bbatsov/projectile/issues/1205): Check that project directory exists when switching projects.
 * Move Projectile's menu out of the "Tools" menu.
+* Ignore STDERR when running shell commands so it doesn't pollute usable output
 
 ### Bugs fixed
 

--- a/test/projectile-legacy-test.el
+++ b/test/projectile-legacy-test.el
@@ -190,10 +190,6 @@
   (should (string-prefix-p "git" (projectile-get-sub-projects-command 'git)))
   (should (string-empty-p (projectile-get-sub-projects-command 'none))))
 
-(ert-deftest projectile-test-files-via-ext-command ()
-  (should (not (projectile-files-via-ext-command "" "")))
-  (should (not (projectile-files-via-ext-command "" nil))))
-
 (ert-deftest projectile-test-setup-hook-functions-projectile-mode ()
   (noflet ((projectile--cleanup-known-projects () nil)
            (projectile-discover-projects-in-search-path () nil))


### PR DESCRIPTION
# Background

This is a proposed fix for the issue described in https://github.com/bbatsov/projectile/issues/1323

In the case where a project contains nested git repos that are not submodules, projectile commands do not work and give output like:

```
apply: Setting current directory: No such file or directory, /Users/siddhartha/work/sandbox/testtest/my-project/fatal: no submodule mapping found in .gitmodules for path 'inner-project'
inner-project/
```

What is happening here is that at some point, projectile runs the command `git submodule --quiet foreach 'echo $path' | tr '\\n' '\\0'` to get paths to subprojects within the project. When this happens, in the case of nested repos mentioned above:

1. git yields the following output `Result: "fatal: no submodule mapping found in .gitmodules for path 'inner-project'\ninner-project�"` -- _Note that the part after the `\n` is the legitimate output expected here._

2. Projectile concatenates this (whole) string with the base project root to derive the full path to the subproject, resulting in a junk path

3. As it is treating this error output as a path, projectile then calls the same command on that new folder to get subprojects recursively which then yields `File is missing: "Setting current directory", "No such file or directory", "/Users/siddhartha/work/sandbox/my-project/fatal: no submodule mapping found in .gitmodules for path 'inner-project'`

... which causes the operation to fail.

# Solution

In running shell commands, the built-in function `shell-command-to-string` combines STDOUT with STDERR. For the purposes of using this output programmatically we only need STDOUT, since STDERR contains error output rather than the legitimate results of command execution. This PR introduces a modified version of the built-in function as suggested [here](https://emacs.stackexchange.com/questions/21422/how-to-discard-stderr-when-running-a-shell-function). Relevant excerpt from the Emacs docs regarding this change:

```
DESTINATION can also have the form (REAL-BUFFER STDERR-FILE); in that case,
REAL-BUFFER says what to do with standard output, as above,
while STDERR-FILE says what to do with standard error in the child.
STDERR-FILE may be nil (discard standard error output),
t (mix it with ordinary output), or a file name string.
```

**Other changes included:**
- rename the function `projectile-files-via-ext-command` → `projectile-get-results-from-shell-command`
- migrate tests for this function from ERT to buttercup
- add a couple more tests for it

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
~- [ ] You've updated the readme (if adding/changing user-visible functionality) [N/A]~

Thanks!
