### PR TITLE
Separate compile-history

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -4069,10 +4069,12 @@ project of that type"
 
 (defun projectile-read-command (prompt command)
   "Adapted from `compilation-read-command'."
-  (read-shell-command prompt command
-                      (if (equal (car compile-history) command)
-                          '(compile-history . 1)
-                        'compile-history)))
+  (let ((compile-history
+         (ring-elements (projectile--get-command-history (projectile-ensure-project (projectile-project-root))))))
+    (read-shell-command prompt command
+                        (if (equal (car compile-history) command)
+                            '(compile-history . 1)
+                          'compile-history))))
 
 (defun projectile-compilation-dir ()
   "Retrieve the compilation directory for this project."


### PR DESCRIPTION
Hi @bbatsov, The first thank you for the great package.

I would like to send a PR, that is useful for me.

`projectile-compile` will have separated compile-history by using `projectile--get-command-history`. If something needs to be improved please tell me, I will try to resolve it.

Hope it is useful!
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
