### PR TITLE
Added better documentation on asterisk prefix

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -410,6 +410,17 @@ is set to 'alien'."
     ".clangd")
   "A list of directories globally ignored by projectile.
 Regular expressions can be used.
+
+Strings that don't start with * are only ignored at the top level
+of the project. Strings that start with * are ignored everywhere
+in the project, as if there was no *. So note that * when used as
+a prefix is not a wildcard; it is an indicator that the directory
+should be ignored at all levels, not just root.
+
+Examples: \"tmp\" ignores only ./tmp at the top level of the
+project, but not ./src/tmp. \"*tmp\" will ignore both ./tmp and
+./src/tmp, but not ./not-a-tmp or ./src/not-a-tmp.
+
 Note that files aren't filtered if `projectile-indexing-method'
 is set to 'alien'."
   :safe (lambda (x) (not (remq t (mapcar #'stringp x))))


### PR DESCRIPTION
More explanation was added as to how the asterisk prefix works, based on
the fabulous documentation by ntc2, here:

https://github.com/bbatsov/projectile/pull/1153#issuecomment-401146353


- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)
