### PR TITLE
Add projectile-comint-mode variable to allow for interactive compilation buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### New features
 
-* Add `projectile-comint-mode` variable to allow interactive compilation buffers
+* Add `projectile-<cmd>-use-comint-mode` variables (where `<cmd>` is `configure`, `compile`, `test`, `install`, `package`, or `run`). These enable interactive compilation buffers.
 * Add `projectile-update-project-type` function for updating the properties of existing project types.
 * [#1658](https://github.com/bbatsov/projectile/pull/1658): New command `projectile-reset-known-projects`.
 * [#1656](https://github.com/bbatsov/projectile/pull/1656): Add support for CMake configure, build and test presets. Enabled by setting `projectile-cmake-presets` to non-nil, disabled by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### New features
 
+* Add `projectile-comint-mode` variable to allow interactive compilation buffers
 * Add `projectile-update-project-type` function for updating the properties of existing project types.
 * [#1658](https://github.com/bbatsov/projectile/pull/1658): New command `projectile-reset-known-projects`.
 * [#1656](https://github.com/bbatsov/projectile/pull/1656): Add support for CMake configure, build and test presets. Enabled by setting `projectile-cmake-presets` to non-nil, disabled by default.

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -717,9 +717,10 @@ your project, you could customize it with the following:
 
 By default, compilation buffers are not writable, which allows you to
 e.g.  press `g` to restart the last command. Setting
-`projectile-comint-mode` to a non-nil value allows you to make
-projectile compilation buffers interactive, letting you e.g. test a
-command-line program with `projectile-run-project`.
+`projectile-<cmd>-use-comint-mode` (where `<cmd>` is `configure`,
+`compile`, `test`, `install`, `package`, or `run`) to a non-nil value
+allows you to make projectile compilation buffers interactive, letting
+you e.g. test a command-line program with `projectile-run-project`.
 
 [source,elisp]
 ----

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -735,3 +735,16 @@ external command or an Emacs Lisp function:
 ----
 (setq projectile-test-cmd #'custom-test-function)
 ----
+
+== Interact with a project's compilation buffer
+
+By default, compilation buffers are not writable, which allows you to e.g.
+press `g` to restart the last command. Setting `projectile-comint-mode` to a
+non-nil value allows you to make projectile compilation buffers interactive.
+This is especially useful for testing a program with `projectile-run-project`.
+
+[source,elisp]
+----
+(setq projectile-comint-mode t)
+----
+

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -715,10 +715,11 @@ your project, you could customize it with the following:
 ((nil . ((projectile-project-name . "your-project-name-here"))))
 ----
 
-By default, compilation buffers are not writable, which allows you to e.g.
-press `g` to restart the last command. Setting `projectile-comint-mode` to a
-non-nil value allows you to make projectile compilation buffers interactive,
-letting you e.g. test a command-line program with `projectile-run-project`.
+By default, compilation buffers are not writable, which allows you to
+e.g.  press `g` to restart the last command. Setting
+`projectile-comint-mode` to a non-nil value allows you to make
+projectile compilation buffers interactive, letting you e.g. test a
+command-line program with `projectile-run-project`.
 
 [source,elisp]
 ----

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -715,6 +715,16 @@ your project, you could customize it with the following:
 ((nil . ((projectile-project-name . "your-project-name-here"))))
 ----
 
+By default, compilation buffers are not writable, which allows you to e.g.
+press `g` to restart the last command. Setting `projectile-comint-mode` to a
+non-nil value allows you to make projectile compilation buffers interactive,
+letting you e.g. test a command-line program with `projectile-run-project`.
+
+[source,elisp]
+----
+(setq projectile-comint-mode t)
+----
+
 == Configure a Project's Lifecycle Commands
 
 There are a few variables that are intended to be customized via `.dir-locals.el`.
@@ -734,17 +744,5 @@ external command or an Emacs Lisp function:
 [source,elisp]
 ----
 (setq projectile-test-cmd #'custom-test-function)
-----
-
-== Interact with a project's compilation buffer
-
-By default, compilation buffers are not writable, which allows you to e.g.
-press `g` to restart the last command. Setting `projectile-comint-mode` to a
-non-nil value allows you to make projectile compilation buffers interactive.
-This is especially useful for testing a program with `projectile-run-project`.
-
-[source,elisp]
-----
-(setq projectile-comint-mode t)
 ----
 

--- a/projectile.el
+++ b/projectile.el
@@ -4536,11 +4536,14 @@ project of that type"
       (projectile-read-command prompt default-cmd)
     default-cmd))
 
+(defvar projectile-comint-mode nil
+  "If non-nil, launch projectile compilation buffers in interactive mode.")
+
 (defun projectile-run-compilation (cmd)
   "Run external or Elisp compilation command CMD."
   (if (functionp cmd)
       (funcall cmd)
-    (compile cmd)))
+    (compile cmd projectile-comint-mode)))
 
 (defvar projectile-project-command-history (make-hash-table :test 'equal)
   "The history of last executed project commands, per project.

--- a/projectile.el
+++ b/projectile.el
@@ -4536,7 +4536,7 @@ project of that type"
       (projectile-read-command prompt default-cmd)
     default-cmd))
 
-(defun projectile-run-compilation (cmd use-comint-mode)
+(defun projectile-run-compilation (cmd &optional use-comint-mode)
   "Run external or Elisp compilation command CMD."
   (if (functionp cmd)
       (funcall cmd)
@@ -4586,34 +4586,40 @@ The command actually run is returned."
     command))
 
 (defcustom projectile-configure-use-comint-mode nil
-  "If non-nil, make the output buffer of projectile-configure-project
-interactive."
-  :type 'bool)
+  "Make the output buffer of projectile-configure-project interactive."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "2.5.0"))
 
 (defcustom projectile-compile-use-comint-mode nil
-  "If non-nil, make the output buffer of projectile-compile-project
-interactive."
-  :type 'bool)
+  "Make the output buffer of projectile-compile-project interactive."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "2.5.0"))
 
 (defcustom projectile-test-use-comint-mode nil
-  "If non-nil, make the output buffer of projectile-test-project
-interactive."
-  :type 'bool)
+  "Make the output buffer of projectile-test-project interactive."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "2.5.0"))
 
 (defcustom projectile-install-use-comint-mode nil
-  "If non-nil, make the output buffer of projectile-install-project
-interactive."
-  :type 'bool)
+  "Make the output buffer of projectile-install-project interactive."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "2.5.0"))
 
 (defcustom projectile-package-use-comint-mode nil
-  "If non-nil, make the output buffer of projectile-package-project
-interactive."
-  :type 'bool)
+  "Make the output buffer of projectile-package-project interactive."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "2.5.0"))
 
 (defcustom projectile-run-use-comint-mode nil
-  "If non-nil, make the output buffer of projectile-run-project
-interactive."
-  :type 'bool)
+  "Make the output buffer of projectile-run-project interactive."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "2.5.0"))
 
 ;;;###autoload
 (defun projectile-configure-project (arg)

--- a/projectile.el
+++ b/projectile.el
@@ -4536,8 +4536,9 @@ project of that type"
       (projectile-read-command prompt default-cmd)
     default-cmd))
 
-(defvar projectile-comint-mode nil
-  "If non-nil, launch projectile compilation buffers in interactive mode.")
+(defcustom projectile-comint-mode nil
+  "If non-nil, launch projectile compilation buffers in interactive mode."
+  :type 'bool)
 
 (defun projectile-run-compilation (cmd)
   "Run external or Elisp compilation command CMD."

--- a/projectile.el
+++ b/projectile.el
@@ -4536,15 +4536,11 @@ project of that type"
       (projectile-read-command prompt default-cmd)
     default-cmd))
 
-(defcustom projectile-comint-mode nil
-  "If non-nil, launch projectile compilation buffers in interactive mode."
-  :type 'bool)
-
-(defun projectile-run-compilation (cmd)
+(defun projectile-run-compilation (cmd use-comint-mode)
   "Run external or Elisp compilation command CMD."
   (if (functionp cmd)
       (funcall cmd)
-    (compile cmd projectile-comint-mode)))
+    (compile cmd use-comint-mode)))
 
 (defvar projectile-project-command-history (make-hash-table :test 'equal)
   "The history of last executed project commands, per project.
@@ -4558,7 +4554,7 @@ Projects are indexed by their project-root value.")
                projectile-project-command-history)))
 
 (cl-defun projectile--run-project-cmd
-    (command command-map &key show-prompt prompt-prefix save-buffers)
+    (command command-map &key show-prompt prompt-prefix save-buffers use-comint-mode)
   "Run a project COMMAND, typically a test- or compile command.
 
 Cache the COMMAND for later use inside the hash-table COMMAND-MAP.
@@ -4586,8 +4582,38 @@ The command actually run is returned."
                                                         project-root))))
     (unless (file-directory-p default-directory)
       (mkdir default-directory))
-    (projectile-run-compilation command)
+    (projectile-run-compilation command use-comint-mode)
     command))
+
+(defcustom projectile-configure-use-comint-mode nil
+  "If non-nil, make the output buffer of projectile-configure-project
+interactive."
+  :type 'bool)
+
+(defcustom projectile-compile-use-comint-mode nil
+  "If non-nil, make the output buffer of projectile-compile-project
+interactive."
+  :type 'bool)
+
+(defcustom projectile-test-use-comint-mode nil
+  "If non-nil, make the output buffer of projectile-test-project
+interactive."
+  :type 'bool)
+
+(defcustom projectile-install-use-comint-mode nil
+  "If non-nil, make the output buffer of projectile-install-project
+interactive."
+  :type 'bool)
+
+(defcustom projectile-package-use-comint-mode nil
+  "If non-nil, make the output buffer of projectile-package-project
+interactive."
+  :type 'bool)
+
+(defcustom projectile-run-use-comint-mode nil
+  "If non-nil, make the output buffer of projectile-run-project
+interactive."
+  :type 'bool)
 
 ;;;###autoload
 (defun projectile-configure-project (arg)
@@ -4601,7 +4627,8 @@ with a prefix ARG."
     (projectile--run-project-cmd command projectile-configure-cmd-map
                                  :show-prompt arg
                                  :prompt-prefix "Configure command: "
-                                 :save-buffers t)))
+                                 :save-buffers t
+                                 :use-comint-mode projectile-configure-use-comint-mode)))
 
 ;;;###autoload
 (defun projectile-compile-project (arg)
@@ -4615,7 +4642,8 @@ with a prefix ARG."
     (projectile--run-project-cmd command projectile-compilation-cmd-map
                                  :show-prompt arg
                                  :prompt-prefix "Compile command: "
-                                 :save-buffers t)))
+                                 :save-buffers t
+                                 :use-comint-mode projectile-compile-use-comint-mode)))
 
 ;;;###autoload
 (defun projectile-test-project (arg)
@@ -4629,7 +4657,8 @@ with a prefix ARG."
     (projectile--run-project-cmd command projectile-test-cmd-map
                                  :show-prompt arg
                                  :prompt-prefix "Test command: "
-                                 :save-buffers t)))
+                                 :save-buffers t
+                                 :use-comint-mode projectile-test-use-comint-mode)))
 
 ;;;###autoload
 (defun projectile-install-project (arg)
@@ -4643,7 +4672,8 @@ with a prefix ARG."
     (projectile--run-project-cmd command projectile-install-cmd-map
                                  :show-prompt arg
                                  :prompt-prefix "Install command: "
-                                 :save-buffers t)))
+                                 :save-buffers t
+                                 :use-comint-mode projectile-install-use-comint-mode)))
 
 ;;;###autoload
 (defun projectile-package-project (arg)
@@ -4657,7 +4687,8 @@ with a prefix ARG."
     (projectile--run-project-cmd command projectile-package-cmd-map
                                  :show-prompt arg
                                  :prompt-prefix "Package command: "
-                                 :save-buffers t)))
+                                 :save-buffers t
+                                 :use-comint-mode projectile-package-use-comint-mode)))
 
 ;;;###autoload
 (defun projectile-run-project (arg)
@@ -4670,7 +4701,8 @@ with a prefix ARG."
   (let ((command (projectile-run-command (projectile-compilation-dir))))
     (projectile--run-project-cmd command projectile-run-cmd-map
                                  :show-prompt arg
-                                 :prompt-prefix "Run command: ")))
+                                 :prompt-prefix "Run command: "
+                                 :use-comint-mode projectile-run-use-comint-mode)))
 
 ;;;###autoload
 (defun projectile-repeat-last-command (show-prompt)


### PR DESCRIPTION
Hi,
This is my first PR here, I'm trying to follow the guidelines but I apologize in advance if I'm doing something wrong. I have not updated the readme or docs yet because I haven't found a suitable place to put my change and I didn't want to change the wrong files.

This is a very simple change that leverages Emacs' `compile` command argument to allow for interactive compilation buffers. This is particularly useful when using `projectile-project-run-cmd`, as it allows you to interact with your program.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
