### PR TITLE
add sort by path length & custom method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### New features
 
-* Add `related-files-fn` option to use custom function to find test/impl/other files.
+* Add `path-length` and `custom-method` files sorting options
+* Add `related-files-fn` option to use custom function to find test/impl/other files
 * [#1019](https://github.com/bbatsov/projectile/issues/1019): Jump to a test named the same way but in a different directory.
 * [#982](https://github.com/bbatsov/projectile/issues/982): Add heuristic for projectile-find-matching-test.
 * Support a list of functions for `related-files-fn` options and helper functions.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -127,7 +127,7 @@ To sort files by <a href="https://en.wikipedia.org/wiki/MAC_times#Access_time_(a
 To sort files by the length of the file path:
 
 ```el
-(setq projectile-sort-order path-length)
+(setq projectile-sort-order 'path-length)
 ```
 
 To sort files by a user-defined method:
@@ -138,7 +138,7 @@ To sort files by a user-defined method:
   (< (length file1) (length file2)))
 
 (setq projectile-sort-custom-method 'my-custom-sort-method)
-(setq projectile-sort-order custom-method)
+(setq projectile-sort-order 'custom-method)
 ```
 
 ## Caching

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -124,6 +124,22 @@ To sort files by <a href="https://en.wikipedia.org/wiki/MAC_times#Access_time_(a
 (setq projectile-sort-order 'access-time)
 ```
 
+To sort files by the length of the file path:
+
+```el
+(setq projectile-sort-order path-length)
+```
+
+To sort files by a user-defined method:
+
+```el
+;; passed to PREDICATE of cl-sort
+(defun my-custom-sort-method (file1 file2)
+  (< (length file1) (length file2)))
+
+(setq projectile-sort-custom-method 'my-custom-sort-method)
+(setq projectile-sort-order custom-method)
+```
 
 ## Caching
 

--- a/projectile.el
+++ b/projectile.el
@@ -256,7 +256,7 @@ is set to 'alien'."
           (const :tag "Custom method" custom-method)))
 
 (defcustom projectile-sort-custom-method nil
-  "The sort method to use for custom sorting
+  "The sort method to use for custom sorting.
 
 This should be the name of a predicate method usable by `cl-sort'"
   :group 'projectile

--- a/projectile.el
+++ b/projectile.el
@@ -251,7 +251,16 @@ is set to 'alien'."
           (const :tag "Recently opened files" recentf)
           (const :tag "Recently active buffers, then recently opened files" recently-active)
           (const :tag "Access time (atime)" access-time)
-          (const :tag "Modification time (mtime)" modification-time)))
+          (const :tag "Modification time (mtime)" modification-time)
+          (const :tag "Path length" path-length)
+          (const :tag "Custom method" custom-method)))
+
+(defcustom projectile-sort-custom-method nil
+  "The sort method to use for custom sorting
+
+This should be the name of a predicate method usable by `cl-sort'"
+  :group 'projectile
+  :type 'symbol)
 
 (defcustom projectile-verbose t
   "Echo messages that are not errors."
@@ -2173,7 +2182,9 @@ With a prefix arg INVALIDATE-CACHE invalidates the cache first."
     (recentf (projectile-sort-by-recentf-first files))
     (recently-active (projectile-sort-by-recently-active-first files))
     (modification-time (projectile-sort-by-modification-time files))
-    (access-time (projectile-sort-by-access-time files))))
+    (access-time (projectile-sort-by-access-time files))
+    (path-length (projectile-sort-by-path-length files))
+    (custom-method (projectile-sort-by-custom-method files))))
 
 (defun projectile-sort-by-recentf-first (files)
   "Sort FILES by a recent first scheme."
@@ -2206,6 +2217,23 @@ With a prefix arg INVALIDATE-CACHE invalidates the cache first."
        (let ((file1-atime (nth 4 (file-attributes file1)))
              (file2-atime (nth 4 (file-attributes file2))))
          (not (time-less-p file1-atime file2-atime)))))))
+
+(defun projectile-sort-by-path-length (files)
+  "Sort FILES by path length."
+  (let ((default-directory (projectile-project-root)))
+    (cl-sort
+     (copy-sequence files)
+     (lambda (file1 file2)
+       (let ((path-len1 (length file1))
+             (path-len2 (length file2)))
+         (< path-len1 path-len2))))))
+
+(defun projectile-sort-by-custom-method (files)
+  "Sort FILES by custom method."
+  (let ((default-directory (projectile-project-root)))
+    (cl-sort
+     (copy-sequence files)
+     projectile-sort-custom-method)))
 
 
 ;;;; Find directory in project functionality

--- a/projectile.el
+++ b/projectile.el
@@ -253,7 +253,8 @@ is set to 'alien'."
           (const :tag "Access time (atime)" access-time)
           (const :tag "Modification time (mtime)" modification-time)
           (const :tag "Path length" path-length)
-          (const :tag "Custom method" custom-method)))
+          (const :tag "Custom method" custom-method))
+  :package-version '(projectile . "2.1.0")))
 
 (defcustom projectile-sort-custom-method nil
   "The sort method to use for custom sorting.


### PR DESCRIPTION
I wanted to be able to sort the list of files for `projectile-find-file` by the length of the full path. The reason is that if I want to find `models/user.rb` and I'm presented with

```
models/special_case/user_hamburger.rb
models/user.rb
```
I can only get the one I want by navigating in the completion window, which is cumbersome (or maybe there's another way, but I don't know it), rather than just doing more incremental completion. There's nothing to type to narrow down to just the file I want (or nothing short).

By contrast, if I'm presented with that list in reverse, and I actually am looking for `user_hamburger.rb`, I can get to it with incremental completion, and I can see what letters to type to get there.

I originally started out to add an option to sort the list by a custom method, so I could add my own sort-by-path-length method and use that. When I finished, I considered that enough other users would want to sort by path length that I might as well add an option to do that. So I did, and that's what I now use for my sort method, rather than the custom method.

I considered removing the sort-by-custom-method code, but thought that the maintainers might think both were useful. I can remove one or the other if the maintainers think it's too much.

NOTE: I don't really know how to write cask tests. I looked and I didn't see any tests for the existing sorting or even for `projectile-project-files`, so I presume not writing tests for my change is okay. I did manage to install cask & butterfly & confirm that I at least didn't break any existing tests.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
i _think_ so, kinda
- [x] You've added tests (if possible) to cover your change(s)
arguably not possible
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
as far as i can tell, although checkdoc says all kinds of stuff is wrong so i could have missed something
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
