### PR TITLE
Port advices to new mechanism

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -960,7 +960,7 @@ Invoked automatically when `projectile-mode' is enabled."
   (mapcar #'projectile-discover-projects-in-directory projectile-project-search-path))
 
 
-(defadvice delete-file (before purge-from-projectile-cache (filename &optional trash))
+(defun delete-file-projectile-remove-from-cache (filename &optional trash)
   (if (and projectile-enable-caching (projectile-project-p))
       (let* ((project-root (projectile-project-root))
              (true-filename (file-truename filename))
@@ -3577,12 +3577,11 @@ If the prefix argument SHOW_PROMPT is non nil, the command can be edited."
     (unless (string= command executed-command)
       (ring-insert command-history executed-command))))
 
-(defadvice compilation-find-file (around projectile-compilation-find-file)
+(defun compilation-find-file-projectile-find-compilation-buffer (orig-fun marker filename directory &rest formats)
   "Try to find a buffer for FILENAME, if we cannot find it,
 fallback to the original function."
-  (let ((filename (ad-get-arg 1))
-        full-filename)
-    (ad-set-arg 1
+  (let (full-filename)
+    (setq filename
                 (or
                  (if (file-exists-p (expand-file-name filename))
                      filename)
@@ -3602,7 +3601,7 @@ fallback to the original function."
                           full-filename)))
                  ;; Fall back to the old argument
                  filename))
-    ad-do-it))
+    (funcall #'orig-fun marker filename directory formats))
 
 (defun projectile-open-projects ()
   "Return a list of all open projects.
@@ -4329,13 +4328,13 @@ Otherwise behave as if called interactively.
     (add-hook 'find-file-hook 'projectile-find-file-hook-function)
     (add-hook 'projectile-find-dir-hook #'projectile-track-known-projects-find-file-hook t)
     (add-hook 'dired-before-readin-hook #'projectile-track-known-projects-find-file-hook t t)
-    (ad-activate 'compilation-find-file)
-    (ad-activate 'delete-file))
+    (advice-add 'compilation-find-file :around #'compilation-find-file-projectile-find-compilation-buffer)
+    (advice-add 'delete-file :before #'delete-file-projectile-remove-from-cache))
    (t
     (remove-hook 'find-file-hook #'projectile-find-file-hook-function)
     (remove-hook 'dired-before-readin-hook #'projectile-track-known-projects-find-file-hook t)
-    (ad-deactivate 'compilation-find-file)
-    (ad-deactivate 'delete-file))))
+    (advice-remove 'compilation-find-file #'compilation-find-file-projectile-find-compilation-buffer)
+    (advice-remove 'delete-file #'delete-file-projectile-remove-from-cache))))
 
 ;;;###autoload
 (define-obsolete-function-alias 'projectile-global-mode 'projectile-mode "1.0")

--- a/projectile.el
+++ b/projectile.el
@@ -3580,28 +3580,22 @@ If the prefix argument SHOW_PROMPT is non nil, the command can be edited."
 (defun compilation-find-file-projectile-find-compilation-buffer (orig-fun marker filename directory &rest formats)
   "Try to find a buffer for FILENAME, if we cannot find it,
 fallback to the original function."
-  (let (full-filename)
-    (setq filename
-                (or
-                 (if (file-exists-p (expand-file-name filename))
-                     filename)
-                 ;; Try to find the filename using projectile
-                 (and (projectile-project-p)
-                      (let ((root (projectile-project-root))
-                            (dirs (cons "" (projectile-current-project-dirs))))
-                        (when (setq full-filename
-                                    (car (cl-remove-if-not
-                                          #'file-exists-p
-                                          (mapcar
-                                           (lambda (f)
-                                             (expand-file-name
-                                              filename
-                                              (expand-file-name f root)))
-                                           dirs))))
-                          full-filename)))
-                 ;; Fall back to the old argument
-                 filename))
-    (funcall #'orig-fun marker filename directory formats))
+  (when (and (not (file-exists-p (expand-file-name filename)))
+             (projectile-project-p))
+    (let* ((root (projectile-project-root))
+           (dirs (cons "" (projectile-current-project-dirs)))
+           (new-filename (car (cl-remove-if-not
+                               #'file-exists-p
+                               (mapcar
+                                (lambda (f)
+                                  (expand-file-name
+                                   filename
+                                   (expand-file-name f root)))
+                                dirs)))))
+      (when new-filename
+        (setq filename new-filename))))
+
+  (funcall #'orig-fun marker filename directory formats))
 
 (defun projectile-open-projects ()
   "Return a list of all open projects.

--- a/projectile.el
+++ b/projectile.el
@@ -168,6 +168,11 @@ A value of nil means the cache never expires."
   :type '(choice (const :tag "Disabled" nil)
                  (integer :tag "Seconds")))
 
+(defcustom projectile-auto-update-cache t
+  "Wether the cache should automatically be updated when files are opened or deleted."
+  :group 'projectile
+  :type 'boolean)
+
 (defcustom projectile-require-project-root 'prompt
   "Require the presence of a project root to operate when true.
 When set to 'prompt Projectile will ask you to select a project
@@ -961,7 +966,7 @@ Invoked automatically when `projectile-mode' is enabled."
 
 
 (defun delete-file-projectile-remove-from-cache (filename &optional trash)
-  (if (and projectile-enable-caching (projectile-project-p))
+  (if (and projectile-enable-caching projectile-auto-update-cache (projectile-project-p))
       (let* ((project-root (projectile-project-root))
              (true-filename (file-truename filename))
              (relative-filename (file-relative-name true-filename project-root)))
@@ -4280,7 +4285,8 @@ tramp."
   (unless (file-remote-p default-directory)
     (when projectile-dynamic-mode-line
       (projectile-update-mode-line))
-    (projectile-cache-files-find-file-hook)
+    (when projectile-auto-update-cache
+      (projectile-cache-files-find-file-hook))
     (projectile-track-known-projects-find-file-hook)
     (projectile-visit-project-tags-table)))
 


### PR DESCRIPTION
**don't merge yet**

-----

Projectile uses this defadvice for `delete-file`:

``` elisp
(defadvice delete-file (before purge-from-projectile-cache (filename &optional trash))
  (if (and projectile-enable-caching (projectile-project-p))
      (let* ((project-root (projectile-project-root))
             (true-filename (file-truename filename))
             (relative-filename (file-relative-name true-filename project-root)))
        (if (projectile-file-cached-p relative-filename project-root)
            (projectile-purge-file-from-cache relative-filename)))))
```

It does the right thing, except it's very annoying when you delete a huge directory through `dired` for example, because it slows down the deletion by an order of magnitude.

There are several options around this problem:

- Add ability to disable the above advice, and let the user deal with cache invalidation.
- Advice `dired-do-delete` so it disables the `delete-file` advice, perform its task then enable the advice and finally invalidate the cache.

Additionnaly, should the old `defadvice` be ported to `advice-add` & friends?

Anyway, tell me what you reckon is the way forward, I might make a PR.