### PR TITLE
Fix projectile-project-search-path defcustom type

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -632,7 +632,7 @@ When set to nil you'll have always add projects explicitly with
 You can think of something like $PATH, but for projects instead of executables.
 Examples of such paths might be ~/projects, ~/work, etc."
   :group 'projectile
-  :type 'list
+  :type '(repeat directory)
   :package-version '(projectile . "1.0.0"))
 
 (defcustom projectile-git-command "git ls-files -zco --exclude-standard"


### PR DESCRIPTION
Current type declaration of `projectile-project-search-path` is showing a type mismatch error in Customize with the default value `nil`. This PR fixes this issue.
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
