### PR TITLE
Optimize ibuffer support to avoid calling projectile-project-root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 * [#1540](https://github.com/bbatsov/projectile/pull/1540): Add default `test-suffix` to Angular projects.
 * Add a `:project-file` param to `projectile-register-project-type`.
+* [#1588](https://github.com/bbatsov/projectile/pull/1588) Improve performance of `projectile-ibuffer` with many buffers not in project.
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -4515,8 +4515,10 @@ overwriting each other's changes."
   (:reader (read-directory-name "Project root: " (projectile-project-root))
            :description nil)
   (with-current-buffer buf
-    (equal (file-name-as-directory (expand-file-name qualifier))
-           (projectile-project-root))))
+    (let ((directory (file-name-as-directory (expand-file-name qualifier))))
+      (and (projectile-project-buffer-p buf directory)
+           (equal directory
+                  (projectile-project-root))))))
 
 (defun projectile-ibuffer-by-project (project-root)
   "Open an IBuffer window showing all buffers in PROJECT-ROOT."


### PR DESCRIPTION
Previously, `projectile-ibuffer` was very slow for me - this is due to calling `projectile-project-root` (which is rather slow) on all buffers. However, there exists already a function `projectile-project-buffer-p` which is much faster - which can be used to isolate buffers which have no chance of being in the directory. 

The only question is whether this is correct - as far as I know if a buffer's default directory is not under a project root, it cannot be within a project. I'm also assuming this function works correctly over tramp (as I haven't tested it on tramp), although it seems to test that properly (?). 

I did find one discrepancy, currently `projectile-ibuffer` seems to include modes that are ignored by other projectile functions (at least `projectile-globally-ignored-modes` - now they will (correctly?) be dropped from ibuffer. If this behavior isn't desired I can try to modify the function to optionally let ignored buffers through or something.

Regardless, this improves ibuffer performance for me quite a lot - before this patch `projectile-ibuffer` took several seconds to run for me, now it completes instantly. Sorry for not having a real benchmark here, but it seems like these filter functions aren't run when using `benchmark`. I understand that this could be accomplished with the projectile cache, but there's no reason (in my mind) for this function to be so slow even without a cache.

Let me know if tests are needed here - since this is a small change I didn't want to touch too many things.

--

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [N/A] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
