### PR TITLE
Update dotnet project detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * [#1419](https://github.com/bbatsov/projectile/pull/1419): When possible, use [fd](https://github.com/sharkdp/fd) instead
   of `find` to list the files of a non-VCS project. This should be much faster.
 
+### Changes
+
+* A project now registers as `dotnet` if it has a solution (`*.sln*`) file at the project root or project files (`*.[fc]sproj`) in `src/*/`, as well as the old "project files in project root" heuristic.
+
 ### Bugs fixed
 
 * [#97](https://github.com/bbatsov/projectile/issues/97): Respect `.projectile` ignores which are paths to files and patterns when using `projectile-grep`.

--- a/projectile.el
+++ b/projectile.el
@@ -2508,8 +2508,11 @@ test/impl/other files as below:
        (not (projectile-verify-file "stack.yaml"))))
 
 (defun projectile-dotnet-project-p ()
-  (or (projectile-verify-file-wildcard "?*.csproj")
-      (projectile-verify-file-wildcard "?*.fsproj")))
+  (or (projectile-verify-file-wildcard "?*.sln")
+      (projectile-verify-file-wildcard "?*.csproj")
+      (projectile-verify-file-wildcard "src/*/?*.csproj")
+      (projectile-verify-file-wildcard "?*.fsproj")
+      (projectile-verify-file-wildcard "src/*/?*.fsproj")))
 
 (defun projectile-go-project-p ()
   "Check if a project contains Go source files."

--- a/projectile.el
+++ b/projectile.el
@@ -2508,6 +2508,8 @@ test/impl/other files as below:
        (not (projectile-verify-file "stack.yaml"))))
 
 (defun projectile-dotnet-project-p ()
+  "Check if a project contains a *.sln file at the project root, or either
+a .csproj or .fsproj file at either the project root or within src/*/."
   (or (projectile-verify-file-wildcard "?*.sln")
       (projectile-verify-file-wildcard "?*.csproj")
       (projectile-verify-file-wildcard "src/*/?*.csproj")


### PR DESCRIPTION
Previously, this function looked only at `.[cf]sproj` files in the _root_ of the
project directory. _However_, this is not how dotnet projects are typically laid
out. Instead, the `.[cf]sproj` file is often located in a directory like
`src/ProjectName/Project.fsproj`. This is because a given repo might contain
_many_ projects, which are then tied together into a root "solution" file.

This commit checks for the solution (`.sln`) file /first/, then does the
existing "same dir" check plus a `src/*/` check for the project files.

I looked through the current test suite, and I didn't _see_ any tests for this kind of predicate function. I am, however, very happy to add one if one is preferred. 

(Changelog and a docstring for the function I edited coming in the next commit.)

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
