### PR TITLE
Add a custom setting to control automatic project discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Optional support for comments in .projectile dirconfig files using `projectile-dirconfig-comment-prefix`.
 * [#1497](https://github.com/bbatsov/projectile/pull/1497): New command `projectile-run-gdb` (<kbd>x g</kbd> in `projectile-command-map`).
 * Add [Bazel](https://bazel.build) project type.
+* [#1539](https://github.com/bbatsov/projectile/pull/1539): New defcustom `projectile-auto-discover` controlling whether to automatically discover projects in the search path when `projectile-mode` activates.
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -175,6 +175,11 @@ A value of nil means the cache never expires."
   :type '(choice (const :tag "Disabled" nil)
                  (integer :tag "Seconds")))
 
+(defcustom projectile-auto-discover t
+  "Whether to discover projects when `projectile-mode' is activated."
+  :group 'projectile
+  :type 'boolean)
+
 (defcustom projectile-auto-update-cache t
   "Whether the cache should automatically be updated when files are opened or deleted."
   :group 'projectile
@@ -4816,7 +4821,8 @@ Otherwise behave as if called interactively.
     (projectile-load-known-projects)
     ;; update the list of known projects
     (projectile--cleanup-known-projects)
-    (projectile-discover-projects-in-search-path)
+    (when projectile-auto-discover
+      (projectile-discover-projects-in-search-path))
     (add-hook 'find-file-hook 'projectile-find-file-hook-function)
     (add-hook 'projectile-find-dir-hook #'projectile-track-known-projects-find-file-hook t)
     (add-hook 'dired-before-readin-hook #'projectile-track-known-projects-find-file-hook t t)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -310,13 +310,24 @@ You'd normally combine this with `projectile-test-with-sandbox'."
     (expect (projectile-files-via-ext-command "" nil) :not :to-be-truthy)))
 
 (describe "projectile-mode"
-  (it "sets up hook functions"
+  (before-each
     (spy-on 'projectile--cleanup-known-projects)
-    (spy-on 'projectile-discover-projects-in-search-path)
+    (spy-on 'projectile-discover-projects-in-search-path))
+  (it "sets up hook functions"
     (projectile-mode 1)
     (expect (memq 'projectile-find-file-hook-function find-file-hook) :to-be-truthy)
     (projectile-mode -1)
-    (expect (memq 'projectile-find-file-hook-function find-file-hook) :not :to-be-truthy)))
+    (expect (memq 'projectile-find-file-hook-function find-file-hook) :not :to-be-truthy))
+  (it "respects projectile-auto-discover setting"
+    (unwind-protect
+        (progn
+          (let ((projectile-auto-discover nil))
+            (projectile-mode 1)
+            (expect 'projectile-discover-projects-in-search-path :not :to-have-been-called))
+          (let ((projectile-auto-discover t))
+            (projectile-mode 1)
+            (expect 'projectile-discover-projects-in-search-path :to-have-been-called)))
+      (projectile-mode -1))))
 
 (describe "projectile-relevant-known-projects"
   (it "returns a list of known projects"


### PR DESCRIPTION
This PR adds a custom setting `projectile-auto-discover` that controls whether to automatically run `projectile-discover-projects-in-search-path` when Projectile mode is activated.

The main purpose is to enable faster Emacs startup when starting `projectile-mode` automatically from the init file. On my system (~2015 i5, Emacs 27, Linux, with 140 project directories) turning off auto-discovery improves startup time by around 1.7 seconds.

The default setting for `projectile-auto-discover` leaves current behavior unchanged. 

One already has to manually run one of the `projectile-discover-*` commands to update project bookmarks during an Emacs session, so it seems reasonable to allow the user to choose to always use manual updating rather than forcing an update every time they start Emacs or turn on the mode. Since project bookmarks are cached and loaded from disk, it's usually not necessary to update them anyway.

The following tests are failing on master on my machine so I don't think the failures are related to my changes. All other tests are passing.
* `"projectile-grep multi-root grep grep multi-root projects"`
* `"projectile-compilation-dir should not fail on bad compilation dir config"`

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
