### PR TITLE
Makefile: use elpa instead of PKGDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,6 @@ export EMACS ?= emacs
 EMACSFLAGS =
 TESTFLAGS =
 
-PKGDIR := $(shell EMACS=$(EMACS) $(CASK) package-directory)
-
 SRCS = $(wildcard *.el)
 OBJS = $(SRCS:.el=.elc)
 
@@ -29,5 +27,5 @@ compile: elpa
 clean:
 	rm -f $(OBJS)
 
-test: $(PGKDIR)
+test: elpa
 	$(CASK) exec buttercup -L .


### PR DESCRIPTION
Hi!
I found your Makefile has typo; `PGKDIR`.
I try to fix it but your build depends `PGKDIR` (nil). so I use `elpa` instead of it.

All make job works well in my environment, but please try it.

----

# 

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!