### PR TITLE
Fix cabal project detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * [#97](https://github.com/bbatsov/projectile/issues/97): Respect `.projectile`
   ignores which are paths to files and patterns when using `projectile-grep`.
+- [#1391](https://github.com/bbatsov/projectile/issues/1391) A
+  `.cabal` sub-directory is no longer considered project indicator.
 
 ## 2.0.0 (2019-01-01)
 

--- a/projectile.el
+++ b/projectile.el
@@ -2312,7 +2312,7 @@ TEST-DIR which specifies the path to the tests relative to the project root."
 
 (defun projectile-cabal-project-p ()
   "Check if a project contains *.cabal files but no stack.yaml file."
-  (and (projectile-verify-file-wildcard "*.cabal")
+  (and (projectile-verify-file-wildcard "?*.cabal")
        (not (projectile-verify-file "stack.yaml"))))
 
 (defun projectile-go-project-p ()


### PR DESCRIPTION
Adjust the wildcard used to detect cabal projects to exclude a
`.cabal` dotfile (or dot-directory).

When using cabal, a `.cabal` directory will exist inside the user's
home directory. Without this change, projectile will interpret that as
a Cabal project existing directly in the home directory, and thus
every file opened that does not belong to a more specific project will
be categorized as a Haskell Cabal project.

Fixes #1391.