### PR TITLE
Make prefix argument optional for all shells.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3537,7 +3537,7 @@ regular expression."
     (call-interactively 'gdb)))
 
 ;;;###autoload
-(defun projectile-run-shell (arg)
+(defun projectile-run-shell (&optional arg)
   "Invoke `shell' in the project's root.
 
 Switch to the project specific shell buffer if it already exists.
@@ -3548,7 +3548,7 @@ Use a prefix argument ARG to indicate creation of a new process instead."
     (shell (projectile-generate-process-name "shell" arg))))
 
 ;;;###autoload
-(defun projectile-run-eshell (arg)
+(defun projectile-run-eshell (&optional arg)
   "Invoke `eshell' in the project's root.
 
 Switch to the project specific eshell buffer if it already exists.
@@ -3560,7 +3560,7 @@ Use a prefix argument ARG to indicate creation of a new process instead."
       (eshell))))
 
 ;;;###autoload
-(defun projectile-run-ielm (arg)
+(defun projectile-run-ielm (&optional arg)
   "Invoke `ielm' in the project's root.
 
 Switch to the project specific ielm buffer if it already exists.
@@ -3577,7 +3577,7 @@ Use a prefix argument ARG to indicate creation of a new process instead."
       (rename-buffer ielm-buffer-name))))
 
 ;;;###autoload
-(defun projectile-run-term (arg)
+(defun projectile-run-term (&optional arg)
   "Invoke `term' in the project's root.
 
 Switch to the project specific term buffer if it already exists.


### PR DESCRIPTION
I've made `projectile-run-{shell,eshell,ielm,term}` accept an optional prefix argument, to make them consistent with `projectile-run-vterm`. Please let me know if there was a reason for making these function behave in a different way.

Since eldev seems to not be packaged in guix yet, I was not able to run the tests. My apologies!

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
