### PR TITLE
Ignore clangd cache directory

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -392,6 +392,7 @@ Regular expressions can be used."
     ".svn"
     ".stack-work"
     ".ccls-cache"
+    ".cache"
     ".clangd")
   "A list of directories globally ignored by projectile.
 


### PR DESCRIPTION
In recent version of clangd, the clangd cache directory moved to `$PROJECT/.cache/clangd`. See https://github.com/llvm/llvm-project/blob/master/clang-tools-extra/clangd/index/Background.h#L61