### PR TITLE
Add projectile-acquire-root to replace common (projectile-ensure-project (projectile-project-root)) idiom; add function to do action on every buffer in project with that buffer current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### New features
 
-* New project commands `projectile-package-project` and `projectile-install-project`. 
+* New functions `projectile-acquire-root` and `projectile-process-current-project-buffers-current`
+* New project commands `projectile-package-project`, `projectile-install-project`. 
 * [#1539](https://github.com/bbatsov/projectile/pull/1539): New defcustom `projectile-auto-discover` controlling whether to automatically discover projects in the search path when `projectile-mode` activates.
 * Add [emacs-eldev](https://github.com/doublep/eldev) project type.
 * Add Dart project type.

--- a/projectile.el
+++ b/projectile.el
@@ -1125,9 +1125,9 @@ Controlled by `projectile-require-project-root'."
      (t default-directory))))
 
 (defun projectile-acquire-root (&optional dir)
-  "Finds the current project's root, and if that fails, prompts
-the user to supply it. Provides the common
-idiom (projectile-ensure-root (projectile-project-root))"
+  "Find the current project root, and prompts the user for it if that fails.
+Provides the common idiom (projectile-ensure-root (projectile-project-root)).
+Starts the search for the project with DIR."
   (projectile-ensure-project (projectile-project-root dir)))
 
 (defun projectile-project-p (&optional dir)
@@ -1445,8 +1445,8 @@ If PROJECT is not specified the command acts on the current project."
       (funcall action buffer))))
 
 (defun projectile-process-current-project-buffers-current (action)
-  "Invoke ACTION without arguments on every project buffer with
-that buffer current."
+  "Invoke ACTION on every project buffer with that buffer current.
+ACTION is called without arguments."
   (let ((project-buffers (projectile-project-buffers)))
     (dolist (buffer project-buffers)
       (with-current-buffer buffer

--- a/projectile.el
+++ b/projectile.el
@@ -1124,6 +1124,12 @@ Controlled by `projectile-require-project-root'."
      (projectile-require-project-root (error "Projectile can't find a project definition in %s" dir))
      (t default-directory))))
 
+(defun projectile-acquire-root (&optional dir)
+  "Finds the current project's root, and if that fails, prompts
+the user to supply it. Provides the common
+idiom (projectile-ensure-root (projectile-project-root))"
+  (projectile-ensure-project (projectile-project-root dir)))
+
 (defun projectile-project-p (&optional dir)
   "Check if DIR is a project.
 Defaults to the current directory if not provided
@@ -1437,6 +1443,14 @@ If PROJECT is not specified the command acts on the current project."
   (let ((project-buffers (projectile-project-buffers)))
     (dolist (buffer project-buffers)
       (funcall action buffer))))
+
+(defun projectile-process-current-project-buffers-current (action)
+  "Invoke ACTION without arguments on every project buffer with
+that buffer current."
+  (let ((project-buffers (projectile-project-buffers)))
+    (dolist (buffer project-buffers)
+      (with-current-buffer buffer
+        (funcall action)))))
 
 (defun projectile-project-buffer-files (&optional project)
   "Get a list of a project's buffer files.

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1474,14 +1474,16 @@ You'd normally combine this with `projectile-test-with-sandbox'."
 (describe "projectile-process-current-project-buffers-current"
   (it "expects projectile-process-current-project-buffers and
 projectile-process-current-project-buffers-current to have similar behaviour"
-    (projectile-test-with-sandox
+    (projectile-test-with-sandbox
      (projectile-test-with-files
-      ("project/.projectile"
-       "project/bufferA"
-       "project/fileA"
-       "project/dirA/fileC")
+      ("projectA/"
+       "projectA/.projectile"
+       "projectA/bufferA"
+       "projectA/fileA"
+       "projectA/dirA/"
+       "projectA/dirA/fileC")
       (let ((list-a '())
             (list-b '()))
         (projectile-process-current-project-buffers (lambda (b) (push b list-a)))
-        (projectile-process-current-project-buffers-current (lamdba () (push (current-buffer) list-b)))
+        (projectile-process-current-project-buffers-current (lambda () (push (current-buffer) list-b)))
         (expect list-a :to-equal list-b))))))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1470,3 +1470,18 @@ You'd normally combine this with `projectile-test-with-sandbox'."
       (projectile-dir-files-native "projectA/")
       (expect 'projectile-ignored-files :to-have-been-called-times 1)
       (expect 'projectile-ignored-directories :to-have-been-called-times 1)))))
+
+(describe "projectile-process-current-project-buffers-current"
+  (it "expects projectile-process-current-project-buffers and
+projectile-process-current-project-buffers-current to have similar behaviour"
+    (projectile-test-with-sandox
+     (projectile-test-with-files
+      ("project/.projectile"
+       "project/bufferA"
+       "project/fileA"
+       "project/dirA/fileC")
+      (let ((list-a '())
+            (list-b '()))
+        (projectile-process-current-project-buffers (lambda (b) (push b list-a)))
+        (projectile-process-current-project-buffers-current (lamdba () (push (current-buffer) list-b)))
+        (expect list-a :to-equal list-b))))))


### PR DESCRIPTION
The idiom (projectile-ensure-project (projectile-project-root)) is very common, and as such I thought it prudent to add a function to replace it, as that could lead to better code. The function projectile-acquire-root was added to do so.

There is a function to run some action on every project buffer (projectile-process-current-project-buffers). However, some functions (e.g. hack-dir-local-variables-non-file-buffer) that cannot take a buffer as an argument. To support executing such functions on all project buffers, I added projectile-process-current-project-buffers-current. The difference between it and its sibling projectile-process-current-project-buffers is that my function passes no arguments, but instead makes the project buffer current as it iterates over all project buffers. A test case was added to ensure that its behaviour is similar to its sibling, yielding the same set of buffers in the same order.
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (`make test`)
- [x ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
