### PR TITLE
Add  related-file option to support flexible test file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### Changes
+* Add `related-file` option to support more flexible way of finding test files
+
 ### Bugs fixed
 
 * [#97](https://github.com/bbatsov/projectile/issues/97): Respect `.projectile`

--- a/projectile.el
+++ b/projectile.el
@@ -2279,7 +2279,7 @@ The project types are symbols and they are linked to plists holding
 the properties of the various project types.")
 
 (cl-defun projectile-register-project-type
-    (project-type marker-files &key compilation-dir configure compile test run test-suffix test-prefix src-dir test-dir related-file-func)
+    (project-type marker-files &key compilation-dir configure compile test run test-suffix test-prefix src-dir test-dir related-file)
   "Register a project type with projectile.
 
 A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
@@ -2295,13 +2295,12 @@ TEST-SUFFIX which specifies test file suffix, and
 TEST-PREFIX which specifies test file prefix.
 SRC-DIR which specifies the path to the source relative to the project root.
 TEST-DIR which specifies the path to the tests relative to the project root.
-RELATED-FILE-FUNC which finds the related files such as test/impl files.
-          (my-related-file-func FILENAME TYPE)
+RELATED-FILE which specifies function to find the related files such as test/impl files.
+          (my/related-file FILENAME TYPE)
           FILENAME does not include directory component.
           TYPE can be 'test or 'impl.
           Should return a related filename or nil if not found.
-
-          RELATED-FILE-FUNC can be used instead of TEST_SUFFIX/PREFIX for the
+          RELATED-FILE can be used instead of TEST_SUFFIX/PREFIX for the
           more complex projects."
   (let ((project-plist (list 'marker-files marker-files
                              'compilation-dir compilation-dir
@@ -2322,8 +2321,8 @@ RELATED-FILE-FUNC which finds the related files such as test/impl files.
       (plist-put project-plist 'src-dir src-dir))
     (when test-dir
       (plist-put project-plist 'test-dir test-dir))
-    (when related-file-func
-      (plist-put project-plist 'related-file-func related-file-func))
+    (when related-file
+      (plist-put project-plist 'related-file related-file))
 
     (setq projectile-project-types
           (cons `(,project-type . ,project-plist)
@@ -2711,7 +2710,7 @@ Fallback to DEFAULT-VALUE for missing attributes."
 
 (defun projectile-related-file (project-type)
   "Find relative file based on PROJECT-TYPE."
-  (projectile-project-type-attribute project-type 'related-file-func))
+  (projectile-project-type-attribute project-type 'related-file))
 
 (defun projectile-src-directory (project-type)
   "Find default src directory based on PROJECT-TYPE."

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -922,8 +922,8 @@ test temp directory"
         (expect (projectile-find-matching-file "spec/bar/bar.service.spec.js") :to-equal "source/bar/bar.service.js"))))))
 
 
-(describe "related-file-func option"
-  (it "finds matching test or file in a custom project registered with related-file-func"
+(describe "related-file option"
+  (it "finds matching test or file"
     (projectile-test-with-sandbox
       (projectile-test-with-files
        ("project/src/"
@@ -935,15 +935,15 @@ test temp directory"
              (projectile-enable-caching nil))
          (projectile-register-project-type
           'cpp-project '("somefile")
-          :related-file-func (lambda (filename type)
-                               (let ((config
-                                      (cond
-                                       ((eq type 'test) (cons (rx (group (1+ anything )) ".cpp") "Test\\1.cpp"))
-                                       ((eq type 'impl) (cons (rx "Test" (group (1+ anything )) ".cpp") "\\1.cpp")))))
-                                 (when config
-                                   (cl-destructuring-bind (regexp . rep) config
-                                     (if (string-match regexp filename)
-                                         (replace-regexp-in-string regexp rep filename)))))))
+          :related-file (lambda (filename type)
+                          (let ((config
+                                 (cond
+                                  ((eq type 'test) (cons (rx (group (1+ anything )) ".cpp") "Test\\1.cpp"))
+                                  ((eq type 'impl) (cons (rx "Test" (group (1+ anything )) ".cpp") "\\1.cpp")))))
+                            (when config
+                              (cl-destructuring-bind (regexp . rep) config
+                                (if (string-match regexp filename)
+                                    (replace-regexp-in-string regexp rep filename)))))))
          (spy-on 'projectile-project-type :and-return-value 'cpp-project)
          (spy-on 'projectile-project-root :and-return-value (file-truename (expand-file-name "project/")))
          (expect (projectile-find-matching-test "src/Foo.cpp") :to-equal "test/TestFoo.cpp")


### PR DESCRIPTION
Add new 'related-file' option to specify a function to find test file for the given filename.
-----------------
This new option can be used in the future to handle 'other' file aspect as well.


- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [n/a] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
