### PR TITLE
Check directory arguments passed interactively.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1109,9 +1109,15 @@ If PROJECT is not specified acts on the current project."
   (mapcar (lambda (subdir) (concat project-dir subdir))
           (or (nth 0 (projectile-parse-dirconfig-file)) '(""))))
 
+(defun projectile--directory-p (directory)
+  "Checks if DIRECTORY is a string designating a valid directory."
+  (and (stringp directory) (file-directory-p directory)))
+
 (defun projectile-dir-files (directory)
   "List the files in DIRECTORY and in its sub-directories.
 Files are returned as relative paths to DIRECTORY."
+  (unless (projectile--directory-p directory)
+    (error "Directory %S does not exist" directory))
   ;; check for a cache hit first if caching is enabled
   (let ((files-list (and projectile-enable-caching
                          (gethash directory projectile-projects-cache))))
@@ -3703,6 +3709,8 @@ With a prefix ARG invokes `projectile-commander' instead of
 
 This command will first prompt for the directory the file is in."
   (interactive "DFind file in directory: ")
+  (unless (projectile--directory-p directory)
+    (user-error "Directory %S does not exist" directory))
   (let ((default-directory directory))
     (if (projectile-project-p)
         ;; target directory is in a project

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -246,7 +246,13 @@ test temp directory"
     (expect (projectile-get-project-directories "/my/root/") :to-equal '("/my/root/foo" "/my/root/bar/baz"))))
 
 (describe "projectile-dir-files"
+  (it "fails unless directory exists"
+    (spy-on 'file-directory-p :and-call-fake
+            (lambda (filename) (equal filename "/my/root/")))
+    (expect (projectile-dir-files "asdf") :to-throw))
   (it "lists the files in directory and sub-directories"
+    (spy-on 'file-directory-p :and-call-fake
+            (lambda (filename) (equal filename "/my/root/")))
     (spy-on 'projectile-patterns-to-ignore)
     (spy-on 'projectile-index-directory :and-call-fake (lambda (dir patterns progress-reporter)
                                                          (expect dir :to-equal "/my/root/")
@@ -1080,3 +1086,13 @@ test temp directory"
     (spy-on 'projectile-project-type :and-return-value "bar")
     (let ((projectile-mode-line-prefix " Pro"))
       (expect (projectile-default-mode-line) :to-equal " Pro[foo:bar]"))))
+
+(describe "projectile--directory-p"
+  (it "tests which directory exists"
+    (expect (projectile--directory-p nil) :to-be nil)
+    (expect (projectile--directory-p "asdf") :to-be nil)
+    (expect (projectile--directory-p user-emacs-directory) :to-be-truthy)))
+
+(describe "projectile-find-file-in-directory"
+  (it "fails when called in a non-existing directory"
+    (expect (projectile-find-file-in-directory "asdf") :to-throw)))


### PR DESCRIPTION
projectile-completing-read and projectile-dir-files: check that argument is a directory, otherwise early exit. 

projectile--directory-p: new function (a robust version of file-directory-p).
