### PR TITLE
Fixing projectile-replace to respect .projectile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#1227](https://github.com/bbatsov/projectile/issues/1227) projectile-replace respects the `.projectile` file now.
+
 ## 2.1.0 (2020-02-04)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -3487,21 +3487,23 @@ are impossible (for instance on Windows), returns a list of all
 files in the project."
   (if (projectile-unixy-system-p)
       (let* ((search-term (shell-quote-argument string))
+             (files (projectile-project-files directory))
+             (files-string (mapconcat 'identity files " "))
              (cmd (cond ((executable-find "ag")
-                         (concat "ag --literal --nocolor --noheading -l -- "
-                                 search-term))
+                         (format "ag --literal --nocolor --noheading -l -- %s %s"
+                                 search-term files-string))
                         ((executable-find "ack")
-                         (concat "ack --literal --noheading --nocolor -l -- "
-                                 search-term))
+                         (format "ack --literal --noheading --nocolor -l -- %s %s"
+                                 search-term files-string))
                         ((and (executable-find "git")
                               (eq (projectile-project-vcs) 'git))
-                         (concat "git grep -HlI " search-term))
+                         (format "git grep -HlI %s %s" search-term files-string))
                         (t
                          ;; -r: recursive
                          ;; -H: show filename for each match
                          ;; -l: show only file names with matches
                          ;; -I: no binary files
-                         (format "grep -rHlI %s ." search-term)))))
+                         (format "grep -rHlI %s %s" search-term files-string)))))
         (projectile-files-from-cmd cmd directory))
     ;; we have to reject directories as a workaround to work with git submodules
     (cl-remove-if


### PR DESCRIPTION
#1227 is a long standing issue and I've decided to give it a go. Previously the commands that are finding files with a certain pattern in them were ran on the entire project. Now I've modified the commands slightly so that they only check the files that are not ignored because of the .projectile file.

I am not sure if this is the best way to implement this. Feedback and other opinions will be welcomed.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)