### PR TITLE
projectile-files-via-ext-command: support magic filenames

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1373,9 +1373,12 @@ Only text sent to standard output is taken into account."
   (when (stringp command)
     (let ((default-directory root))
       (with-temp-buffer
-        (call-process-shell-command command nil '(t nil))
-        (let ((shell-output (buffer-substring (point-min) (point-max))))
-          (split-string (string-trim shell-output) "\0" t))))))
+        (let ((stderr-buffer (current-buffer)))
+          (with-temp-buffer
+            (let ((stdout-buffer (current-buffer)))
+              (shell-command command stdout-buffer stderr-buffer)
+              (let ((shell-output (buffer-substring (point-min) (point-max))))
+                (split-string (string-trim shell-output) "\0" t)))))))))
 
 (defun projectile-adjust-files (project vcs files)
   "First remove ignored files from FILES, then add back unignored files."

--- a/projectile.el
+++ b/projectile.el
@@ -1375,10 +1375,9 @@ Only text sent to standard output is taken into account."
       (with-temp-buffer
         (let ((stderr-buffer (current-buffer)))
           (with-temp-buffer
-            (let ((stdout-buffer (current-buffer)))
-              (shell-command command stdout-buffer stderr-buffer)
-              (let ((shell-output (buffer-substring (point-min) (point-max))))
-                (split-string (string-trim shell-output) "\0" t)))))))))
+            (shell-command command t stderr-buffer)
+            (let ((shell-output (buffer-substring (point-min) (point-max))))
+              (split-string (string-trim shell-output) "\0" t))))))))
 
 (defun projectile-adjust-files (project vcs files)
   "First remove ignored files from FILES, then add back unignored files."


### PR DESCRIPTION
In 351e0c3b430392c73372f4129b1174c088a934b2 I switched from
`shell-command-to-string` to `call-process-shell-command` so that we
could capture only the stdout, not the stderr.

However, `call-process-shell-command` does not support magic
filenames, which breaks the use of `projectile-files-via-ext-command`
in TRAMP for example.

In this commit we swich to `shell-command`, which supports both
separating stdout and stderr and magic handlers.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

Fixes #1616 