### PR TITLE
fix: compilation-find-file advice

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -4739,7 +4739,10 @@ If the prefix argument SHOW_PROMPT is non nil, the command can be edited."
 (defun compilation-find-file-projectile-find-compilation-buffer (orig-fun marker filename directory &rest formats)
   "Try to find a buffer for FILENAME, if we cannot find it,
 fallback to the original function."
-  (when (and (not (file-exists-p (expand-file-name filename)))
+  (when (and (not (file-exists-p (expand-file-name filename
+                                                   (if directory
+                                                       (expand-file-name directory)
+                                                     default-directory))))
              (projectile-project-p))
     (let* ((root (projectile-project-root))
            (dirs (cons "" (projectile-current-project-dirs)))


### PR DESCRIPTION
We should check if file doesn't exist in the passed directory and not
the default directory. In cases where the compilation happens in
another directory (like ./build), the passed filename can be
relative (like ../file.cpp) and checking for its existence in the
default-directory fails