### PR TITLE
Add project detection for Debian packaging directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#1608](https://github.com/bbatsov/projectile/pull/1608): Use rebar3 build system by default for Erlang projects.
 * Rename `projectile-project-root-files-functions` to `projectile-project-root-functions`.
 * [#1647](https://github.com/bbatsov/projectile/issues/1647): Use "-B" in the mvn commands to avoid ANSI coloring clutter in the compile buffer
+* [#1657](https://github.com/bbatsov/projectile/pull/1657): Add project detection for Debian packaging directories.
 
 ### Bugs fixed
 

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -126,6 +126,9 @@ are the configuration files of various build tools. Out of the box the following
 
 | WORKSPACE
 | Bazel workspace file
+
+| debian/control
+| Debian package dpkg control file
 |===
 
 There's also Projectile's own `.projectile` which serves both as a project marker

--- a/projectile.el
+++ b/projectile.el
@@ -2702,6 +2702,9 @@ test/impl/other files as below:
                                   :compile "bazel build"
                                   :test "bazel test"
                                   :run "bazel run")
+(projectile-register-project-type 'debian "debian/control"
+                                  :project-file "debian/control"
+                                  :compile "debuild -uc -us")
 
 ;; Make & CMake
 (projectile-register-project-type 'make '("Makefile")


### PR DESCRIPTION
This adds project detection for unpacked Debian source packages. We detect
this type by the presence of a debian/control even though technically we
should probably check for all of debian/{rules,contro,changelog}. I found
documenting this too cumbersome so I went with just the control file.

In Debian there's two main (lightweight) ways of building packages:
dpkg-buildpackage and debuild. The latter is pretty much just a wrapper for
the former that also runs static checks across the resulting package.

Developers usually use debuild so that's what we use here. The -uc -us
options we hardcode are extremely common. They disable codesigning which
you'd usually not want to do for a simple developmnet build since it can
always be done using debsign before uploading the package.

Since tests usually run as part of the Debian package build and there isn't
a unified way to run just the tests we don't add a :test command.

Technically there's autopkgtest for running special 'as installed' tests
after the package build, but this requires setting up some virtualisation
drivers beforehand so it doesn't make much sense here either.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)