### PR TITLE
Add a Function for Updating the Properties of an Existing Project Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Add `projectile-update-project-type-function` for updating the properties of existing project types
+
 ### Changes
 
 * Add `project` param to `projectile-generate-process-name`.

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -434,6 +434,22 @@ Each helper means `projectile-related-files-fn-helper-name` function.
    :related-files-fn my/related-files)
 ----
 
+=== Editing Existing Project Types
+
+You can also edit specific options of already existing project types:
+
+[source,elisp]
+----
+(projectile-update-project-type
+   'sbt
+   :related-files-fn
+   (list
+    (projectile-related-files-fn-test-with-suffix "scala" "Spec")
+    (projectile-related-files-fn-test-with-suffix "scala" "Test")))
+----
+
+This will keep all existing options for the `sbt` project type, but change the value of the `related-files-fn` option.
+
 == Customizing Project Detection
 
 Project detection is pretty simple - Projectile just runs a list of

--- a/projectile.el
+++ b/projectile.el
@@ -2600,7 +2600,29 @@ all but the first plist."
 
 (cl-defun projectile--build-project-plist
     (marker-files &key project-file compilation-dir configure compile install package test run test-suffix test-prefix src-dir test-dir related-files-fn)
-  "Build a project type plist with the provided arguments."
+  "Return a project type plist with the provided arguments.
+
+A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
+and optional keyword arguments:
+PROJECT-FILE the main project file in the root project directory.
+COMPILATION-DIR the directory to run the tests- and compilations in,
+CONFIGURE which specifies a command that configures the project
+          `%s' in the command will be substituted with (projectile-project-root)
+          before the command is run,
+COMPILE which specifies a command that builds the project,
+INSTALL which specifies a command to install the project.
+PACKAGE which specifies a command to package the project.
+TEST which specified a command that tests the project,
+RUN which specifies a command that runs the project,
+TEST-SUFFIX which specifies test file suffix, and
+TEST-PREFIX which specifies test file prefix.
+SRC-DIR which specifies the path to the source relative to the project root.
+TEST-DIR which specifies the path to the tests relative to the project root.
+RELATED-FILES-FN which specifies a custom function to find the related files such as
+test/impl/other files as below:
+    CUSTOM-FUNCTION accepts FILE as relative path from the project root and returns
+    a plist containing :test, :impl or :other as key and the relative path/paths or
+    predicate as value.  PREDICATE accepts a relative path as the input."
   (let ((project-plist (list 'marker-files marker-files
                              'project-file project-file
                              'compilation-dir compilation-dir
@@ -2640,6 +2662,8 @@ CONFIGURE which specifies a command that configures the project
           `%s' in the command will be substituted with (projectile-project-root)
           before the command is run,
 COMPILE which specifies a command that builds the project,
+INSTALL which specifies a command to install the project.
+PACKAGE which specifies a command to package the project.
 TEST which specified a command that tests the project,
 RUN which specifies a command that runs the project,
 TEST-SUFFIX which specifies test file suffix, and
@@ -2675,7 +2699,7 @@ test/impl/other files as below:
     "Update an existing projectile project type.
 
 Non-nil passed items will override existing values for the project type given
-by PROJECT-TYPE.  Nothing will happen if PROJECT-TYPE is not already registered
+by PROJECT-TYPE.  Raise an error if PROJECT-TYPE is not already registered
 with projectile.  The arguments to this function are as for
 projectile-register-project-type:
 
@@ -2688,6 +2712,8 @@ CONFIGURE which specifies a command that configures the project
           `%s' in the command will be substituted with (projectile-project-root)
           before the command is run,
 COMPILE which specifies a command that builds the project,
+INSTALL which specifies a command to install the project.
+PACKAGE which specifies a command to package the project.
 TEST which specified a command that tests the project,
 RUN which specifies a command that runs the project,
 TEST-SUFFIX which specifies test file suffix, and
@@ -2727,7 +2753,7 @@ test/impl/other files as below:
                                       project-type-elt
                                     p))
                       projectile-project-types))
-      (message (format "No existing project found for: %s" project-type))))
+      (error "No existing project found for: %s" project-type)))
 
 (defun projectile-cabal-project-p ()
   "Check if a project contains *.cabal files but no stack.yaml file."


### PR DESCRIPTION
Hi! This PR adds a convenience function for changing the properties of a project type that is already registered. The use case would be if you only want to change one parameter and keep the others as they already are. Example usage:

```elisp
(projectile-update-project-type
   'sbt
   :related-files-fn
   (list
    (projectile-related-files-fn-test-with-suffix "scala" "Spec")
    (projectile-related-files-fn-test-with-suffix "scala" "Test")))
```

Before I was editing `projectile-project-types` manually, so I hope this change is useful if there is not already a nice way to do this.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
