### PR TITLE
Optimize native indexing

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1181,6 +1181,9 @@ Files are returned as relative paths to DIRECTORY."
 The function calls itself recursively until all sub-directories
 have been indexed.  The PROGRESS-REPORTER is updated while the
 function is executing."
+  (projectile-index-directory--internal directory patterns progress-reporter (projectile-ignored-files) (projectile-ignored-directories)))
+
+(defun projectile-index-directory--internal (directory patterns progress-reporter ignored-files ignored-directories)
   (apply #'append
          (mapcar
           (lambda (f)
@@ -1189,12 +1192,24 @@ function is executing."
                                 '("." ".." ".svn" ".cvs")))
               (progress-reporter-update progress-reporter)
               (if (file-directory-p f)
-                  (unless (projectile-ignored-directory-p
-                           (file-name-as-directory f))
-                    (projectile-index-directory f patterns progress-reporter))
-                (unless (projectile-ignored-file-p f)
+                  (unless (projectile-ignored-directory-p--internal
+                           (file-name-as-directory f) ignored-files)
+                    (projectile-index-directory--internal f patterns progress-reporter ignored-files ignored-directories))
+                (unless (projectile-ignored-file-p--internal f ignored-files)
                   (list f)))))
           (directory-files directory t))))
+
+(defun projectile-ignored-directory-p--internal (directory ignored-directories)
+  (cl-some
+   (lambda (name)
+     (string-match-p name directory))
+   ignored-directories))
+
+(defun projectile-ignored-file-p--internal (file ignored-files)
+  (cl-some
+   (lambda (name)
+     (string-match-p name file))
+   ignored-files))
 
 ;;; Alien Project Indexing
 ;;


### PR DESCRIPTION
This is intended as a fix for #675. 

On my system, native indexing was taking a few seconds with projects with ~100 files and was completely unusable (>15 seconds) for larger projects with ~1000 files. Decided to run the indexing function under the profiler, and the function was spending most of the time simply inside calls to  `(projectile-ignored-files)` and `(projectile-ignored-directories)`. 

As far as I can tell, this is completely unnecessary as the output of these functions depends only on  `default-directory` and will not change during the entire indexing process. This patch creates a version of `projectile-indexing-method` where I store and reuse the results of these two functions.

**Results**
```
;; Before patch
(benchmark-run-compiled 5 (projectile-dir-files-native "~/src/projectile"))
(18.034280782 12 1.424345668998285)

;; After patch
(benchmark-run-compiled 5 (projectile-dir-files-native "~/src/projectile"))
(0.349568535 0 0.0)

;; Larger project with ~2000 files, unusably slow before the patch
(benchmark-run-compiled 5 (projectile-dir-files-native "~/src/folly"))
(0.9296409800000001 0 0.0)

```

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
