### PR TITLE
Fix compilation-find-file advice handling of directory

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -4334,24 +4334,18 @@ If the prefix argument SHOW_PROMPT is non nil, the command can be edited."
       (ring-insert command-history executed-command))))
 
 (defun compilation-find-file-projectile-find-compilation-buffer (orig-fun marker filename directory &rest formats)
-  "Try to find a buffer for FILENAME, if we cannot find it,
-fallback to the original function."
-  (when (and (not (file-exists-p (expand-file-name filename)))
-             (projectile-project-p))
-    (let* ((root (projectile-project-root))
-           (dirs (cons "" (projectile-current-project-dirs)))
-           (new-filename (car (cl-remove-if-not
-                               #'file-exists-p
-                               (mapcar
-                                (lambda (f)
-                                  (expand-file-name
-                                   filename
-                                   (expand-file-name f root)))
-                                dirs)))))
-      (when new-filename
-        (setq filename new-filename))))
-
-  (apply orig-fun `(,marker ,filename ,directory ,@formats)))
+  "Advice around compilation-find-file. We enhance its functionality by
+appending the current project's directories to its search path. This way
+when filenames in compilation buffers can't be found by compilation's
+normal logic they are searched for in project directories."
+  (let* ((root (projectile-project-root))
+         (compilation-search-path
+          (if (projectile-project-p)
+              (append compilation-search-path (list root)
+                      (mapcar (lambda (f) (expand-file-name f root))
+                              (projectile-current-project-dirs)))
+            compilation-search-path)))
+    (apply orig-fun `(,marker ,filename ,directory ,@formats))))
 
 (defun projectile-open-projects ()
   "Return a list of all open projects.


### PR DESCRIPTION
compilation-mode keeps track of the "current" directory in the output by
matching on messages such as make's "Entering directory ...", when this
happens the 'directory' variable is set, but the current code just ignores
it when checking whether we should search across project directories or
not. This means that in cases when the filename is actually unambigous
relative to the given directory we'll still go off and try to find it all
over the project which is less than ideal.

Instead of re-implementing the correct directory logic here we refactor
compilation-find-file-projectile-find-compilation-buffer to locally append
our project directories to the the global compilation-search-path and let
the real compilation-find-file fun do it's thing.

While this makes the behaviour more consistent with the original fun it
does mean that now we always have to get all the project dirs which could
be quite involved in large projects. Previously we could elide this in the
"exits" case.

-----------------
- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- [ ] 