### PR TITLE
Adding support for limiting project buffer count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 
 ### New features
 
+* [#1523](https://github.com/bbatsov/projectile/issues/1523): Add a new defcustom (`projectile-limit-project-buffer-count`) controllng whether or not projectile should limit the number of opened buffers per project. Add a new defcustom (`projectile-max-buffer-count`) controlling how many opened buffers projectile should maintain.
 * Optional support for comments in .projectile dirconfig files using `projectile-dirconfig-comment-prefix`.
 * [#1497](https://github.com/bbatsov/projectile/pull/1497): New command `projectile-run-gdb` (<kbd>x g</kbd> in `projectile-command-map`).
 
 ### Bugs fixed
 
 * [#1503](https://github.com/bbatsov/projectile/pull/1503): Leave archive before searching for the project root.
+
 
 ## 2.1.0 (2020-02-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## master (unreleased)
-
+    
 ### New features
 
 * [#1523](https://github.com/bbatsov/projectile/issues/1523): Add a new defcustom (`projectile-limit-project-buffer-count`) controllng whether or not projectile should limit the number of opened buffers per project. Add a new defcustom (`projectile-max-buffer-count`) controlling how many opened buffers projectile should maintain.
@@ -11,7 +11,6 @@
 ### Bugs fixed
 
 * [#1503](https://github.com/bbatsov/projectile/pull/1503): Leave archive before searching for the project root.
-
 
 ## 2.1.0 (2020-02-04)
 
@@ -345,7 +344,7 @@ understandable error if current buffer is not visiting a file.
 * [#182] Invalidate project cache if .projectile is modified.
 
 ## 0.10.0 (2013-12-09)
-
+    
 ### New features
 
 * Added new command `projectile-find-file-other-window`.
@@ -407,7 +406,7 @@ the switch action is `projectile-commander`.
 * `projectile-switch-project` (<kbd>C-c p s</kbd>) now runs `projectile-find-file` instead of `dired`.
 
 ## 0.9.1 (2013-04-26)
-
+    
 ### New features
 
 * Display recentf files in helm-projectile.

--- a/projectile.el
+++ b/projectile.el
@@ -737,13 +737,10 @@ position."
           (const :tag "Move to end" move-to-end)
           (const :tag "Keep" keep)))
 
-(defcustom projectile-limit-project-buffer-count nil
-  "If non-nil, the buffer count for a particular project will be capped."
-  :group 'projectile
-  :type 'boolean)
+(defcustom projectile-max-buffer-count nil
+  "Maximum number of buffers per project that are kept open.
 
-(defcustom projectile-max-buffer-count 10
-  "Maximum number of buffers per project that are kept open."
+If the value is nil, there is no limit to the opend buffers count."
   :group 'projectile
   :type 'integer)
 
@@ -4756,7 +4753,7 @@ tramp."
 
 (defun projectile-maybe-limit-buffers ()
   "Limit the opened buffers for a project."
-  (when projectile-limit-project-buffer-count
+  (when projectile-max-buffer-count
     (let ((buffers (projectile-project-buffer-files)))
       (when (> (length buffers) projectile-max-buffer-count)
         (kill-buffer (get-file-buffer (car (last buffers))))))))

--- a/projectile.el
+++ b/projectile.el
@@ -737,6 +737,16 @@ position."
           (const :tag "Move to end" move-to-end)
           (const :tag "Keep" keep)))
 
+(defcustom projectile-limit-project-buffer-count nil
+  "If non-nil, the buffer count for a particular project will be capped."
+  :group 'projectile
+  :type 'boolean)
+
+(defcustom projectile-max-buffer-count 10
+  "Maximum number of buffers per project that are kept open."
+  :group 'projectile
+  :type 'integer)
+
 
 ;;; Version information
 
@@ -4735,6 +4745,7 @@ thing shown in the mode line otherwise."
 The function does pretty much nothing when triggered on remote files
 as all the operations it normally performs are extremely slow over
 tramp."
+  (projectile-maybe-limit-buffers)
   (unless (file-remote-p default-directory)
     (when projectile-dynamic-mode-line
       (projectile-update-mode-line))
@@ -4742,6 +4753,13 @@ tramp."
       (projectile-cache-files-find-file-hook))
     (projectile-track-known-projects-find-file-hook)
     (projectile-visit-project-tags-table)))
+
+(defun projectile-maybe-limit-buffers ()
+  "Limit the opened buffers for a project."
+  (when projectile-limit-project-buffer-count
+    (let ((buffers (projectile-project-buffer-files)))
+      (when (> (length buffers) projectile-max-buffer-count)
+        (kill-buffer (get-file-buffer (car (last buffers))))))))
 
 ;;;###autoload
 (define-minor-mode projectile-mode


### PR DESCRIPTION
I've added two new customs that can be used to control the feature suggested in #1523. The check if the current buffer count is cover the cap is performed every time the `find-file` hook is executed *and* projectile mode is active. 

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
