### PR TITLE
Switch to rebar3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master (unreleased)
+* [#1608](https://github.com/bbatsov/projectile/pull/1608): Use rebar3 build system by default for Erlang projects
 
 ## 2.3.0 (2020-11-27)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ concept of a project is pretty basic - just a folder containing some
 special file (e.g. a VCS marker or a project descriptor
 file). Currently `git`, `mercurial`, `darcs` and `bazaar` repos are
 considered projects by default. So are `lein`, `maven`, `sbt`,
-`scons`, `rebar` and `bundler` projects. If you want to mark a folder
+`scons`, `rebar3` and `bundler` projects. If you want to mark a folder
 manually as a project just create an empty `.projectile` file in it.
 
 Here are some of Projectile's features:

--- a/projectile.el
+++ b/projectile.el
@@ -2675,8 +2675,8 @@ test/impl/other files as below:
 ;; Erlang & Elixir
 (projectile-register-project-type 'rebar '("rebar.config")
                                   :project-file "rebar.config"
-                                  :compile "rebar"
-                                  :test "rebar eunit"
+                                  :compile "rebar3 compile"
+                                  :test "rebar3 do eunit,ct"
                                   :test-suffix "_SUITE")
 (projectile-register-project-type 'elixir '("mix.exs")
                                   :project-file "mix.exs"


### PR DESCRIPTION
This PR replaces legacy Erlang build tool `rebar`, that largely fell out of use, with the contemporary version called `rebar3`.
`rebar` script is no longer in active use in the Erlang world, so it makes sense to update the defaults.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
