### PR TITLE
Leave archive before searching for project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * [#1497](https://github.com/bbatsov/projectile/pull/1497)] New command `projectile-run-gdb` (<kbd>x g</kbd> in `projectile-command-map`).
+* [#1503](https://github.com/bbatsov/projectile/pull/1503)] Leave archive before searching for the project root.
 
 ## 2.1.0 (2020-02-04)
 

--- a/projectile.el
+++ b/projectile.el
@@ -1077,6 +1077,11 @@ If DIR is not supplied its set to the current directory by default."
   ;; cl-subst to replace this 'none value with nil so a nil value is used
   ;; instead
   (let ((dir (or dir default-directory)))
+    ;; Back out of any archives, the project will live on the outside and
+    ;; searching them is slow.
+    (when (and (fboundp 'tramp-archive-file-name-archive)
+               (tramp-archive-file-name-p dir))
+      (setq dir (file-name-directory (tramp-archive-file-name-archive dir))))
     (cl-subst nil 'none
               ;; The `is-local' and `is-connected' variables are
               ;; used to fix the behavior where Emacs hangs


### PR DESCRIPTION
When TRAMP archives are enabled, back out of the archive before trying to find
the project root. Starting inside the archive makes opening archives quite slow.


**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
  - Would require gvfs, as far as I know.
- [ ] All tests are passing (`make test`)
  - Don't pass locally, with or without this change.
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)