### PR TITLE
Fix file paths in projectile-replace* with prefix arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#1438](https://github.com/bbatsov/projectile/pull/1438): Make sure `projectile-files-via-ext-command` returns files, not errors.
 * [#1450](https://github.com/bbatsov/projectile/pull/1450): Call `switch-project-action` within project's temp buffer.
 * [#1340](https://github.com/bbatsov/projectile/pull/1340): Fix remote projects being removed if TRAMP can't connect.
+* [#1655](https://github.com/bbatsov/projectile/pull/1655): Fix `projectile-replace-regexp` searching the wrong files when called with prefix arg.
 
 ## 2.3.0 (2020-11-27)
 

--- a/projectile.el
+++ b/projectile.el
@@ -3737,7 +3737,8 @@ files in the project."
     ;; we have to reject directories as a workaround to work with git submodules
     (cl-remove-if
      #'file-directory-p
-     (mapcar #'projectile-expand-root (projectile-dir-files directory)))))
+     (mapcar #'(lambda (file) (expand-file-name file directory))
+             (projectile-dir-files directory)))))
 
 ;;;###autoload
 (defun projectile-replace (&optional arg)
@@ -3803,7 +3804,8 @@ to run the replacement."
           ;; don't support Emacs regular expressions.
           (cl-remove-if
            #'file-directory-p
-           (mapcar #'projectile-expand-root (projectile-dir-files directory)))))
+           (mapcar #'(lambda (file) (expand-file-name file directory))
+                   (projectile-dir-files directory)))))
     ;; FIXME: Probably would fail on Emacs 27+, fourth argument is gone.
     (with-no-warnings (tags-query-replace old-text new-text nil (cons 'list files)))))
 


### PR DESCRIPTION
When prefix arg is supplied and a directory is selected, the directory
passed to projectile-dir-files is not necessarily the project root, so
using projectile-expand-root yields incorrect behavior.

For example, in a project rooted at `~/project` with files:

```
~/project/
~/project/Makefile
~/project/foo/bar.c
```

With `C-u M-x projectile-replace-regexp`, selecting directory `~/project/foo/`, projectile incorrectly attempts to read file `~/project/bar.c`, resulting in an error.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] ~~You've updated the readme (if adding/changing user-visible functionality)~~

Thanks!

When running `eldev test`, I see that two tests fail, but they also fail in master, so I don't think it has anything to do with this PR.