### PR TITLE
Add projectile-current-on-switch information

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -197,6 +197,10 @@ If you want Projectile to be usable in every directory (even without the presenc
 
 ## Switching projects
 
+By default, projectile does not include the current project in the list when
+switching projects. If you want to include the current project, customize
+variable `projectile-current-project-on-switch`.
+
 When running `projectile-switch-project` (<kbd>s-p p</kbd>) Projectile invokes
 the command specified in `projectile-switch-project-action` (by default it is
 `projectile-find-file`).


### PR DESCRIPTION
I would have liked to see this when checking the docs - I had to look for this longer than I'd wanted. Veteran Emacs users probably check the list of configurable variables first, but those using Emacs as a secondary tool  (like me) usually check the docs first.

Relates to #1016 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
