### PR TITLE
Allow Functions for :test-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#1671](https://github.com/bbatsov/projectile/pull/1671) Allow the `:test-dir` option of a project to be set to a function for more flexible test switching.
+
 ### Bugs fixed
 
 * [#1673](https://github.com/bbatsov/projectile/issues/1673): Fix CMake system-preset filename.
@@ -10,7 +14,7 @@
 
 ### New features
 
-* Add `projectile-update-project-type-function` for updating the properties of existing project types.
+* Add `projectile-update-project-type` function for updating the properties of existing project types.
 * [#1658](https://github.com/bbatsov/projectile/pull/1658): New command `projectile-reset-known-projects`.
 * [#1656](https://github.com/bbatsov/projectile/pull/1656): Add support for CMake configure, build and test presets. Enabled by setting `projectile-cmake-presets` to non-nil, disabled by default.
 

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -237,7 +237,7 @@ Bellow is a listing of all the available options for `projectile-register-projec
 | A command to test the project.
 
 | :test-dir
-| A path, relative to the project root, where the test code lives.
+| A path, relative to the project root, where the test code lives.  A function may also be specified which takes one parameter - the directory of a file, and it should return the directory in which the test file should reside.
 
 | :test-prefix
 | A prefix to generate test files names.
@@ -294,15 +294,23 @@ Note that your function has to return a string to work properly.
 
 === Related file location
 
-For simple projects, `:test-prefix` and `:test-suffix` option with string will
-be enough to specify test prefix/suffix applicable regardless of file extensions
-on any directory path. `projectile-other-file-alist` variable can be also set to
-find other files based on the extension.
+The `:test-prefix` and `:test-suffix` will work regardless of file extension
+or directory path should and be enough for simple projects.  The
+`projectile-other-file-alist` variable can also be set to find other files
+based on the extension.
 
-For the full control of finding related files, `:related-files-fn` option with a
-custom function or a list of custom functions can be used. The custom function
-accepts the relative file name from the project root and it should return the
-related file information as plist with the following optional key/value pairs:
+For fine-grained control of implementation/test toggling, the `:test-dir` option
+of a project may take a function of one parameter (the implementation
+directory absolute path) and return the directory of the test file. This in
+conjunction with the options `:test-prefix` and `:test-suffix` will then be
+used to determine the full path of the test file. This option will always be
+respected if it is set.
+
+Alternatively, for flexible file switching accross a range of projects,
+the `:related-files-fn` option set to a custom function or a
+list of custom functions can be used. The custom function accepts the relative
+file name from the project root and it should return related file information
+as a plist with the following optional key/value pairs:
 
 |===
 | Key | Value | Command applicable
@@ -346,6 +354,8 @@ of a function can be fast as it does not iterate over each source file.
 . There is a difference in behaviour between no key and `nil` value for the
 key. Only when the key does not exist, other project options such as
 `:test_prefix` or `projectile-other-file-alist` mechanism is tried.
+. If the `:test-dir` option is set to a function, this will take precedence over
+any value for `:related-files-fn` set when `projectile-toggle-between-implementation-and-test` is called.
 
 ==== Example - Same source file name for test and impl
 
@@ -447,14 +457,43 @@ You can also edit specific options of already existing project types:
 [source,elisp]
 ----
 (projectile-update-project-type
-   'sbt
-   :related-files-fn
-   (list
-    (projectile-related-files-fn-test-with-suffix "scala" "Spec")
-    (projectile-related-files-fn-test-with-suffix "scala" "Test")))
+ 'sbt
+ :related-files-fn
+ (list
+  (projectile-related-files-fn-test-with-suffix "scala" "Spec")
+  (projectile-related-files-fn-test-with-suffix "scala" "Test")))
 ----
 
 This will keep all existing options for the `sbt` project type, but change the value of the `related-files-fn` option.
+
+
+=== `:test-dir` vs `:related-files-fn`
+
+The `:test-dir` option is useful if the test location for a given implementation
+file is almost always going to be in the same place accross all projects
+belonging to a given project type, `maven` projects are an example of this:
+
+[source,elisp]
+----
+(projectile-update-project-type
+ 'maven
+ :test-dir
+ (lambda (file-path) (projectile-complementary-dir file-path "main" "test")))
+----
+
+If instead you work on a lot of elisp projects using `eldev`, the
+`:related-files-fn` option may be more appropriate since the test locations tend
+to vary accross projects:
+
+[source,elisp]
+----
+(projectile-update-project-type
+ 'emacs-eldev
+ :related-files-fn
+ (list
+  (projectile-related-files-fn-test-with-suffix "el" "-test")
+  (projectile-related-files-fn-test-with-prefix "el" "test-")))
+----
 
 == Customizing Project Detection
 


### PR DESCRIPTION
Hi :wave:, this PR is a proposed solution to https://github.com/bbatsov/projectile/issues/1650, achieved by allowing the `:test-dir` option to take a function which returns the test directory given the implementation directory.

The behaviour for the project in https://github.com/bbatsov/projectile/issues/1650 with the config:

```elisp
(setq projectile-create-missing-test-files t)
(projectile-update-project-type
   'sbt
   :test-dir
   (lambda (file-path) (projectile-complementary-dir file-path "main" "test")))
```
Is that calling `projectile-toggle-between-implementation-and-test` from `src/main/scala/bar/package.scala` sticks you in `src/main/scala/bar/packageSpec.scala` and calling from `src/test/scala/foo/package.scala` sticks you in `src/test/scala/foo/packageSpec.scala` (regardless of either test file existing).

Calling `projectile-toggle-between-implementation-and-test` from either test file however will prompt a choice between the two existing `package.scala` files. I can PR a similar change for allowing `:src-dir` to take a function if you are happy with these changes.

Setting the option to a function should override existing behaviour (for example `:related-files-fn`) , and if the option is not a function then the behaviour should be the same as before. I've added more detailed documentation in the README about the new behaviour, and also added a comparison of when I think you should use `:test-dir` over `related-files-fn` and vice versa.

Apologies for the large PR :slightly_smiling_face:, I'm not sure how it could be split up on top of omitting changes to `src-dir`.

Thanks, let me know what you think!

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
