### PR TITLE
Fix the Makefile so that we can compile projectile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-/elpa
-/.elpa
-/.cask
-*.elc
 *~
-[#]*[#]
+*\#*\#
+*.\#*
+*.elc
+.cask
+elpa*
 /TAGS
 /project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 ### Bugs fixed
 
 * [#1315](https://github.com/bbatsov/projectile/issues/1315): Give preference to the project types that were registered last.
+* [#1367](https://github.com/bbatsov/projectile/issues/1367): Fix the Makefile so that we can compile projectile - use `make`.
 
 ## 1.0.0 (2018-07-21)
 

--- a/Makefile
+++ b/Makefile
@@ -8,18 +8,23 @@ PKGDIR := $(shell EMACS=$(EMACS) $(CASK) package-directory)
 SRCS = $(wildcard *.el)
 OBJS = $(SRCS:.el=.elc)
 
-.PHONY: compile test clean
+.PHONY: compile test clean elpa
 
-elpa:
+all: compile
+
+elpa-$(EMACS):
 	$(CASK) install
 	$(CASK) update
 	touch $@
+
+elpa: elpa-$(EMACS)
 
 elpaclean:
 	rm -f elpa*
 	rm -rf .cask # Clean packages installed for development
 
-compile: $(OBJS)
+compile: elpa
+	$(CASK) build
 
 clean:
 	rm -f $(OBJS)


### PR DESCRIPTION
The functionality has been basically copied from cider and now we can call make
in order to produce projectile.elc.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [X] You've updated the changelog (if adding/changing user-visible functionality)