### PR TITLE
WIP Add projectile-tags-exclude-supports-globs

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -234,6 +234,11 @@ set to 'ggtags', then ggtags will be used for
           (const :tag "standard" find-tag))
   :package-version '(projectile . "0.14.0"))
 
+(defcustom projectile-tags-exclude-supports-globs nil
+  "If t - treat all non-matched ignores from .projectile as globs"
+  :group 'projectile
+  :type 'boolean)
+
 (defcustom projectile-sort-order 'default
   "The sort order used for a project's files."
   :group 'projectile
@@ -2885,11 +2890,17 @@ SEARCH-TERM is a regexp."
                           (cons "--fixed-strings" args))))
     (error "Package `ripgrep' is not available")))
 
+(defun projectile-tags-exclude-globs ()
+  "Return list with globs for exclide if `projectile-tags-exclude-supports-globs' set to t"
+  (if projectile-tags-exclude-supports-globs
+      (cl-remove-if 'file-directory-p (projectile-paths-to-ignore))
+    nil))
+
 (defun projectile-tags-exclude-patterns ()
   "Return a string with exclude patterns for ctags."
   (mapconcat (lambda (pattern) (format "--exclude=\"%s\""
                                        (directory-file-name pattern)))
-             (projectile-ignored-directories-rel) " "))
+             (append (projectile-ignored-directories-rel) (projectile-tags-exclude-globs)) " "))
 
 ;;;###autoload
 (defun projectile-regenerate-tags ()


### PR DESCRIPTION
Hey. I'm using https://github.com/universal-ctags/ctags as my default ctags implementation and it seems that --excludes options doesn't work as intended. It performs 2 kinds of matches

```
For each file name considered by ctags, each pattern specified using this option will
be compared against both the complete path (e.g.   some/path/base.ext)  and  the  base  name  (e.g.
base.ext)  of  the  file,  thus allowing patterns which match a given file name irrespective of its
path, or match only a specific path. If appropriate support is available from the  runtime  library
of  your  C  compiler, then the pattern may contain the usual shell wildcards (not regular expressions)
common on Unix (be sure to quote the option parameter to protect the wildcards from being  expanded
by the shell before being passed to ctags; also be aware that wildcards can match the slash charac‐
ter, '/').
```

What does it mean practically for non-file match: it compares absolute path with relative path passed from `projectile-ignored-directories-rel` and doesn't perform partial match in the middle of string but works well for top-level directories (because of the second, basename, check)

`/home/username/project_root/src/ignored_dir` doesn't match to `src/ignored_dir`

But we can pass globs in such case, so if we check for `*/src/ignored_dir` it will match.

I'm not sure what is the best possible implementation for this functionality. I've started with an additional option that additionally passes all non-matched to directory/file strings to exclude function.

If this way isn't good, I'm thinking about extending `projectile-parse-dirconfig-file` to support additional modifier that will fill some additional variable (e.g. `*` for ctags globs).

Or maybe you suggest a better way to implement this functionality.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
