### PR TITLE
Use projectile-acquire-root in projectile-vc

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3838,7 +3838,8 @@ directory to open."
                      (projectile-completing-read
                       "Open project VC in: "
                       projectile-known-projects))))
-  (or project-root (setq project-root (projectile-project-root)))
+  (unless project-root
+    (setq project-root (projectile-acquire-root)))
   (let ((vcs (projectile-project-vcs project-root)))
     (cl-case vcs
       (git


### PR DESCRIPTION
When calling projectile-vc outside of a project directory, it crashes with

    abbreviate-file-name: Wrong type argument: stringp, nil

This change makes it use projectile-acquire-root, which may prompt the
user or display a nicer error message in this case.
