### PR TITLE
Improve performance of native indexing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Bugs fixed
 
+* [#675](https://github.com/bbatsov/projectile/issues/675): Performance improvement for native project indexing strategy.
 * [#97](https://github.com/bbatsov/projectile/issues/97): Respect `.projectile` ignores which are paths to files and patterns when using `projectile-grep`.
 * [#1391](https://github.com/bbatsov/projectile/issues/1391): A `.cabal` sub-directory is no longer considered project indicator.
 * [#1385](https://github.com/bbatsov/projectile/issues/1385): Update `projectile-replace` for Emacs 27.

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1414,3 +1414,26 @@ You'd normally combine this with `projectile-test-with-sandbox'."
 (describe "projectile-find-file-in-directory"
   (it "fails when called in a non-existing directory"
     (expect (projectile-find-file-in-directory "asdf") :to-throw)))
+
+(describe "projectile-dir-files-native"
+  (it "calculates ignored files and directories only once during recursion"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("projectA/"
+       "projectA/.svn/"
+       "projectA/src/.svn/"
+       "projectA/src/html/.svn/"
+       "projectA/.git/"
+       "projectA/src/html/"
+       "projectA/src/framework/lib/"
+       "projectA/src/framework.conf"
+       "projectA/src/html/index.html"
+       "projectA/.projectile")
+
+      ;; verify that indexing only invokes these funcs once during recursion
+      (spy-on 'projectile-ignored-files :and-call-through)
+      (spy-on 'projectile-ignored-directories :and-call-through)
+      
+      (projectile-dir-files-native "projectA/")
+      (expect 'projectile-ignored-files :to-have-been-called-times 1)
+      (expect 'projectile-ignored-directories :to-have-been-called-times 1)))))


### PR DESCRIPTION
Originally reported under bug #675, native indexing for non-trivial
projects is extremely slow due to repeated invocations of
(projectile-ignored-[files|directories]) during recursion.

@shitikanth proposed a solution under #1495 in Feb 2020.

This PR incorporates @bbatsov's feedback on #1495 and may
resolve #1495 and close #675.

Thanks to @shitikanth for initial research and solution idea.

Benchmarking suggests at least a 10x improvement.
e.g.: indexing the projectile source project itself under linux:

(benchmark-run 3 (projectile-dir-files-native default-directory))

OLD: (2.109717349 25 0.5421294649999999)
NEW: (0.098484531 1 0.022120505000000013)

The effect was even more pronounced for me on Windows.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [n/a] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
