### PR TITLE
updates git-submodules-command to fix relative paths

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -629,7 +629,7 @@ Examples of such paths might be ~/projects, ~/work, etc."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-git-submodule-command "git submodule --quiet foreach 'echo $path' | tr '\\n' '\\0'"
+(defcustom projectile-git-submodule-command "git submodule --quiet foreach 'echo $displaypath' | tr '\\n' '\\0'"
   "Command used by projectile to list submodules of a given git repository.
 Set to nil to disable listing submodules contents."
   :group 'projectile


### PR DESCRIPTION
Updates git-submodules-command to use $displaypath rather than $path.

$displaypath returns the path to a module relative to the current working directory whereas $path (used previously) only returns the path relative to the git root. 

This causes issues with function `projectile-get-sub-projects-command` when the git root is not the same as the project root.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
