### PR TITLE
Add a new defcustom to configure projectile-kill-buffers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#896](https://github.com/bbatsov/projectile/issues/896) Add commands `projectile-previous-project-buffer ` and
 `projectile-next-project-buffer ` to switch to other buffer in the project.
 * [#1016](https://github.com/bbatsov/projectile/issues/1016): Add a new defcustom (`projectile-current-project-on-switch`) controlling what to do with the current project on switch.
+* [#1233](https://github.com/bbatsov/projectile/issues/1233): Add a new defcustom (`projectile-kill-buffers-filter`) controlling which buffers are killed by `projectile-kill-buffers`.
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -123,9 +123,6 @@ using the native indexing method."
 
 When the kill-all option is selected, kills each buffer.
 
-When the keep-processes option is selected, keep buffers associated to a
-process.
-
 When the kill-only-files option is selected, kill only the buffer
 associated to a file.
 
@@ -133,8 +130,7 @@ Otherwise, it should be a predicate that takes one argument: the buffer to
 be killed."
   :group 'projectile
   :type '(radio
-          (const :tag "All project files" kill-all)
-          (const :tag "Preserve process buffer" keep-processes)
+          (const :tag "All project buffers" kill-all)
           (const :tag "Project file buffers" kill-only-files)
           (function :tag "Predicate")))
 
@@ -3170,7 +3166,6 @@ The buffer are killed according to the value of
                    (funcall projectile-kill-buffers-filter buffer)
                  (case projectile-kill-buffers-filter
                    (kill-all t)
-                   (keep-processes (not (get-buffer-process buffer)))
                    (kill-only-files (buffer-file-name buffer))
                    (t (error "Invalid projectile-kill-buffers-filter value: %S" projectile-kill-buffers-filter)))))
           (kill-buffer buffer))))))


### PR DESCRIPTION
~~3~~ 2 options are implemented:
- all-buffers (corresponds to the existing behavior)
~~keep-processes~~
- kill-only-files: kill only the buffer that have a buffer-file-name.

changelog:
* projectile-kill-buffers-filter: new defcustom.

------------- 
Note:
- option 2 corresponds to the use-case described in #1233  
- maybe option kill-only-files is not useful; and maybe other choices are. Suggestions are welcome!

edit: eventually kept only `kill-only-files`, while allowing any predicate to be used.

cc @mfiano 
fix #1233 