### PR TITLE
Fix rediscovery when clearing known projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
 * Add `projectile-update-project-type-function` for updating the properties of existing project types
+* [#1658](https://github.com/bbatsov/projectile/pull/1658): New command `projectile-reset-known-projects`.
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -4656,6 +4656,13 @@ See `projectile--cleanup-known-projects'."
   (projectile-save-known-projects))
 
 ;;;###autoload
+(defun projectile-reset-known-projects ()
+  "Clear known projects and rediscover."
+  (interactive)
+  (projectile-clear-known-projects)
+  (projectile-discover-projects-in-search-path))
+
+;;;###autoload
 (defun projectile-remove-known-project (&optional project)
   "Remove PROJECT from the list of known projects."
   (interactive (list (projectile-completing-read

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1509,6 +1509,14 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
       (projectile-clear-known-projects)
       (expect projectile-known-projects :to-equal nil))))
 
+(describe "projectile-reset-known-projects"
+  (it "resets known projects"
+    (spy-on 'projectile-clear-known-projects)
+    (spy-on 'projectile-discover-projects-in-search-path)
+    (projectile-reset-known-projects)
+    (expect 'projectile-clear-known-projects :to-have-been-called)
+    (expect 'projectile-discover-projects-in-search-path :to-have-been-called)))
+
 (describe "projectile-test-ignored-directory-p"
   (it "ignores specified literal directory values"
     (spy-on 'projectile-ignored-directories :and-return-value '("/path/to/project/tmp"))


### PR DESCRIPTION
Fix rediscovery in `projectile-clear-known-projects`.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)