### PR TITLE
Usage of vc root dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 2.1.0 (2020-02-04)
 
++ [#323](https://github.com/bbatsov/projectile/issues/323) Adding support fot the usage of the new `vc-root-dir`.
+
 ### New features
 
 * [#1486](https://github.com/bbatsov/projectile/pull/1486) Allow `projectile-run-shell/eshell/term/vterm/ielm` to start extra processes if invoked with the prefix argument.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -374,3 +374,7 @@ By default the minor mode indicator of Projectile appears in the form
     (via TRAMP), as recalculating the project name is a fairly slow operation there
     and would slow down a bit opening the files. They will also not appear for
     non-file buffers, as they get updated via `find-file-hook`.
+
+## Buffer count limiting
+
+Projectile can be configured to keep a maximum number of buffers of a project that are opened at one point. The custom variable `projectile-max-buffer-count` can be set to an integer that will be the buffer count cap. If this limit is reached, by opening a new file, projectile will close the least recent buffer of the current project. If the variable is nil, the will be no cap on the buffer count.

--- a/projectile.el
+++ b/projectile.el
@@ -351,6 +351,7 @@ containing a root file."
 
 (defcustom projectile-project-root-files-functions
   '(projectile-root-local
+    projectile-root-vc-root
     projectile-root-bottom-up
     projectile-root-top-down
     projectile-root-top-down-recurring)
@@ -1068,6 +1069,11 @@ topmost sequence of matched directories.  Nil otherwise."
              (or (string-match locate-dominating-stop-dir-regexp (projectile-parent dir))
                  (not (projectile-file-exists-p (expand-file-name f (projectile-parent dir)))))))))
    (or list projectile-project-root-files-top-down-recurring)))
+
+(defun projectile-root-vc-root (dir)
+  "DIR is a directory."
+  (when (file-equal-p dir default-directory)
+    (vc-root-dir)))
 
 (defun projectile-project-root (&optional dir)
   "Retrieves the root directory of a project if available.

--- a/projectile.el
+++ b/projectile.el
@@ -1071,7 +1071,8 @@ topmost sequence of matched directories.  Nil otherwise."
    (or list projectile-project-root-files-top-down-recurring)))
 
 (defun projectile-root-vc-root (dir)
-  "DIR is a directory."
+  "Retrieve the root directory of the project at DIR using 'vc-root-dir'.
+Works only if DIR is the current default directory"
   (when (file-equal-p dir default-directory)
     (vc-root-dir)))
 


### PR DESCRIPTION
I saw that  #323 was marked high-priority but the support for `vc-root-dir` was still not implemented.

I've added an extra projectile-root-files-function that works only if the directory is the current default directory  (i.e if the requested project-root is of the current project). It uses the suggested in #323 `vc-root-dir` and should cover the majority of the uses cases of `projectile-project-root`

I've also added documentation for the feature introduced in #1532.

-------------------
- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
