### PR TITLE
Add documentation for projectile-sort-order

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -14,8 +14,8 @@ obtain the list of files in a project.
 
 The `alien` indexing method optimizes to the limit the speed of
 the `hybrid` indexing method.  This means that Projectile will not do
-any processing of the files returned by the external commands and
-you're going to get the maximum performance possible.  This behaviour
+any processing or sorting of the files returned by the external commands 
+and you're going to get the maximum performance possible.  This behaviour
 makes a lot of sense for most people, as they'd typically be putting
 ignores in their VCS config (e.g. `.gitignore`) and won't care about
 any additional ignores/unignores/sorting that Projectile might also
@@ -83,6 +83,46 @@ find . -type f -print0
 
     It's a great idea to install [fd](https://github.com/sharkdp/fd) and use it as a replacement for both `git ls-files` (`fd` understands `.gitignore`) and `find`.
     The magic command you'll need with it is something like `fd . -0`.
+
+## Sorting
+
+You can choose how Projectile sorts files by customizing `projectile-sort-order`.
+
+!!! Info
+
+    Note that if Alien indexing is set, files are not sorted by Projectile at all.
+
+The default is to not sort files:
+
+```el
+(setq projectile-sort-order 'default)
+```
+
+To sort files by recently opened:
+
+```el
+(setq projectile-sort-order 'recentf)
+```
+
+To sort files by recently active buffers and then recently opened files:
+
+```el
+(setq projectile-sort-order 'recently-active)
+```
+
+<!-- These URLs below are in HTML so that the parentheses in the URL fragments are properly recognised. -->
+
+To sort files by <a href="https://en.wikipedia.org/wiki/MAC_times#Modification_time_(mtime)">modification time</a> (mtime):
+
+```el
+(setq projectile-sort-order 'modification-time)
+```
+
+To sort files by <a href="https://en.wikipedia.org/wiki/MAC_times#Access_time_(atime)">access time<a/> (atime):
+
+```el
+(setq projectile-sort-order 'access-time)
+```
 
 
 ## Caching

--- a/projectile.el
+++ b/projectile.el
@@ -96,7 +96,7 @@ idea to pair the native indexing method with caching.
 The hybrid indexing method uses external tools (e.g. git, find,
 etc) to speed up the indexing process.  Still, the files will be
 post-processed by Projectile for sorting/filtering purposes.
-In this sense that approach is a hybrid between native and indexing
+In this sense that approach is a hybrid between native indexing
 and alien indexing.
 
 The alien indexing method optimizes to the limit the speed
@@ -241,14 +241,17 @@ set to 'ggtags', then ggtags will be used for
   :package-version '(projectile . "0.14.0"))
 
 (defcustom projectile-sort-order 'default
-  "The sort order used for a project's files."
+  "The sort order used for a project's files.
+
+Note that files aren't sorted if `projectile-indexing-method'
+is set to 'alien'."
   :group 'projectile
   :type '(radio
-          (const :tag "default" default)
-          (const :tag "recentf" recentf)
-          (const :tag "recently active" recently-active)
-          (const :tag "access time" access-time)
-          (const :tag "modification time" modification-time)))
+          (const :tag "Default (no sorting)" default)
+          (const :tag "Recently opened files" recentf)
+          (const :tag "Recently active buffers, then recently opened files" recently-active)
+          (const :tag "Access time (atime)" access-time)
+          (const :tag "Modification time (mtime)" modification-time)))
 
 (defcustom projectile-verbose t
   "Echo messages that are not errors."


### PR DESCRIPTION
Adds documentation on the different sorting methods and how they interact with the alien indexing method. I found the different methods a little bit confusing, and especially that they didn't work when alien indexing was turned on.


-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)