### PR TITLE
Use projectile-with-default-dir in projectile-run-vterm

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3455,9 +3455,8 @@ Use a prefix argument ARG to indicate creation of a new process instead."
     (unless (buffer-live-p (get-buffer buffer))
       (unless (require 'vterm nil 'noerror)
         (error "Package 'vterm' is not available"))
-      (vterm buffer)
-      (vterm-send-string (concat "cd " project))
-      (vterm-send-return))
+      (projectile-with-default-dir project
+        (vterm buffer)))
     (switch-to-buffer buffer)))
 
 (defun projectile-files-in-project-directory (directory)


### PR DESCRIPTION
This avoids "cd \<project root\>" as first line of the newly created terminal and is consistent with other functions, e.g. `projectile-run-term`.

I did not update `CHANGELOG.md` because this is a really small enhancement, even if it is user-visible.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
