### PR TITLE
fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 sudo: false
 language: emacs-lisp
+dist: xenial
 env:
   - EMACS_BINARY=emacs-25.1-travis MAKE_TEST=test
   - EMACS_BINARY=emacs-25.2-travis MAKE_TEST=test
-  - EMACS_BINARY=emacs-26.1-travis MAKE_TEST=test
-  - EMACS_BINARY=emacs-git-snapshot-travis MAKE_TEST=test
+  - EMACS_BINARY=emacs-26.3-travis-linux-xenial MAKE_TEST=test
+  - EMACS_BINARY=emacs-git-snapshot-travis-linux-xenial MAKE_TEST=test
 matrix:
   allow_failures:
     - env: EMACS_BINARY=emacs-git-snapshot-travis


### PR DESCRIPTION
The third and fourth jobs were broken due to what was fixed by this, I think: https://github.com/rejeep/evm/pull/130

All jobs now succeed: https://travis-ci.org/peterbecich/projectile/builds/619137833

The Emacs 26.1 job is updated to Emacs 26.3.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- ~You've added tests (if possible) to cover your change(s)~
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
