### PR TITLE
[Docs] Add missing keyboard shortcut for "Toggle between related files"

### DIFF
--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -72,7 +72,7 @@ You need to know only a handful of Projectile commands to start benefiting from 
 * Replace in project (kbd:[s-p r])
 * Invoke any Projectile command via the Projectile Commander (kbd:[s-p m])
 * Toggle between implementation and test (kbd:[s-p t])
-* Toggle between related files (e.g. `foo.h` <-> `foo.c` and `Gemfile` <-> `Gemfile.lock`)
+* Toggle between related files (e.g. `foo.h` <-> `foo.c` and `Gemfile` <-> `Gemfile.lock`) (kbd:[s-p a])
 * Run a shell command in the root of the project (kbd:[s-p !] for a sync command and kbd:[s-p &] for an async command)
 * Run various pre-defined project commands like:
 ** build/compile project (kbd:[s-p c])


### PR DESCRIPTION
A missing keyboard shortcut in the docs.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
