### PR TITLE
Display any errors from projectile files external command

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1380,15 +1380,12 @@ If `command' is nil or an empty string, return nil.
 This allows commands to be disabled.
 
 Only text sent to standard output is taken into account."
-  (save-window-excursion
-    (when (stringp command)
-      (let ((default-directory root))
-        (with-temp-buffer
-          (let ((stderr-buffer (current-buffer)))
-            (with-temp-buffer
-              (shell-command command t stderr-buffer)
-              (let ((shell-output (buffer-substring (point-min) (point-max))))
-                (split-string (string-trim shell-output) "\0" t)))))))))
+  (when (stringp command)
+    (let ((default-directory root))
+      (with-temp-buffer
+        (shell-command command t "*projectile-files-errors*")
+        (let ((shell-output (buffer-substring (point-min) (point-max))))
+          (split-string (string-trim shell-output) "\0" t))))))
 
 (defun projectile-adjust-files (project vcs files)
   "First remove ignored files from FILES, then add back unignored files."


### PR DESCRIPTION
It's useful to see any error messages that these commands return.

This also fixes another issue: previously if pop-up-frames was non-nil and an
error occurred then a new frame would be opened to display the error buffer. But
the error buffer would be immediately deleted by `with-temp-buffer`, leaving an
additional frame displaying the users current buffer.

The use of `save-window-excursion` worked around this issue when only Emacs
windows were in use, which is perhaps why no-one noticed.

Fixes #1631

I don't think this change is unit-testable, so no tests. I'll update the changelog if you want to merge this.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
