### PR TITLE
 Allow Function for :src-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* [#1671](https://github.com/bbatsov/projectile/pull/1671) Allow the `:test-dir` option of a project to be set to a function for more flexible test switching.
+* [#1671](https://github.com/bbatsov/projectile/pull/1671)/[#1679](https://github.com/bbatsov/projectile/pull/1679) Allow the `:test-dir` and `:src-dir` options of a project to be set to functions for more flexible test switching.
 
 ### Bugs fixed
 

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -231,13 +231,13 @@ Bellow is a listing of all the available options for `projectile-register-projec
 | A command to run the project.
 
 | :src-dir
-| A path, relative to the project root, where the source code lives.
+| A path, relative to the project root, where the source code lives.  A function may also be specified which takes one parameter - the directory of a test file, and it should return the directory in which the implementation file should reside.  This option is only used for implementation/test toggling.
 
 | :test
 | A command to test the project.
 
 | :test-dir
-| A path, relative to the project root, where the test code lives.  A function may also be specified which takes one parameter - the directory of a file, and it should return the directory in which the test file should reside.
+| A path, relative to the project root, where the test code lives.  A function may also be specified which takes one parameter - the directory of a file, and it should return the directory in which the test file should reside.  This option is only used for implementation/test toggling.
 
 | :test-prefix
 | A prefix to generate test files names.
@@ -305,6 +305,14 @@ directory absolute path) and return the directory of the test file. This in
 conjunction with the options `:test-prefix` and `:test-suffix` will then be
 used to determine the full path of the test file. This option will always be
 respected if it is set.
+
+Similarly, the `:src-dir` option, the analogue of `:test-dir`, may also take a
+function and exhibits exactly the same behaviour as above except that its
+parameter corresponds to the directory of a test file and it should return the
+directory of the corresponding implementation file.
+
+It's recommended that either both or neither of these options are set to
+functions for consistent behaviour.
 
 Alternatively, for flexible file switching accross a range of projects,
 the `:related-files-fn` option set to a custom function or a
@@ -467,16 +475,19 @@ You can also edit specific options of already existing project types:
 This will keep all existing options for the `sbt` project type, but change the value of the `related-files-fn` option.
 
 
-=== `:test-dir` vs `:related-files-fn`
+=== `:test-dir`/`:src-dir` vs `:related-files-fn`
 
-The `:test-dir` option is useful if the test location for a given implementation
-file is almost always going to be in the same place accross all projects
-belonging to a given project type, `maven` projects are an example of this:
+Setting the `:test-dir` and `:src-dir` options to functions is useful if the
+test location for a given implementation file is almost always going to be in
+the same place accross all projects belonging to a given project type, `maven`
+projects are an example of this:
 
 [source,elisp]
 ----
 (projectile-update-project-type
  'maven
+ :src-dir
+ (lambda (file-path) (projectile-complementary-dir file-path "test" "main"))
  :test-dir
  (lambda (file-path) (projectile-complementary-dir file-path "main" "test")))
 ----

--- a/projectile.el
+++ b/projectile.el
@@ -3311,6 +3311,22 @@ PROJECT-ROOT is the targeted directory.  If nil, use
      (test-suffix (concat impl-file-name test-suffix "." impl-file-ext))
      (t (error "Project type `%s' not supported!" project-type)))))
 
+(defun projectile--impl-name-for-test-name (test-file-path)
+  "Determine the name of the implementation file for TEST-FILE-PATH.
+
+TEST-FILE-PATH may be a absolute path, relative path or a file name."
+  (let* ((project-type (projectile-project-type))
+         (test-file-name (file-name-sans-extension (file-name-nondirectory test-file-path)))
+         (test-file-ext (file-name-extension test-file-path))
+         (test-prefix (funcall projectile-test-prefix-function project-type))
+         (test-suffix (funcall projectile-test-suffix-function project-type)))
+    (cond
+     (test-prefix
+      (concat (string-remove-prefix test-prefix test-file-name) "." test-file-ext))
+     (test-suffix
+      (concat (string-remove-suffix test-suffix test-file-name) "." test-file-ext))
+     (t (error "Project type `%s' not supported!" project-type)))))
+
 (defun projectile--impl-to-test-dir (impl-dir-path)
   "Return the directory path of a test whose impl file resides in IMPL-DIR-PATH.
 
@@ -3476,6 +3492,17 @@ concatenated with FILENAME-FN applied to the file name of FILE-PATH."
          (dir (funcall dir-fn (file-name-directory file-path))))
     (concat (file-name-as-directory dir) complementary-filename)))
 
+(defun projectile--impl-file-from-src-dir-fn (test-file)
+  "Return the implementation file path for the absolute path TEST-FILE relative to the project root in the case the current project type's src-dir has been set to a custom function, return nil if this is not the case or the path points to a file that does not exist."
+  (when-let ((src-dir (projectile-src-directory (projectile-project-type))))
+    (when (functionp src-dir)
+      (let ((impl-file (projectile--complementary-file
+                        test-file
+                        src-dir
+                        #'projectile--impl-name-for-test-name)))
+        (when (file-exists-p impl-file)
+          (file-relative-name impl-file (projectile-project-root)))))))
+
 (defun projectile--test-file-from-test-dir-fn (impl-file)
   "Return the test file path for the absolute path IMPL-FILE relative to the project root, in the case the current project type's test-dir has been set to a custom function, else return nil."
   (when-let ((test-dir (projectile-test-directory (projectile-project-type))))
@@ -3510,11 +3537,14 @@ concatenated with FILENAME-FN applied to the file name of FILE-PATH."
 
 (defun projectile--find-matching-file (test-file)
   "Return a list of impl files tested by TEST-FILE."
-  (if-let ((plist (projectile--related-files-plist-by-kind test-file :impl)))
-      (projectile--related-files-from-plist plist)
-    (if-let ((predicate (projectile--test-to-impl-predicate test-file)))
-        (projectile--best-or-all-candidates-based-on-parents-dirs
-         test-file (cl-remove-if-not predicate (projectile-current-project-files))))))
+  (if-let ((impl-file-from-src-dir-fn
+            (projectile--impl-file-from-src-dir-fn test-file)))
+      (list impl-file-from-src-dir-fn)
+    (if-let ((plist (projectile--related-files-plist-by-kind test-file :impl)))
+        (projectile--related-files-from-plist plist)
+      (if-let ((predicate (projectile--test-to-impl-predicate test-file)))
+          (projectile--best-or-all-candidates-based-on-parents-dirs
+           test-file (cl-remove-if-not predicate (projectile-current-project-files)))))))
 
 (defun projectile--choose-from-candidates (candidates)
   "Choose one item from CANDIDATES."

--- a/projectile.el
+++ b/projectile.el
@@ -3300,7 +3300,9 @@ PROJECT-ROOT is the targeted directory.  If nil, use
    (t 'none)))
 
 (defun projectile--test-name-for-impl-name (impl-file-path)
-  "Determine the name of the test file for IMPL-FILE-PATH."
+  "Determine the name of the test file for IMPL-FILE-PATH.
+
+IMPL-FILE-PATH may be a absolute path, relative path or a file name."
   (let* ((project-type (projectile-project-type))
          (impl-file-name (file-name-sans-extension (file-name-nondirectory impl-file-path)))
          (impl-file-ext (file-name-extension impl-file-path))


### PR DESCRIPTION
Hi! This PR is a follow up to https://github.com/bbatsov/projectile/pull/1671, it allows the `:src-dir` property of projects to be set to a function like `:test-dir` was in the previous PR.

Similar to to `:test-dir`, when `projectile-toggle-between-implementation-and-test` is called and the user is in a test file, and it's determined a project type has it's `:src-dir` property set to a function, this function will be called to obtain the directory in which the implementation file of the corresponding test file resides.

The result is that from the project in #1650 with the config:

```elisp
(setq projectile-create-missing-test-files t)
(projectile-update-project-type
   'sbt
   :src-dir
   (lambda (file-path) (projectile-complementary-dir file-path "test" "main"))
   :test-dir
   (lambda (file-path) (projectile-complementary-dir file-path "main" "test")))
```

Is that calling `projectile-toggle-between-implementation-and-test` from:
* `src/main/scala/bar/package.scala` sticks you in `src/test/scala/bar/packageSpec.scala` (regardless of the test file existing)
* `src/main/scala/foo/package.scala` sticks you in `src/test/scala/foo/packageSpec.scala` (regardless of the test file existing)
* `src/test/scala/bar/packageSpec.scala` sticks you in `src/main/scala/bar/package.scala` (if the latter file exists)
* `src/test/scala/foo/packageSpec.scala` sticks you in `src/main/scala/foo/package.scala` (if the latter file exists)
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
