### PR TITLE
Allow multiple root-dirs to be search by projectile-grep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#1385](https://github.com/bbatsov/projectile/issues/1385): Update `projectile-replace` for Emacs 27.
 * [#1432](https://github.com/bbatsov/projectile/issues/1432): Support .NET project.
 * [#1270](https://github.com/bbatsov/projectile/issues/1270): Fix running commands that don't have a default value.
+* [#1482](https://github.com/bbatsov/projectile/issues/1482): Run a seperate grep buffer per project root
 
 ## 2.0.0 (2019-01-01)
 

--- a/projectile.el
+++ b/projectile.el
@@ -3204,7 +3204,13 @@ With REGEXP given, don't query the user for a regexp."
               (projectile-grep-find-unignored-patterns (projectile-patterns-to-ensure)))
           (grep-compute-defaults)
           (cl-letf (((symbol-function 'rgrep-default-command) #'projectile-rgrep-default-command))
-            (rgrep search-regexp (or files "* .*") root-dir)))))
+            (rgrep search-regexp (or files "* .*") root-dir)
+            (when (get-buffer "*grep*")
+              ;; When grep is using a global *grep* buffer rename it to be
+              ;; scoped to the current root to allow multiple concurrent grep
+              ;; operations, one per root
+              (with-current-buffer "*grep*"
+                (rename-buffer (concat "*grep <" root-dir ">*"))))))))
     (run-hooks 'projectile-grep-finished-hook)))
 
 ;;;###autoload

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -28,6 +28,7 @@
 (require 'projectile)
 (require 'buttercup)
 
+
 (message "Running tests on Emacs %s" emacs-version)
 
 ;; TODO: Revise this init logic
@@ -643,6 +644,32 @@ You'd normally combine this with `projectile-test-with-sandbox'."
         (expect (projectile-project-root) :to-equal correct-project-root))))))
 
 (describe "projectile-grep"
+  (describe "multi-root grep"
+    (after-each
+      (cl-flet ((grep-buffer-p (b) (string-prefix-p "*grep" (buffer-name b))))
+        (let ((grep-buffers (cl-remove-if-not #'grep-buffer-p (buffer-list))))
+          (dolist (grep-buffer grep-buffers)
+            (let ((kill-buffer-query-functions nil))
+              (kill-buffer grep-buffer))))))
+    (it "grep multi-root projects"
+      (projectile-test-with-sandbox
+        (projectile-test-with-files
+            ("project/bar/"
+             "project/baz/")
+          (cd "project")
+          (with-temp-file ".projectile" (insert (concat "+/baz\n"
+                                                        "+/bar\n")))
+          (with-temp-file "foo.txt" (insert "hi"))
+          (with-temp-file "bar/bar.txt" (insert "hi"))
+          (with-temp-file "baz/baz.txt" (insert "hi"))
+          (with-current-buffer (find-file-noselect ".projectile" t)
+            (let ((grep-find-template "<X>")
+                  grep-find-ignored-directories grep-find-ignored-files
+                  projectile-globally-ignored-files
+                  projectile-globally-ignored-file-suffixes
+                  projectile-globally-ignored-directories)
+              (projectile-grep "hi")))))))
+
   (describe "rgrep"
     (before-each
       (spy-on 'compilation-start))


### PR DESCRIPTION
When a project is configured via `.projectile` to include multiple directories
explicitly this results in `projectile-grep` to run over multiple roots.

```
+/foo/bar
+/baz/
```

With a single global *grep* buffer this results in either

a) losing all but the search result of the last root
b) Stalling as the user is asked per root to kill the grep buffer

To avoid this the name of the `*grep*` buffer should to include the current
`root` being search associated with the buffer like `*grep <~/source/foo/bar>*`.

Fixes #1482 