### PR TITLE
Adds python-poetry project type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add [emacs-eldev](https://github.com/doublep/eldev) project type.
 * Add Dart project type.
 * [#1555](https://github.com/bbatsov/projectile/pull/1555) Add search with ripgrep. 
+* Add Python-poetry project type.
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -2702,6 +2702,12 @@ test/impl/other files as below:
                                   :test "pipenv run test"
                                   :test-prefix "test_"
                                   :test-suffix "_test")
+(projectile-register-project-type 'python-poetry '("poetry.lock")
+                                  :project-file "poetry.lock"
+                                  :compile "poetry build"
+                                  :test "poetry run python -m unittest discover"
+                                  :test-prefix "test_"
+                                  :test-suffix"_test")
 ;; Java & friends
 (projectile-register-project-type 'maven '("pom.xml")
                                   :project-file "pom.xml"


### PR DESCRIPTION
Adds a python-poetry project type for [poetry](https://python-poetry.org/) based python projects. Poetry has become increasingly popular, and currently isn't getting recognized as a project type as poetry removes the need for a `setup.py` file.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`make test`)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

Edit: Had to fix one of the commands.. everything should be good to go now 👍 