### PR TITLE
Call `switch-project-action` within project's temp buffer

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -4053,17 +4053,17 @@ With a prefix ARG invokes `projectile-commander' instead of
     (let ((default-directory project-to-switch))
       ;; use a temporary buffer to load PROJECT-TO-SWITCH's dir-locals before calling SWITCH-PROJECT-ACTION
       (with-temp-buffer
-        (hack-dir-local-variables-non-file-buffer))
-      ;; Normally the project name is determined from the current
-      ;; buffer. However, when we're switching projects, we want to
-      ;; show the name of the project being switched to, rather than
-      ;; the current project, in the minibuffer. This is a simple hack
-      ;; to tell the `projectile-project-name' function to ignore the
-      ;; current buffer and the caching mechanism, and just return the
-      ;; value of the `projectile-project-name' variable.
-      (let ((projectile-project-name (funcall projectile-project-name-function
-                                              project-to-switch)))
-        (funcall switch-project-action)))
+        (hack-dir-local-variables-non-file-buffer)
+        ;; Normally the project name is determined from the current
+        ;; buffer. However, when we're switching projects, we want to
+        ;; show the name of the project being switched to, rather than
+        ;; the current project, in the minibuffer. This is a simple hack
+        ;; to tell the `projectile-project-name' function to ignore the
+        ;; current buffer and the caching mechanism, and just return the
+        ;; value of the `projectile-project-name' variable.
+        (let ((projectile-project-name (funcall projectile-project-name-function
+                                                project-to-switch)))
+          (funcall switch-project-action))))
     (run-hooks 'projectile-after-switch-project-hook)))
 
 ;;;###autoload

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -734,6 +734,24 @@ You'd normally combine this with `projectile-test-with-sandbox'."
     (let ((projectile-known-projects nil))
       (expect (projectile-switch-project) :to-throw))))
 
+(describe "projectile-switch-project-by-name"
+  (it "calls the switch project action with project-to-swtich's dir-locals loaded"
+    (let ((foo 'bar)
+          (switch-project-foo)
+          (safe-local-variable-values '((foo . baz)))
+          (projectile-switch-project-action (lambda () (setq switch-project-foo foo))))
+      (projectile-test-with-sandbox
+        (projectile-test-with-files
+            ("project/"
+             "project/.dir-locals.el"
+             "project/.projectile")
+          (append-to-file
+           "((nil . ((foo . baz))))" nil "project/.dir-locals.el")
+          (projectile-add-known-project (file-name-as-directory (expand-file-name "project")))
+          (projectile-switch-project-by-name (file-name-as-directory (expand-file-name "project")))
+
+          (expect switch-project-foo :to-be 'baz))))))
+
 (describe "projectile-ignored-buffer-p"
   (it "checks if buffer should be ignored"
     (let ((projectile-globally-ignored-buffers '("*nrepl messages*" "*something*")))


### PR DESCRIPTION
This makes sure that any buffer local variables that were loaded by
`hack-dir-local-variables-non-file-buffer` are loaded with the
appropriate variables when the action is called.

Also removes the code to set project name to the new project as it should be properly set given we're now running from the new project's buffer.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
  - ~I'm not sure of how/if this should be tested, open to suggestions~
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
