### PR TITLE
Updated docs: gave an example for projectile-mode-line-function

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -321,7 +321,7 @@ By default the minor mode indicator of Projectile appears in the form
 
 * `projectile-mode-line-prefix` (by default " Projectile") controls the static part of the mode-line
 * `projectile-dynamic-mode-line` (by default `t`) controls whether to display the project name & type part of the mode-line
-* `projectile-mode-line-function` (by default `projectile-default-mode-line`) controls the actual function to be invoked to generate the mode-line. If you'd like to show different info you should supply a custom function to replace the default.
+* `projectile-mode-line-function` (by default `projectile-default-mode-line`) controls the actual function to be invoked to generate the mode-line. If you'd like to show different info you should supply a custom function to replace the default, for example `(setq projectile-mode-line-function '(lambda () (format " Proj[%s]" (projectile-project-name))))`
 
 !!! Note
 


### PR DESCRIPTION
I tried setting the function to something along the lines of the old syntax of customizing projectile-mode-line to "'(:eval (format " Proj[%s]" (projectile-project-name)))" as mentioned in the _stable_ documentation.
This confusion cost me about an hour, so I thought giving an example might help somebody else.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
