### PR TITLE
Add emacs-eldev project type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#1539](https://github.com/bbatsov/projectile/pull/1539): New defcustom `projectile-auto-discover` controlling whether to automatically discover projects in the search path when `projectile-mode` activates.
+* Add [emacs-eldev](https://github.com/doublep/eldev) project type.
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -2786,6 +2786,11 @@ test/impl/other files as below:
                                   :compile "cask install"
                                   :test-prefix "test-"
                                   :test-suffix "-test")
+(projectile-register-project-type 'emacs-eldev (lambda () (or (projectile-verify-file "Eldev")
+                                                              (projectile-verify-file "Eldev-local")))
+                                  :compile "eldev package"
+                                  :test "eldev test"
+                                  :run "eldev emacs")
 
 ;; R
 (projectile-register-project-type 'r '("DESCRIPTION")

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -980,7 +980,16 @@ You'd normally combine this with `projectile-test-with-sandbox'."
        "project/package.json")
       (let ((projectile-indexing-method 'native))
         (spy-on 'projectile-project-root :and-return-value (file-truename (expand-file-name "project/")))
-        (expect (projectile-detect-project-type) :to-equal 'rails-rspec))))))
+        (expect (projectile-detect-project-type) :to-equal 'rails-rspec)))))
+  (it "detects project-type for elisp eldev projects"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/"
+       "project/Eldev"
+       "project/project.el")
+      (let ((projectile-indexing-method 'native))
+        (spy-on 'projectile-project-root :and-return-value (file-truename (expand-file-name "project/")))
+        (expect (projectile-detect-project-type) :to-equal 'emacs-eldev))))))
 
 (describe "projectile-dirname-matching-count"
   (it "counts matching dirnames ascending file paths"


### PR DESCRIPTION
[Eldev](https://github.com/doublep/eldev) is a build tool for Elisp projects, comparable to Cask. Normally I would create a separate package (like I did for [Flycheck](https://github.com/flycheck/flycheck-eldev)) for integrating it, but since this is only a few lines, I feel it would be an overkill.

Eldev is virtually unused currently, but this is chicken-and-egg problem: if I integrate it in more places, *maybe* it will get more users as a side-effect.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
