### PR TITLE
update racket project type with :install and :package

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3054,7 +3054,9 @@ test/impl/other files as below:
 ;; Racket
 (projectile-register-project-type 'racket '("info.rkt")
                                   :project-file "info.rkt"
-                                  :test "raco test .")
+                                  :test "raco test ."
+                                  :install "raco pkg install"
+                                  :package "raco pkg create --source $(pwd)")
 
 ;; Dart
 (projectile-register-project-type 'dart '("pubspec.yaml")


### PR DESCRIPTION
This commit adds:
- install - which runs "raco pkg install" to insatll the current package
- package - which runs raco pkg create --source X
  where X is the absolute path to the current package directory

Signed-off-by: Maciej Barć <xgqt@riseup.net>

-----------------

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
