### PR TITLE
Fix debian packaging directory registration.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2824,7 +2824,7 @@ test/impl/other files as below:
                                   :compile "bazel build"
                                   :test "bazel test"
                                   :run "bazel run")
-(projectile-register-project-type 'debian "debian/control"
+(projectile-register-project-type 'debian '("debian/control")
                                   :project-file "debian/control"
                                   :compile "debuild -uc -us")
 


### PR DESCRIPTION
#1657 seemed to cause some problems. It passes a string, instead of a list of strings or a function, as the marker-files parameter to projectile-register-project-type, which, when opening a project-file gave me this:

```
Debugger entered--Lisp error: (wrong-type-argument stringp 100)
  expand-file-name(100 "/home/jeh/code/gitlab/jehelset/projectile-cmake/")
  projectile-expand-root(100)
  (file-exists-p (projectile-expand-root file))
  projectile-verify-file(100)
  apply(projectile-verify-file 100)
  #f(compiled-function (&rest cl-x) #<bytecode 0x15936a79d645>)(100)
  mapcar(#f(compiled-function (&rest cl-x) #<bytecode 0x15936a79d645>) "debian/control")
  cl-mapcar(#f(compiled-function (&rest cl-x) #<bytecode 0x15936a79d645>) "debian/control")
  apply(cl-mapcar #f(compiled-function (&rest cl-x) #<bytecode 0x15936a79d645>) "debian/control" nil)
  cl-map(nil #f(compiled-function (&rest cl-x) #<bytecode 0x15936a79d645>) "debian/control")
  apply(cl-map nil #f(compiled-function (&rest cl-x) #<bytecode 0x15936a79d645>) "debian/control" nil)
  cl-every(projectile-verify-file "debian/control")
  projectile-verify-files("debian/control")
```

Adjusted the registration to pass a list of strings instead, like the other projects do.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
