### PR TITLE
Make sure projectile-files-via-ext-command returns files not errors

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1356,10 +1356,15 @@ VCS is the VCS of the project."
   "Get a list of relative file names in the project ROOT by executing COMMAND.
 
 If `command' is nil or an empty string, return nil.
-This allows commands to be disabled."
+This allows commands to be disabled.
+
+Only text sent to standard output is taken into account."
   (when (stringp command)
     (let ((default-directory root))
-      (split-string (shell-command-to-string command) "\0" t))))
+      (with-temp-buffer
+        (call-process-shell-command command nil '(t nil))
+        (let ((shell-output (buffer-substring (point-min) (point-max))))
+          (split-string (string-trim shell-output) "\0" t))))))
 
 (defun projectile-adjust-files (project vcs files)
   "First remove ignored files from FILES, then add back unignored files."

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -305,9 +305,11 @@ You'd normally combine this with `projectile-test-with-sandbox'."
     (expect (string-empty-p (projectile-get-sub-projects-command 'none)) :to-be-truthy)))
 
 (describe "projectile-files-via-ext-command"
-  (it "returns nil when command is nil or empty"
-    (expect (projectile-files-via-ext-command "" "") :not :to-be-truthy)
-    (expect (projectile-files-via-ext-command "" nil) :not :to-be-truthy)))
+   (it "returns nil when command is nil or empty or fails"
+     (expect (projectile-files-via-ext-command "" "") :not :to-be-truthy)
+     (expect (projectile-files-via-ext-command "" nil) :not :to-be-truthy)
+     (expect (projectile-files-via-ext-command "" "echo Not a file name! > &2") :not :to-be-truthy)
+     (expect (projectile-files-via-ext-command "" "echo filename") :to-equal '("filename"))))
 
 (describe "projectile-mode"
   (it "sets up hook functions"


### PR DESCRIPTION
If a command fails, it may return an error message like:
`fatal: No url found for submodule path 'XXX' in .gitmodules`.

It just filters out error messages to avoid the calling code to try to
use it as a file name.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
