### PR TITLE
Add ripgrep search option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1539](https://github.com/bbatsov/projectile/pull/1539): New defcustom `projectile-auto-discover` controlling whether to automatically discover projects in the search path when `projectile-mode` activates.
 * Add [emacs-eldev](https://github.com/doublep/eldev) project type.
 * Add Dart project type.
+* [#1555](https://github.com/bbatsov/projectile/pull/1555) Add search with ripgrep. 
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -3581,7 +3581,7 @@ Returns a list of expanded filenames."
 (defun projectile-files-with-string (string directory)
   "Return a list of all files containing STRING in DIRECTORY.
 
-Tries to use ag, ack, git-grep, and grep in that order.  If those
+Tries to use rg, ag, ack, git-grep, and grep in that order.  If those
 are impossible (for instance on Windows), returns a list of all
 files in the project."
   (if (projectile-unixy-system-p)

--- a/projectile.el
+++ b/projectile.el
@@ -3586,8 +3586,11 @@ are impossible (for instance on Windows), returns a list of all
 files in the project."
   (if (projectile-unixy-system-p)
       (let* ((search-term (shell-quote-argument string))
-             (cmd (cond ((executable-find "ag")
-                         (concat "ag --literal --nocolor --noheading -l -- "
+             (cmd (cond ((executable-find "rg")
+			   (concat "rg -lF --no-heading --color never -- "
+				    search-term))
+			  ((executable-find "ag")
+			   (concat "ag --literal --nocolor --noheading -l -- "
                                  search-term))
                         ((executable-find "ack")
                          (concat "ack --literal --noheading --nocolor -l -- "


### PR DESCRIPTION
Added as first option, like in [spacemacs](https://develop.spacemacs.org/doc/DOCUMENTATION.html#searching) and [visual studio code](https://code.visualstudio.com/updates/v1_11#_text-search-improvements).

Add ripgrep search option to the `projectile-files-with-string` function

I will check all boxes below (although I did not really check all these things as I consider it not very relevant here), as this is a minor addition that is succesfully tested on Fedora 32.
Also it is probably useful to mention here that I actually implemented this option as a fix to issue  #1554 (which describes that the grep and ack search options return errors here) 

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ x] You've added tests (if possible) to cover your change(s)
- [ x] All tests are passing (`make test`)
- [ x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
