### PR TITLE
Use fd when available instead of find

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -81,8 +81,8 @@ find . -type f -print0
 
 !!! Tip
 
-    It's a great idea to install [fd](https://github.com/sharkdp/fd) and use it as a replacement for both `git ls-files` (`fd` understands `.gitignore`) and `find`.
-    The magic command you'll need with it is something like `fd . -0`.
+    It's a great idea to install [fd](https://github.com/sharkdp/fd) which is much faster thant `find`.
+    If `fd` is found, projectile will use as a replacement for `find`.
 
 ## Sorting
 

--- a/projectile.el
+++ b/projectile.el
@@ -643,7 +643,10 @@ Set to nil to disable listing submodules contents."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-generic-command "find . -type f -print0"
+(defcustom projectile-generic-command
+  (if (executable-find "fd")
+      "fd . -0"
+    "find . -type f -print0")
   "Command used by projectile to get the files in a generic project."
   :group 'projectile
   :type 'string)


### PR DESCRIPTION
The patch make fd the default for searching for files in non-DVCS
projects.

- [ ] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
