### PR TITLE
Improve error handling in default-generic-command

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3677,17 +3677,22 @@ Should be set via .dir-locals.el.")
 If found, checks if value is symbol or string.  In case of symbol
 resolves to function `funcall's.  Return value of function MUST
 be string to be executed as command."
-  (let ((command (plist-get (alist-get project-type projectile-project-types) command-type)))
-    (cond
-     ((stringp command) command)
-     ((functionp command)
-      (if (fboundp command)
-          (funcall (symbol-function command))))
-     ((and (not command) (eq command-type 'compilation-dir))
-      ;; `compilation-dir' is special in that it is used as a fallback for the root
-      nil)
-     (t
-      (user-error "The value for: %s in project-type: %s was neither a function nor a string." command-type project-type)))))
+  (when (not project-type)
+    (user-error "project-type is not set"))
+  (let ((project-type-props (alist-get project-type projectile-project-types)))
+    (when (not project-type-props)
+      (user-error "Unrecognized project-type: %s" project-type))
+    (let ((command (plist-get project-type-props command-type)))
+      (cond
+       ((stringp command) command)
+       ((functionp command)
+        (if (fboundp command)
+            (funcall (symbol-function command))))
+       ((and (not command) (eq command-type 'compilation-dir))
+        ;; `compilation-dir' is special in that it is used as a fallback for the root
+        nil)
+       (t
+        (user-error "The value for: %s in project-type: %s was neither a function nor a string." command-type project-type))))))
 
 (defun projectile-default-configure-command (project-type)
   "Retrieve default configure command for PROJECT-TYPE."


### PR DESCRIPTION
Improve the error message in two cases:

* The project type is not set
* The project type is not recognized

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
