### PR TITLE
fix projectile-replace for emacs 27.0.50

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3480,7 +3480,7 @@ to run the replacement."
                     (projectile-prepend-project-name
                      (format "Replace %s with: " old-text))))
          (files (projectile-files-with-string old-text directory)))
-    (if (version< emacs-version "27")
+    (if (version< emacs-version "27.1")
         ;; Adapted from `tags-query-replace' for literal strings (not regexp)
         (progn
           (setq tags-loop-scan `(let ,(unless (equal old-text (downcase old-text))


### PR DESCRIPTION
projectile-replace is broken in emacs 27.0.50, as per #1386
projectile-replace: Symbol’s function definition is void: fileloop-initialize-replace

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!