### PR TITLE
Bring back buffer kill count message

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3166,8 +3166,8 @@ The buffer are killed according to the value of
          (project-name (projectile-project-name project))
          (buffers (projectile-project-buffers project)))
     (when (yes-or-no-p
-           (format "Are you sure you want to kill buffers for '%s'? "
-                   project-name))
+           (format "Are you sure you want to kill %s buffers for '%s'? "
+                   (length buffers) project-name))
       (dolist (buffer buffers)
         (when (and
                ;; we take care not to kill indirect buffers directly


### PR DESCRIPTION
This was removed in 90997d6, but I find it handy as a warning that I
might be killing the wrong project. If I mean to kill one with only a
few buffers and I see the message "kill 20 buffers", I'll be saved
from making a very annoying mistake.

Plural/singular handling probably doesn't matter much. Personally, I
would never use this command for a project with a single buffer -- I
would just use `kill-this-buffer`.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
