### PR TITLE
[Fix #1488] Fix projectile-find-file-in-directory when in a subdir of…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#1432](https://github.com/bbatsov/projectile/issues/1432): Support .NET project.
 * [#1270](https://github.com/bbatsov/projectile/issues/1270): Fix running commands that don't have a default value.
 * [#1482](https://github.com/bbatsov/projectile/issues/1482): Run a seperate grep buffer per project root
+* [#1488](https://github.com/bbatsov/projectile/issues/1488): Fix projectile-find-file-in-directory when in a subdir of projectile-project-root
 
 ## 2.0.0 (2019-01-01)
 

--- a/projectile.el
+++ b/projectile.el
@@ -4109,7 +4109,7 @@ This command will first prompt for the directory the file is in."
         ;; target directory is in a project
         (let ((file (projectile-completing-read "Find file: "
                                                 (projectile-dir-files directory))))
-          (find-file (expand-file-name file (projectile-project-root)))
+          (find-file (expand-file-name file directory))
           (run-hooks 'projectile-find-file-hook))
       ;; target directory is not in a project
       (projectile-find-file))))


### PR DESCRIPTION
… projectile-project-root

The file-name should be expanded from directory and not from
projectile-project-root.

Signed-off-by: Loys Ollivier <loys.ollivier@gmail.com>