### PR TITLE
[Fix #1514] Fix projectile-ag global ignores not in effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#1699](https://github.com/bbatsov/projectile/pull/1699): `projectile-ripgrep` now supports [`rg.el`](https://github.com/dajva/rg.el).
 
+### Bugs fixed
+
+* [#1514](https://github.com/bbatsov/projectile/issues/1514): Fix `projectile-ag` global ignores not in effect.
+
 ## 2.5.0 (2021-08-10)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -3808,12 +3808,12 @@ regular expression."
                                   (delete-dups
                                    (append
                                     ag-ignore-list
+                                    (projectile-ignored-files-rel)
+                                    (projectile-ignored-directories-rel)
                                     (projectile--globally-ignored-file-suffixes-glob)
                                     ;; ag supports git ignore files directly
                                     (unless (eq (projectile-project-vcs) 'git)
-                                      (append (projectile-ignored-files-rel)
-                                              (projectile-ignored-directories-rel)
-                                              grep-find-ignored-files
+                                      (append grep-find-ignored-files
                                               grep-find-ignored-directories
                                               '()))))))
             ;; reset the prefix arg, otherwise it will affect the ag-command


### PR DESCRIPTION
fix #1514

Hi👋
I fixed `projectile-ag` global ignores not in effect!

## Check

#### Set global ignore and run
```el
(setq projectile-globally-ignored-directories '("node_modules"))
(setq projectile-globally-ignored-files '("baz"))
(projectile-ag "bar")
```
↓output contain ignore file, directory
```
ag --ignore baz --ignore node_modules/ --literal --group --line-number --column --color --color-match 30\;43 --color-path 1\;32 --smart-case --stats -- bar .
```

#### Not set global ignore and run
```el
(setq projectile-globally-ignored-directories nil)
(setq projectile-globally-ignored-files nil)
(projectile-ag "bar")
```
↓output
```
ag --literal --group --line-number --column --color --color-match 30\;43 --color-path 1\;32 --smart-case --stats -- bar .
```
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribFix `projectile-ag` global ignores not effectution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
