### PR TITLE
Remove extra "the" from Contributing docs

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -26,8 +26,7 @@ guidelines](https://github.com/bbatsov/projectile/blob/master/CONTRIBUTING.md).
 
 Good documentation is just as important as good code.
 
-Consider improving and extending the
-this manual and the
+Consider improving and extending this manual and the
 [community wiki](https://github.com/bbatsov/projectile/wiki).
 
 ### Working on the Manual


### PR DESCRIPTION
There was an extra "the" in the Contributing section of the docs. This deletes it.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
