### PR TITLE
Use rebar3 shell to run Erlang projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `project` param to `projectile-generate-process-name`.
 * [#1608](https://github.com/bbatsov/projectile/pull/1608): Use rebar3 build system by default for Erlang projects.
 * Rename `projectile-project-root-files-functions` to `projectile-project-root-functions`.
+* [#1643](https://github.com/bbatsov/projectile/pull/1643) Use rebar3 shell to run Erlang projects
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -2726,7 +2726,8 @@ test/impl/other files as below:
                                   :project-file "rebar.config"
                                   :compile "rebar3 compile"
                                   :test "rebar3 do eunit,ct"
-                                  :test-suffix "_SUITE")
+                                  :test-suffix "_SUITE"
+                                  :run "rebar3 shell")
 (projectile-register-project-type 'elixir '("mix.exs")
                                   :project-file "mix.exs"
                                   :compile "mix compile"


### PR DESCRIPTION
`rebar3 shell` command opens REPL with the code of the project preloaded. It is a reasonble default for `projectile-run-project` command for Erlang projects.  

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
