### PR TITLE
Fix grep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#97](https://github.com/bbatsov/projectile/issues/97): Respect `.projectile`
+  ignores which are paths to files and patterns when using `projectile-grep`.
+
 ## 2.0.0 (2019-01-01)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -2815,7 +2815,8 @@ This is a subset of `grep-read-files', where either a matching entry from
 (defun projectile-rgrep-default-command (regexp files dir)
   "Compute the command for \\[rgrep] to use by default.
 
-Extension of the Emacs 25.1 implementation of `rgrep-default-command'."
+Extension of the Emacs 25.1 implementation of `rgrep-default-command', with
+which it shares its arglist."
   (require 'find-dired)      ; for `find-name-arg'
   (grep-expand-template
    grep-find-template

--- a/projectile.el
+++ b/projectile.el
@@ -2910,6 +2910,9 @@ Extension of the Emacs 25.1 implementation of `rgrep-default-command'."
                                                               (concat "./" ignore)))
                                             projectile-grep-find-unignored-paths
                                             " -o -path ")))
+                              (and projectile-grep-find-unignored-paths
+                                   projectile-grep-find-unignored-patterns
+                                   " -o")
                               (and projectile-grep-find-unignored-patterns
                                    (concat " -path "
                                            (mapconcat

--- a/projectile.el
+++ b/projectile.el
@@ -966,7 +966,7 @@ Invoked automatically when `projectile-mode' is enabled."
   (mapcar #'projectile-discover-projects-in-directory projectile-project-search-path))
 
 
-(defun delete-file-projectile-remove-from-cache (filename &optional trash)
+(defun delete-file-projectile-remove-from-cache (filename &optional _trash)
   (if (and projectile-enable-caching projectile-auto-update-cache (projectile-project-p))
       (let* ((project-root (projectile-project-root))
              (true-filename (file-truename filename))
@@ -1263,7 +1263,7 @@ they are excluded from the results of this function."
                        submodule))
      submodules)))
 
-(defun projectile-get-sub-projects-files (project-root vcs)
+(defun projectile-get-sub-projects-files (project-root _vcs)
   "Get files from sub-projects for PROJECT-ROOT recursively."
   (projectile-flatten
    (mapcar (lambda (sub-project)

--- a/projectile.el
+++ b/projectile.el
@@ -43,6 +43,7 @@
 (require 'compile)
 (require 'grep)
 (eval-when-compile
+  (require 'find-dired)
   (require 'subr-x))
 
 (eval-when-compile


### PR DESCRIPTION
This fixes https://github.com/bbatsov/projectile/issues/97 as it related to grep.

find’s “-name” option never matches a path, so binding `grep-find-ignored-files` would never allow us to ignore such.  Therefore, .`projectile` paths like the following would not ignore anything when grepping (except for directories unusually bearing extensions):

```
-/foo/bar.txt
```

It was only possible to ignore _all_ files in a project with a given name, and only by specifying that name with a leading slash:

```
-/foo.txt
```

Specifying a file or directory name without a leading slash would not ignore anything:

```
-foo.txt
-foo/
```

Also, if an ignore was a path to a directory that existed from the root, then all such paths to directories in a project would be ignored.  However, if the path was to a direct descendant of the root which was _not_ a directory (or did not even exist), then all _non-directory files_ in the project with that direct descendant’s name would be ignored, and if the path was to a 2nd-generation or later non-directory or non-existent descendant, then nothing would be ignored.

These strange cases stemmed from probable misuse of `grep-find-ignored-directories`, which seems to only be intended for ignoring directory names appearing anywhere, and misuse of `grep-find-ignored-files`, which seems to only be intended for ignoring file names appearing anywhere and without respect to parent directories.  Therefore, binding ignores via `grep-find-ignored-directories` and `grep-find-ignored-files` greatly limited what could be ignored.

To ignore paths to files and to get more consistent behavior, I thought it was warranted to write a special exclusion expression supporting paths and which only ignored files and directories relative to the root.  Also, to fulfill the promise of [the documentation](https://docs.projectile.mx/en/latest/projects/#ignoring-files) and provide support for relative paths (or patterns as I interpreted it), it was warranted to write another special exclusion expression supporting patterns occurring anywhere.

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings _I documented `projectile-rgrep-default-command` to the same extent as its source function, `rgrep-default-command`.  Let me know if you’d prefer more documentation._
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- ~You've updated the readme (if adding/changing user-visible functionality)~

Thanks for considering these changes.