### PR TITLE
fix empty projectile-recentf

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3266,7 +3266,7 @@ directory to open."
          (mapcar
           (lambda (f) (file-relative-name f project-root))
           (cl-remove-if-not
-           (lambda (f) (string-prefix-p project-root f))
+           (lambda (f) (string-prefix-p project-root (expand-file-name f)))
            recentf-list)))))
 
 (defun projectile-serialize-cache ()


### PR DESCRIPTION
`recentf-list` contains paths relative to `~` (e.g. `~/projects/project/x/y/z`), `projectile-project-root` returns an absolute path (e.g. `/home/user/project/project`), so `projectile-recentf-files` always returns an empty list as `/home/user/project/project` is not a prefix of `~/projects/project/x/y/z`.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
