### PR TITLE
Enhance go project detection by referring to go.mod file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#982](https://github.com/bbatsov/projectile/issues/982) Add heuristic for projectile-find-matching-test
 * Support a list of functions for `related-files-fn` options and helper functions
 * [#1405](https://github.com/bbatsov/projectile/pull/1405) Add Bloop Scala build server project detection
+* [#1418](https://github.com/bbatsov/projectile/pull/1418) The presence of a go.mod file implies a go project
 * [#1419](https://github.com/bbatsov/projectile/pull/1419) When possible, use [fd](https://github.com/sharkdp/fd) instead
   of `find` to list the files of a non-VCS project. This should be much faster.
 

--- a/projectile.el
+++ b/projectile.el
@@ -2508,8 +2508,8 @@ test/impl/other files as below:
 
 (defun projectile-go-project-p ()
   "Check if a project contains Go source files."
-  (or (projectile-verify-file-wildcard "*.go")
-      (projectile-verify-file "go.mod")))
+  (or (projectile-verify-file "go.mod")
+      (projectile-verify-file-wildcard "*.go")))
 
 (define-obsolete-variable-alias 'projectile-go-function 'projectile-go-project-test-function "1.0.0")
 (defcustom projectile-go-project-test-function #'projectile-go-project-p

--- a/projectile.el
+++ b/projectile.el
@@ -2508,7 +2508,8 @@ test/impl/other files as below:
 
 (defun projectile-go-project-p ()
   "Check if a project contains Go source files."
-  (projectile-verify-file-wildcard "*.go"))
+  (or (projectile-verify-file-wildcard "*.go")
+      (projectile-verify-file "go.mod")))
 
 (define-obsolete-variable-alias 'projectile-go-function 'projectile-go-project-test-function "1.0.0")
 (defcustom projectile-go-project-test-function #'projectile-go-project-p


### PR DESCRIPTION
This PR fixes an issue encountered when working in a go project that doesn't have any `.go` files at the root. The fix is to check for a `go.mod` file at the root of the project, avoiding a recursive descent of the project. The `go.mod` file is new-ish and will be present in projects that are using Go modules. The file will be present in all (or almost all) Go projects when Go 1.13 is released later this year.

I didn't add any tests, but this is the fix I applied to my local install of projectile and it worked great.

Feel free to remove or tweak my Changelog entry, this change may not be big enough to warrant documentation.


- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
