### PR TITLE
[Fix #1500] Add support for recursive project discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1680](https://github.com/bbatsov/projectile/pull/1680): Add support for recursive project discovery
 * [#1671](https://github.com/bbatsov/projectile/pull/1671)/[#1679](https://github.com/bbatsov/projectile/pull/1679) Allow the `:test-dir` and `:src-dir` options of a project to be set to functions for more flexible test switching.
 
 ### Bugs fixed

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -19,12 +19,15 @@ Projectile about all of the projects in it with the command `M-x
 projectile-discover-projects-in-directory`.
 
 You can go one step further and set a list of folders which Projectile
-is automatically going to check for projects on startup:
+is automatically going to check for projects on startup.
+
+Recursive discovery is configured by specifying the search depth in a cons cell:
 
 [source,elisp]
 ----
-(setq projectile-project-search-path '("~/projects/" "~/work/"))
+(setq projectile-project-search-path '("~/projects/" "~/work/" ("~/github" . 1)))
 ----
+
 
 You can suppress the auto-discovery of projects on startup by setting
 `projectile-auto-discover` to `nil`. You can manually trigger the project


### PR DESCRIPTION
Extend type of `projectile-project-search-path` to allow elements of
form (DIRECTORY . DEPTH) to discover projects at the specified depth.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
