### PR TITLE
Autoload projectile-add-known-project

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -4165,6 +4165,7 @@ See `projectile--cleanup-known-projects'."
       (and (functionp projectile-ignored-project-function)
            (funcall projectile-ignored-project-function project-root))))
 
+;;;###autoload
 (defun projectile-add-known-project (project-root)
   "Add PROJECT-ROOT to the list of known projects."
   (interactive (list (read-directory-name "Add to known projects: ")))


### PR DESCRIPTION
As a follow up to #1454, this only autoloads `projectile-add-known-project`, as it is an interactive command.