### PR TITLE
Add support for CMake-presets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add `projectile-update-project-type-function` for updating the properties of existing project types
 * [#1658](https://github.com/bbatsov/projectile/pull/1658): New command `projectile-reset-known-projects`.
+* [#1656](https://github.com/bbatsov/projectile/pull/1656): Add support for CMake configure, build and test presets. Enabled by setting `projectile-cmake-presets` to non-nil, disabled by default.
 
 ### Changes
 
@@ -14,6 +15,7 @@
 * Rename `projectile-project-root-files-functions` to `projectile-project-root-functions`.
 * [#1647](https://github.com/bbatsov/projectile/issues/1647): Use "-B" in the mvn commands to avoid ANSI coloring clutter in the compile buffer
 * [#1657](https://github.com/bbatsov/projectile/pull/1657): Add project detection for Debian packaging directories.
+* [#1656](https://github.com/bbatsov/projectile/pull/1656): CMake compilation-dir removed to accomodate preset support, commands adjusted to run from project-root, with "build" still being the default build-directory. The non-preset test-command now uses "cmake" with "--target test" instead of "ctest".
 
 ### Bugs fixed
 

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -501,3 +501,11 @@ NOTE: The project name & type will not appear when editing remote files
  (via TRAMP), as recalculating the project name is a fairly slow operation there
  and would slow down a bit opening the files. They will also not appear for
  non-file buffers, as they get updated via `find-file-hook`.
+
+== Project-type-specific Configuration
+
+=== CMake
+
+Projectile supports https://cmake.org/cmake/help/git-stage/manual/cmake-presets.7.html[CMake presets]. Preset support is disabled by default, but can be enabled by setting `projectile-enable-cmake-presets` to non-nil. With preset-support enabled Projectile will parse the preset files and present the command-specific presets when executing a lifecycle command. In addition a `*no preset*` option is included for entering the command manually.
+
+NOTE: Preset support requires a CMake version that supports preset and for `json-parse-buffer` to be available.

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -124,6 +124,9 @@ are the configuration files of various build tools. Out of the box the following
 | Makefile
 | Make
 
+| CMakeLists.txt
+| CMake
+
 | WORKSPACE
 | Bazel workspace file
 


### PR DESCRIPTION
Support configuring, building and testing CMake projects using [cmake-presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html).

Introduces `projectile--cmake-command` for CMake projects which computes a command based on the command-type. If CMake preset support is enabled through the `projectile-enable-cmake-presets` custom, and if presets are supported for the command-type by CMake, CMake preset-files are parsed and a completing-read is done on the names of the command presets along with an option for manual configuration. If not supported, or there are no presets specified for the given command-type, it reverts to manual configuration as before. Configure, build and test commands for CMake projects are all implemented in terms of this command.

To support presets the compilation-dir for CMake-projects was removed, and the manual commands were adjusted to support being run from the project-root.

Needs `json-parse-buffer` to be available, else falls back to manual configuration.

Tested manually with CMake 3.19 (presets supported), and 3.18 (not supported) only, and emacs 27.1 (json-parse-buffer available) and emacs 26.3 (json-parse-buffer unavailable). Not sure how to to project-type specific testing. Initially implemented at [jehelset/projectile-cmake](https://gitlab.com/jehelset/projectile-cmake). 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
