### PR TITLE
[#1617] Switch to right buffer in projectile-switch-project-by-name

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -4392,20 +4392,27 @@ With a prefix ARG invokes `projectile-commander' instead of
                                    'projectile-commander
                                  projectile-switch-project-action)))
     (run-hooks 'projectile-before-switch-project-hook)
-    (let ((default-directory project-to-switch))
-      ;; use a temporary buffer to load PROJECT-TO-SWITCH's dir-locals before calling SWITCH-PROJECT-ACTION
-      (with-temp-buffer
-        (hack-dir-local-variables-non-file-buffer)
-        ;; Normally the project name is determined from the current
-        ;; buffer. However, when we're switching projects, we want to
-        ;; show the name of the project being switched to, rather than
-        ;; the current project, in the minibuffer. This is a simple hack
-        ;; to tell the `projectile-project-name' function to ignore the
-        ;; current buffer and the caching mechanism, and just return the
-        ;; value of the `projectile-project-name' variable.
-        (let ((projectile-project-name (funcall projectile-project-name-function
-                                                project-to-switch)))
-          (funcall switch-project-action))))
+    (let* ((default-directory project-to-switch)
+           (switched-buffer
+            ;; use a temporary buffer to load PROJECT-TO-SWITCH's dir-locals
+            ;; before calling SWITCH-PROJECT-ACTION
+            (with-temp-buffer
+              (hack-dir-local-variables-non-file-buffer)
+              ;; Normally the project name is determined from the current
+              ;; buffer. However, when we're switching projects, we want to
+              ;; show the name of the project being switched to, rather than
+              ;; the current project, in the minibuffer. This is a simple hack
+              ;; to tell the `projectile-project-name' function to ignore the
+              ;; current buffer and the caching mechanism, and just return the
+              ;; value of the `projectile-project-name' variable.
+              (let ((projectile-project-name (funcall projectile-project-name-function
+                                                      project-to-switch)))
+                (funcall switch-project-action)
+                (current-buffer)))))
+      ;; If switch-project-action switched buffers then with-temp-buffer will
+      ;; have lost that change, so switch back to the correct buffer.
+      (when (buffer-live-p switched-buffer)
+          (switch-to-buffer switched-buffer)))
     (run-hooks 'projectile-after-switch-project-hook)))
 
 ;;;###autoload


### PR DESCRIPTION
As discussed in #1617, manually switch to the correct buffer after exiting from `with-temp-buffer`.

Adds tests for both cases mentioned in #1617, and they fail without the change so in that sense it should be solid.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

I didn't update the changelog or readme as I'm not sure how you want to indicate this especially since it's fixing a regression from another already-logged change (#1450).