### PR TITLE
Fix get-immediate-sub-projects when argument is not the root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#1369](https://github.com/bbatsov/projectile/issues/1369): Fix projectile-get-immediate-sub-projects when passed a non-root argument
+
 ## 2.0.0 (2019-01-01)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -1241,13 +1241,14 @@ PATH is the vcs root or project root from which to start
 searching, and should end with an appropriate path delimiter, such as
 '/' or a '\\'.
 
-If the vcs get-sub-projects query returns results outside of path,
+If the vcs get-sub-projects query returns results outside of PATH,
 they are excluded from the results of this function."
-  (let* ((vcs (projectile-project-vcs path))
+  (let* ((root (projectile-project-root path))
+         (vcs (projectile-project-vcs path))
          ;; search for sub-projects under current project `project'
          (submodules (mapcar
                       (lambda (s)
-                        (file-name-as-directory (expand-file-name s path)))
+                        (file-name-as-directory (expand-file-name s root)))
                       (projectile-files-via-ext-command path (projectile-get-sub-projects-command vcs))))
          (project-child-folder-regex
           (concat "\\`"


### PR DESCRIPTION
This fixes #1369.

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
