### PR TITLE
Alien indexing submodules should return relative paths

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1261,9 +1261,11 @@ they are excluded from the results of this function."
   "Get files from sub-projects for PROJECT-ROOT recursively."
   (projectile-flatten
    (mapcar (lambda (sub-project)
-             (let ((project-relative-path (file-relative-name sub-project project-root)))
+             (let ((project-relative-path
+                    (file-name-as-directory (file-relative-name
+                                             sub-project project-root))))
                (mapcar (lambda (file)
-                       (concat (file-name-as-directory project-relative-path) file))
+                       (concat project-relative-path file))
                      ;; TODO: Seems we forgot git hardcoded here
                      (projectile-files-via-ext-command sub-project projectile-git-command))))
            (projectile-get-all-sub-projects project-root))))

--- a/projectile.el
+++ b/projectile.el
@@ -1261,10 +1261,11 @@ they are excluded from the results of this function."
   "Get files from sub-projects for PROJECT-ROOT recursively."
   (projectile-flatten
    (mapcar (lambda (sub-project)
-             (mapcar (lambda (file)
-                       (concat sub-project file))
+             (let ((project-relative-path (file-relative-name sub-project project-root)))
+               (mapcar (lambda (file)
+                       (concat (file-name-as-directory project-relative-path) file))
                      ;; TODO: Seems we forgot git hardcoded here
-                     (projectile-files-via-ext-command sub-project projectile-git-command)))
+                     (projectile-files-via-ext-command sub-project projectile-git-command))))
            (projectile-get-all-sub-projects project-root))))
 
 (defun projectile-get-repo-ignored-files (project vcs)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -893,6 +893,13 @@ test temp directory"
         (expect (projectile-get-all-sub-projects project) :to-equal
                 (list (expand-file-name "vendor/client-submodule/" project))))))))
 
+(describe "projectile-get-all-sub-projects-files"
+  (it "returns relative paths to submodule files"
+    (spy-on 'projectile-get-all-sub-projects :and-return-value '("/a/b/x/"))
+    (spy-on 'projectile-files-via-ext-command :and-return-value '("1.txt" "2.txt"))
+    (expect (projectile-get-sub-projects-files "/a/b" 'git) :to-equal
+      (list "x/1.txt" "x/2.txt"))))
+
 (describe "projectile-configure-command"
   (it "configure command for generic project type"
     (spy-on 'projectile-default-configure-command :and-return-value nil)


### PR DESCRIPTION
- When using alien indexing method projectile currently returns the
  full paths to files in submodules, this makes filtering in hybrid
  mode to break because the ignore patterns would be matched against
  the absolute path to submodules files, instead of relative to
  project root

In the projectile 1.0.0 release, files are searched and then processed to make them relative to project root:
https://github.com/bbatsov/projectile/blob/09d1ef17a20c42dc6a2b1622df8faa8fb1c6ad9f/projectile.el#L990

But this has since been refactored and was broken.

This PR fixes #1353
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!