### PR TITLE
Add opt params to projectile-run-(async)-shell-cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add `projectile-update-project-type` function for updating the properties of existing project types.
 * [#1658](https://github.com/bbatsov/projectile/pull/1658): New command `projectile-reset-known-projects`.
 * [#1656](https://github.com/bbatsov/projectile/pull/1656): Add support for CMake configure, build and test presets. Enabled by setting `projectile-cmake-presets` to non-nil, disabled by default.
+* Add optional parameters to `projectile-run-shell-command-in-root` and `projectile-run-async-shell-command-in-root`
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -3891,18 +3891,18 @@ regular expression."
     (call-interactively #'execute-extended-command)))
 
 ;;;###autoload
-(defun projectile-run-shell-command-in-root ()
+(defun projectile-run-shell-command-in-root (command &optional output-buffer error-buffer)
   "Invoke `shell-command' in the project's root."
-  (interactive)
+  (interactive "sShell command: ")
   (projectile-with-default-dir (projectile-acquire-root)
-    (call-interactively #'shell-command)))
+    (shell-command command output-buffer error-buffer)))
 
 ;;;###autoload
-(defun projectile-run-async-shell-command-in-root ()
+(defun projectile-run-async-shell-command-in-root (command &optional output-buffer error-buffer)
   "Invoke `async-shell-command' in the project's root."
-  (interactive)
+  (interactive "sAsync shell command: ")
   (projectile-with-default-dir (projectile-acquire-root)
-    (call-interactively #'async-shell-command)))
+    (async-shell-command command output-buffer error-buffer)))
 
 ;;;###autoload
 (defun projectile-run-gdb ()

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1734,6 +1734,52 @@ projectile-process-current-project-buffers-current to have similar behaviour"
                 (projectile-project-types mock-projectile-project-types))
         (expect (projectile--impl-to-test-dir "/bar/src/bar") :to-throw))))
 
+(describe "projectile-run-shell-command-in-root"
+  (describe "when called directly in elisp"
+    (before-each (spy-on 'shell-command))
+    (describe "when called with all three paramters"
+      (it "expects to call shell-command with the same parameters"
+        (projectile-run-shell-command-in-root "cmd" "output-buffer" "error-buffer")
+        (expect 'shell-command :to-have-been-called-with "cmd" "output-buffer" "error-buffer")))
+    (describe "when called with only one optional paramter"
+      (it "expects to call shell-command with the same parameters"
+        (projectile-run-shell-command-in-root "cmd" "output-buffer")
+        (expect 'shell-command :to-have-been-called-with "cmd" "output-buffer" nil)))
+    (describe "when called with no optional paramters"
+      (it "expects to call shell-command with the same parameters"
+        (projectile-run-shell-command-in-root "cmd")
+        (expect 'shell-command :to-have-been-called-with "cmd" nil nil))))
+  (describe "when called interactively"
+    (before-each (spy-on 'shell-command))
+    (it "expects to be interactive"
+      (expect (interactive-form 'projectile-run-shell-command-in-root) :not :to-be nil))
+    (it "expects to call shell-command with the given command"
+      (funcall-interactively 'projectile-run-shell-command-in-root "cmd")
+      (expect 'shell-command :to-have-been-called-with "cmd" nil nil))))
+
+(describe "projectile-run-async-shell-command-in-root"
+  (describe "when called directly in elisp"
+    (before-each (spy-on 'async-shell-command))
+    (describe "when called with all three paramters"
+      (it "expects to call async-shell-command with the same parameters"
+        (projectile-run-async-shell-command-in-root "cmd" "output-buffer" "error-buffer")
+        (expect 'async-shell-command :to-have-been-called-with "cmd" "output-buffer" "error-buffer")))
+    (describe "when called with only one optional paramter"
+      (it "expects to call async-shell-command with the same parameters"
+        (projectile-run-async-shell-command-in-root "cmd" "output-buffer")
+        (expect 'async-shell-command :to-have-been-called-with "cmd" "output-buffer" nil)))
+    (describe "when called with no optional paramters"
+      (it "expects to call async-shell-command with the same parameters"
+        (projectile-run-async-shell-command-in-root "cmd")
+        (expect 'async-shell-command :to-have-been-called-with "cmd" nil nil))))
+  (describe "when called interactively"
+    (before-each (spy-on 'async-shell-command))
+    (it "expects to be interactive"
+      (expect (interactive-form 'projectile-run-async-shell-command-in-root) :not :to-be nil))
+    (it "expects to call async-shell-command with the given command"
+      (funcall-interactively 'projectile-run-async-shell-command-in-root "cmd")
+      (expect 'async-shell-command :to-have-been-called-with "cmd" nil nil))))
+
 ;; A bunch of tests that make sure Projectile commands handle
 ;; gracefully the case of being run outside of a project.
 (assert-friendly-error-when-no-project projectile-project-info)


### PR DESCRIPTION
## The problem:
The commands `async-shell-command` and `shell-command` accept up to three parameters:
`COMMAND &OPTIONAL OUTPUT-BUFFER ERROR-BUFFER`, the commands `projectile-run-shell-command-on-root` and `projectile-run-async-shell-command-on-root` (which call those commands above) are not callable non-interactively and can't pass the two optional parameters to the `(async)-shell-command`.

## Solution:
Change the signature of these two functions to match the `(async)-shell-command`:

```lisp
(defun projectile-run-shell-command-in-root (command &optional output-buffer error-buffer)
 ...)

(defun projectile-run-async-shell-command-in-root (command &optional output-buffer error-buffer)
 ...)
```

* So they can be now called directly from an elisp code.
* **It is important to emphasize that the interactive call behaves exactly as it did before, so it is not a breaking change in anyway**.
* I also added tests for these changes. I could not add tests to check if these functions are actually called in the root of the project because I didn't know how, but I can add them too if someone guides me :)
* Obs.: the `M-x checkdoc` was generating some warnings before I made any change, but there were none when byte-compiling
* I didn't add anything to the README because I think this change is self-documented in code, but I can add if the maintainers find it necessary
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
