### PR TITLE
fd never use colors

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -645,7 +645,7 @@ Set to nil to disable listing submodules contents."
 
 (defcustom projectile-generic-command
   (if (executable-find "fd")
-      "fd . -0"
+      "fd . -0 --color=never"
     "find . -type f -print0")
   "Command used by projectile to get the files in a generic project."
   :group 'projectile


### PR DESCRIPTION
Prevent projectile-find-file to be littered with escape codes when the
environment variable `LS_COLORS` is set.

Similar PR as for downstream: https://github.com/hlissner/doom-emacs/pull/1449

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
