### PR TITLE
[Fix #1456] Add check for file existence in replace-regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#1456](https://github.com/bbatsov/projectile/issues/1456) Fix `projectile-replace-regexp` immediate stop after encountering a missing file.
 * [#1497](https://github.com/bbatsov/projectile/pull/1497)] New command `projectile-run-gdb` (<kbd>x g</kbd> in `projectile-command-map`).
 
 ## 2.1.0 (2020-02-04)

--- a/projectile.el
+++ b/projectile.el
@@ -3575,7 +3575,7 @@ to run the replacement."
           ;; `projectile-files-with-string' because those regexp tools
           ;; don't support Emacs regular expressions.
           (cl-remove-if
-           #'file-directory-p
+           (lambda (file) (or (file-directory-p file) (not (file-exists-p file))))
            (mapcar #'projectile-expand-root (projectile-dir-files directory)))))
     (tags-query-replace old-text new-text nil (cons 'list files))))
 


### PR DESCRIPTION
projectile-replace-regexp just stopped if a given file being scanned
was missing. The solution is to filter out non-existing files before
invoking tags-query-replace.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
