### PR TITLE
[Fix #1475] Fix unignoring directories in hybrid mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#1385](https://github.com/bbatsov/projectile/issues/1385): Update `projectile-replace` for Emacs 27.
 * [#1432](https://github.com/bbatsov/projectile/issues/1432): Support .NET project.
 * [#1270](https://github.com/bbatsov/projectile/issues/1270): Fix running commands that don't have a default value.
+* [#1475](https://github.com/bbatsov/projectile/issues/1475): Fix directories being ignored with hybrid mode despite being explicitly unignored
 
 ## 2.0.0 (2019-01-01)
 

--- a/projectile.el
+++ b/projectile.el
@@ -1367,7 +1367,7 @@ otherwise operates relative to project root."
     (let (result)
       (dolist (dir directories result)
         (setq result (append result
-                             (projectile-get-repo-ignored-directory project vcs dir))))
+                             (projectile-get-repo-ignored-directory project dir vcs))))
       result)))
 
 (defun projectile-add-unignored (project vcs files)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -235,7 +235,7 @@ You'd normally combine this with `projectile-test-with-sandbox'."
     (spy-on 'projectile-project-vcs :and-return-value 'git)
     (spy-on 'projectile-get-repo-ignored-files :and-return-value '("path/unignored-file"))
     (spy-on 'projectile-get-repo-ignored-directory :and-call-fake
-            (lambda (project vcs dir)
+            (lambda (project dir vcs)
               (list (concat dir "unignored-file"))))
     (let ((projectile-globally-unignored-directories '("path")))
       (expect (projectile-add-unignored nil nil '("file")) :to-equal '("file" "path/unignored-file"))


### PR DESCRIPTION
When using hybrid mode and unignoring files that are ignored by git, the
settings in .projectile would not work. The arguments to internal
function projectile-get-repo-ignored-directory were in the wrong
order. So it would return nil instead of the desired list of git ignored
files.

~~The issue is caught by the projectile-add-unignored test.~~
Looks like I was mistaken and this needs a test.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
