### PR TITLE
Fix incorrect order of if statement forms in projectile-replace

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3481,23 +3481,22 @@ to run the replacement."
                      (format "Replace %s with: " old-text))))
          (files (projectile-files-with-string old-text directory)))
     (if (fboundp #'fileloop-continue)
-        ;; Emacs 25 and 26
-        ;;
-        ;; Adapted from `tags-query-replace' for literal strings (not regexp)
-        (progn
-          (setq tags-loop-scan `(let ,(unless (equal old-text (downcase old-text))
-                                        '((case-fold-search nil)))
-                                  (if (search-forward ',old-text nil t)
-                                      ;; When we find a match, move back to
-                                      ;; the beginning of it so
-                                      ;; perform-replace will see it.
-                                      (goto-char (match-beginning 0))))
-                tags-loop-operate `(perform-replace ',old-text ',new-text t nil nil
-                                                    nil multi-query-replace-map))
-          (tags-loop-continue (or (cons 'list files) t)))
-      ;; Emacs 27+
-      (fileloop-initialize-replace old-text new-text files 'default)
-      (fileloop-continue))))
+        ;; Emacs 27+
+        (progn (fileloop-initialize-replace old-text new-text files 'default)
+               (fileloop-continue))
+      ;; Emacs 25 and 26
+      ;;
+      ;; Adapted from `tags-query-replace' for literal strings (not regexp)
+      (setq tags-loop-scan `(let ,(unless (equal old-text (downcase old-text))
+                                    '((case-fold-search nil)))
+                              (if (search-forward ',old-text nil t)
+                                  ;; When we find a match, move back to
+                                  ;; the beginning of it so
+                                  ;; perform-replace will see it.
+                                  (goto-char (match-beginning 0))))
+            tags-loop-operate `(perform-replace ',old-text ',new-text t nil nil
+                                                nil multi-query-replace-map))
+      (tags-loop-continue (or (cons 'list files) t)))))
 
 ;;;###autoload
 (defun projectile-replace-regexp (&optional arg)


### PR DESCRIPTION
This PR resolves #1459 

The resulting forms of the `(fboundp #'fileloop-continue)` condition are in the incorrect order. So, this swaps them so that the code works as intended. 

No "new" code is written here, just a reordering of older things, so many of the below checkboxes aren't valid for this case.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

