### PR TITLE
Adding project command for GDB.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#1497](https://github.com/bbatsov/projectile/pull/1497)] New command `projectile-run-gdb` (<kbd>x g</kbd> in `projectile-command-map`).
+
 ## 2.1.0 (2020-02-04)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -3373,6 +3373,13 @@ regular expression."
     (call-interactively #'async-shell-command)))
 
 ;;;###autoload
+(defun projectile-run-gdb ()
+  "Invoke `gdb' in the project's root."
+  (interactive)
+  (projectile-with-default-dir (projectile-ensure-project (projectile-project-root))
+    (call-interactively 'gdb)))
+
+;;;###autoload
 (defun projectile-run-shell (arg)
   "Invoke `shell' in the project's root.
 
@@ -4624,6 +4631,7 @@ thing shown in the mode line otherwise."
     (define-key map (kbd "x i") #'projectile-run-ielm)
     (define-key map (kbd "x t") #'projectile-run-term)
     (define-key map (kbd "x s") #'projectile-run-shell)
+    (define-key map (kbd "x g") #'projectile-run-gdb)
     (define-key map (kbd "x v") #'projectile-run-vterm)
     (define-key map (kbd "z") #'projectile-cache-current-file)
     (define-key map (kbd "<left>") #'projectile-previous-project-buffer)
@@ -4667,6 +4675,8 @@ thing shown in the mode line otherwise."
         ["Search in project (ag)" projectile-ag]
         ["Replace in project" projectile-replace]
         ["Multi-occur in project" projectile-multi-occur]
+        "--"
+        ["Run GDB" projectile-run-gdb]
         "--"
         ["Run shell" projectile-run-shell]
         ["Run eshell" projectile-run-eshell]


### PR DESCRIPTION
When I am working on a big project and I have opened a file, deep into the directory structure, it's annoying to navigate the GDB execution to the build folder. (Lots of `../../`). With the new function in this, GDB can be executed at the root of the project which allows an intuitive path for the build folder to be given.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
