### PR TITLE
Don't cache files with ignored suffixes

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1551,10 +1551,14 @@ Regular expressions can be used."
   "Check if FILE should be ignored.
 
 Regular expressions can be used."
-  (cl-some
-   (lambda (name)
-     (string-match-p name file))
-   (projectile-ignored-files)))
+   (or (cl-some
+        (lambda (suf)
+          (string-suffix-p suf file t))
+        projectile-globally-ignored-file-suffixes)
+       (cl-some
+        (lambda (name)
+          (string-match-p name file))
+        (projectile-ignored-files))
 
 (defun projectile-check-pattern-p (file pattern)
   "Check if FILE meets PATTERN."

--- a/projectile.el
+++ b/projectile.el
@@ -1558,7 +1558,7 @@ Regular expressions can be used."
        (cl-some
         (lambda (name)
           (string-match-p name file))
-        (projectile-ignored-files))
+        (projectile-ignored-files))))
 
 (defun projectile-check-pattern-p (file pattern)
   "Check if FILE meets PATTERN."


### PR DESCRIPTION
In `projectile-ignored-file-p`, check that the file doesn't match against `projectile-ignored-file-suffixes`.