### PR TITLE
Add Bloop Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1019](https://github.com/bbatsov/projectile/issues/1019): Jump to a test named the same way but in a different directory.
 * [#982](https://github.com/bbatsov/projectile/issues/982) Add heuristic for projectile-find-matching-test
 * Support a list of functions for `related-files-fn` options and helper functions
+* [#1405](https://github.com/bbatsov/projectile/pull/1405) Add Bloop Scala build server project detection
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -2650,6 +2650,9 @@ test/impl/other files as below:
                                   :test-suffix "_test")
 (projectile-register-project-type 'clojure-cli '("deps.edn")
                                   :test-suffix "_test")
+(projectile-register-project-type 'bloop '(".bloop")
+                                  :compile "bloop compile root"
+                                  :test "bloop test root")
 ;; Ruby
 (projectile-register-project-type 'ruby-rspec '("Gemfile" "lib" "spec")
                                   :compile "bundle exec rake"


### PR DESCRIPTION
Bloop is a Scala Build Server. Projects using bloop will likely have another build system referenced locally, e.g. a `build.sbt` file, but the ideal method to compile/test will be through the `bloop` command to the `bloop` daemon.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
