### PR TITLE
Support for optional comments in .projectile files by customizing projectile-dirconfig-comment-prefix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Optional support for comments in .projectile dirconfig files using `projectile-dirconfig-comment-prefix`.
 * [#1497](https://github.com/bbatsov/projectile/pull/1497): New command `projectile-run-gdb` (<kbd>x g</kbd> in `projectile-command-map`).
 
 ### Bugs fixed

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -326,6 +326,12 @@ When a path is overridden, its contents are still subject to ignore
 patterns. To override those files as well, specify their full path
 with a bang prefix.
 
+If you would like to include comment lines in your .projectile file,
+you can customize the variable `projectile-dirconfig-comment-prefix`.
+Assigning it a non-nil character value, e.g. `#`, will cause lines in
+the .projectile file starting with that character to be treated as
+comments instead of patterns.
+
 ### File-local project root definitions
 
 If you want to override the projectile project root for a specific

--- a/projectile.el
+++ b/projectile.el
@@ -358,6 +358,13 @@ containing a root file."
   :group 'projectile
   :type '(repeat function))
 
+(defcustom projectile-dirconfig-comment-prefix
+  nil
+  "If specified, starting a line in a project's .projectile file with this character marks that line as a comment instead of a pattern. Similar to '#' in .gitignore files."
+  :group 'projectile
+  :type 'character
+  :package-version '(projectile . "2.2.0"))
+
 (defcustom projectile-globally-ignored-files
   (list projectile-tags-file-name)
   "A list of files globally ignored by projectile."
@@ -1744,7 +1751,13 @@ prefix the string will be assumed to be an ignore string."
         (insert-file-contents dirconfig)
         (while (not (eobp))
           (pcase (char-after)
-            (?+ (push (buffer-substring (1+ (point)) (line-end-position)) keep))
+	    ;; ignore comment lines if prefix char has been set
+	    ((pred (lambda (leading-char)
+		     (and projectile-dirconfig-comment-prefix
+			  (eql leading-char
+			       projectile-dirconfig-comment-prefix))))
+	     nil)
+	    (?+ (push (buffer-substring (1+ (point)) (line-end-position)) keep))
             (?- (push (buffer-substring (1+ (point)) (line-end-position)) ignore))
             (?! (push (buffer-substring (1+ (point)) (line-end-position)) ensure))
             (_ (push (buffer-substring (point) (line-end-position)) ignore)))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -251,10 +251,23 @@ You'd normally combine this with `projectile-test-with-sandbox'."
     (spy-on 'file-truename :and-call-fake (lambda (filename) filename))
     (spy-on 'insert-file-contents :and-call-fake
             (lambda (filename)
-              (save-excursion (insert "\n-exclude\n+include\nno-prefix\n left-wspace\nright-wspace\t\n"))))
+              (save-excursion (insert "\n-exclude\n+include\n#may-be-a-comment\nno-prefix\n left-wspace\nright-wspace\t\n"))))
     (expect (projectile-parse-dirconfig-file) :to-equal '(("include/")
-                                                          ("exclude" "no-prefix" "left-wspace" "right-wspace")
-                                                          nil))))
+                                                          ("exclude"
+							   "#may-be-a-comment"
+							   "no-prefix"
+							   "left-wspace"
+							   "right-wspace")
+                                                          nil))
+    ;; same test - but with comment lines enabled using prefix '#'
+    (let ((projectile-dirconfig-comment-prefix ?#))
+      (expect (projectile-parse-dirconfig-file) :to-equal '(("include/")
+							    ("exclude"
+							     "no-prefix"
+							     "left-wspace"
+							     "right-wspace")
+							    nil)))
+    ))
 
 (describe "projectile-get-project-directories"
   (it "gets the list of project directories"


### PR DESCRIPTION
Resolves bbatsov/projectile#1522

Setting the customizable `projectile-dirconfig-comment-prefix` variable to a character, e.g. `?#`, will cause lines in the .projectile which start with that character to be skipped over instead interpreting them as paths.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
