### PR TITLE
Add suport for yadm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### New features
 
-* Added support for `yadm` projects.
+* [1384](https://github.com/bbatsov/projectile/pull/1384): Add support for
+  `yadm` projects.
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* Added support for `yadm` projects.
+
 ### Bugs fixed
 
 * [#97](https://github.com/bbatsov/projectile/issues/97): Respect `.projectile`

--- a/projectile.el
+++ b/projectile.el
@@ -317,9 +317,9 @@ The topmost match has precedence."
   :type '(repeat string))
 
 (defcustom projectile-project-root-files-bottom-up
-  '(".projectile" ; projectile project marker
+  '(".yadm"       ; YADM root dir
+    ".projectile" ; projectile project marker
     ".git"        ; Git VCS root dir
-    ".yadm"       ; YADM root dir
     ".hg"         ; Mercurial VCS root dir
     ".fslckout"   ; Fossil VCS root dir
     "_FOSSIL_"    ; Fossil VCS root DB on Windows
@@ -1215,12 +1215,12 @@ function is executing."
 Fallback to a generic command when not in a VCS-controlled project."
   (pcase vcs
    ('git projectile-git-command)
-   ('yadm projectile-yadm-command)
    ('hg projectile-hg-command)
    ('fossil projectile-fossil-command)
    ('bzr projectile-bzr-command)
    ('darcs projectile-darcs-command)
    ('svn projectile-svn-command)
+   ('yadm projectile-yadm-command)
    (_ projectile-generic-command)))
 
 (defun projectile-get-sub-projects-command (vcs)
@@ -2610,7 +2610,6 @@ PROJECT-ROOT is the targeted directory.  If nil, use
   (or project-root (setq project-root (projectile-project-root)))
   (cond
    ((projectile-file-exists-p (expand-file-name ".git" project-root)) 'git)
-   ((projectile-file-exists-p (expand-file-name ".yadm" project-root)) 'yadm)
    ((projectile-file-exists-p (expand-file-name ".hg" project-root)) 'hg)
    ((projectile-file-exists-p (expand-file-name ".fslckout" project-root)) 'fossil)
    ((projectile-file-exists-p (expand-file-name "_FOSSIL_" project-root)) 'fossil)
@@ -2618,13 +2617,14 @@ PROJECT-ROOT is the targeted directory.  If nil, use
    ((projectile-file-exists-p (expand-file-name "_darcs" project-root)) 'darcs)
    ((projectile-file-exists-p (expand-file-name ".svn" project-root)) 'svn)
    ((projectile-locate-dominating-file project-root ".git") 'git)
-   ((projectile-locate-dominating-file project-root ".yadm") 'yadm)
    ((projectile-locate-dominating-file project-root ".hg") 'hg)
    ((projectile-locate-dominating-file project-root ".fslckout") 'fossil)
    ((projectile-locate-dominating-file project-root "_FOSSIL_") 'fossil)
    ((projectile-locate-dominating-file project-root ".bzr") 'bzr)
    ((projectile-locate-dominating-file project-root "_darcs") 'darcs)
    ((projectile-locate-dominating-file project-root ".svn") 'svn)
+   ((projectile-file-exists-p (expand-file-name ".yadm" project-root)) 'yadm)
+   ((projectile-locate-dominating-file project-root ".yadm") 'yadm)
    (t 'none)))
 
 (defun projectile--test-name-for-impl-name (impl-file-path)


### PR DESCRIPTION
Hello!

[YADM (Yet Another Dotfile Manager)](https://yadm.io) is a wrapper around git, so most of the existing code for git is applicable to YADM as well. It does not, however, store stuff in `.git`, but in another work-tree in `.yadm/repo.git`, hence this PR. I could not find anything related to configuring projectile to handle git work-trees.

I would like to know if you are interested in adding support for this new VCS type in projectile, or if I should maintain my own fork. No hard feelings if you say no :)

This PR introduces adds a new VCS type, `'yadm`, which is defined as the "topmost" entry of `projectile-project-root-files-bottom-up` since the root-file is `~/.yadm` and it should match only as a last resort after we walked up the tree to `~`. Everywhere git was referenced, I added code for yadm as well. However close yadm and git are, I haven't added specific support for yadm in `projectile-grep`, since the git code relies on `vc-git`.

I have set `:package-version` in `projectile-yadm-ignored-command` to `2.0.0` which is obviously wrong, but I don't know if you are willing to pull this into master, so let me know :)

It currently Works On My Machine, let me know if you have any feedback.

Thanks & have a nice day!
Alex

-----------------

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
