### PR TITLE
Return nil when a command doesn't have a default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#1391](https://github.com/bbatsov/projectile/issues/1391): A `.cabal` sub-directory is no longer considered project indicator.
 * [#1385](https://github.com/bbatsov/projectile/issues/1385): Update `projectile-replace` for Emacs 27.
 * [#1432](https://github.com/bbatsov/projectile/issues/1432): Support .NET project.
+* [#1270](https://github.com/bbatsov/projectile/issues/1270): Fix running commands that don't have a default value.
 
 ## 2.0.0 (2019-01-01)
 

--- a/projectile.el
+++ b/projectile.el
@@ -3698,7 +3698,7 @@ be string to be executed as command."
       (if (fboundp command)
           (funcall (symbol-function command))))
      (t
-      (error "The value for: %s in project-type: %s was neither a function nor a string." command-type project-type)))))
+      (error "The value for: %s in project-type: %s was neither a function nor a string" command-type project-type)))))
 
 (defun projectile-default-configure-command (project-type)
   "Retrieve default configure command for PROJECT-TYPE."

--- a/projectile.el
+++ b/projectile.el
@@ -3692,15 +3692,13 @@ resolves to function `funcall's.  Return value of function MUST
 be string to be executed as command."
   (let ((command (plist-get (alist-get project-type projectile-project-types) command-type)))
     (cond
+     ((not command) nil)
      ((stringp command) command)
      ((functionp command)
       (if (fboundp command)
           (funcall (symbol-function command))))
-     ((and (not command) (eq command-type 'compilation-dir))
-      ;; `compilation-dir' is special in that it is used as a fallback for the root
-      nil)
      (t
-      (user-error "The value for: %s in project-type: %s was neither a function nor a string." command-type project-type)))))
+      (error "The value for: %s in project-type: %s was neither a function nor a string." command-type project-type)))))
 
 (defun projectile-default-configure-command (project-type)
   "Retrieve default configure command for PROJECT-TYPE."


### PR DESCRIPTION
Fixes: https://github.com/bbatsov/projectile/issues/1270
Equivalent to: https://github.com/bbatsov/projectile/pull/1268 (but error is still signalled if command is invalid)
Generalizes: https://github.com/bbatsov/projectile/pull/1269

This fixes the regression introduced in https://github.com/bbatsov/projectile/pull/1255 that prevents a user from running a command when it doesn't have a default value.

@bbatsov originally proposed in https://github.com/bbatsov/projectile/pull/1269 that the solution could be generalized by prompting the user; but if we did this, we would prompt the user twice when using projectile-*-project commands. By returning nil, we leave it up to the caller to handle errors. This is equivalent to the behaviour before https://github.com/bbatsov/projectile/pull/1255.

---
- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] No previously passing tests are failing
- [ ] All tests are passing (`make test`)
  - `projectile-find-file-in-directory` fails when called in a non-existing directory, but it was failing before this change
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
