### PR TITLE
Add support for OCaml dune projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add Dart project type.
 * [#1555](https://github.com/bbatsov/projectile/pull/1555) Add search with ripgrep. 
 * Add Python-poetry project type.
+* [#1576](https://github.com/bbatsov/projectile/pull/1576) Add OCaml [Dune](https://github.com/ocaml/dune) project type.
 
 ### Changes
 

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -81,6 +81,9 @@ are the configuration files of various build tools. Out of the box the following
 | stack.yaml
 | Haskell's stack tool based project
 
+| dune-project
+| OCaml Dune project file
+
 | info.rkt
 | Racket package description file
 

--- a/projectile.el
+++ b/projectile.el
@@ -2866,6 +2866,11 @@ test/impl/other files as below:
                                   :run "dart"
                                   :test-suffix "_test.dart")
 
+;; OCaml
+(projectile-register-project-type 'ocaml-dune '("dune-project")
+                                  :project-file "dune-project"
+                                  :compile "dune build"
+                                  :test "dune runtest")
 
 (defvar-local projectile-project-type nil
   "Buffer local var for overriding the auto-detected project type.


### PR DESCRIPTION
Although relatively new, [Dune](https://github.com/ocaml/dune) has become the de-facto standard build tool for OCaml. The vast majority of packages on [Opam](https://opam.ocaml.org/packages/index-popularity.html) uses Dune now.

Reference for project root file: https://dune.readthedocs.io/en/stable/overview.html?highlight=dune-project#project-layout

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
