### PR TITLE
Fix root caching when root doesn't exist

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1075,7 +1075,7 @@ If DIR is not supplied its set to the current directory by default."
                        (lambda (func)
                          (let* ((cache-key (format "%s-%s" func dir))
                                 (cache-value (gethash cache-key projectile-project-root-cache)))
-                           (if (and cache-value (file-exists-p cache-value))
+                           (if (or (not cache-value) (file-exists-p cache-value))
                                cache-value
                              (let ((value (funcall func (file-truename dir))))
                                (puthash cache-key value projectile-project-root-cache)


### PR DESCRIPTION
Previously, the cache for all the root finding functions would only work in the
case when the root was found. However, caching is just useful for buffers where
there's no project defined. Therefore, we enable caching in such situations.

A concrete case where this drastically improves the performance is when used with `ivy-rich`. `ivy-rich` fetches the project root for every buffer and it's important for this to be as fast possible.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
