### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 * [#1432](https://github.com/bbatsov/projectile/issues/1432): Support .NET project.
 * [#1270](https://github.com/bbatsov/projectile/issues/1270): Fix running commands that don't have a default value.
 * [#1475](https://github.com/bbatsov/projectile/issues/1475): Fix directories being ignored with hybrid mode despite being explicitly unignored.
-* [#1482](https://github.com/bbatsov/projectile/issues/1482): Run a seperate grep buffer per project root.
+* [#1482](https://github.com/bbatsov/projectile/issues/1482): Run a separate grep buffer per project root.
 * [#1488](https://github.com/bbatsov/projectile/issues/1488): Fix `projectile-find-file-in-directory` when in a subdir of `projectile-project-root`.
 
 ## 2.0.0 (2019-01-01)

--- a/projectile.el
+++ b/projectile.el
@@ -176,7 +176,7 @@ A value of nil means the cache never expires."
                  (integer :tag "Seconds")))
 
 (defcustom projectile-auto-update-cache t
-  "Wether the cache should automatically be updated when files are opened or deleted."
+  "Whether the cache should automatically be updated when files are opened or deleted."
   :group 'projectile
   :type 'boolean)
 


### PR DESCRIPTION
Fix two very simple typos that were found using the `codespell` tool.

- [x] The default checkboxes are quite irrelevant in this case.