### PR TITLE
[Add #1517] Add per-project compilation buffer variable

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -449,14 +449,11 @@ This affects all commands built on top of `projectile--run-project-cmd` like:
 
 Normally, the buffers created by those commands would be shared (overwritten)
 between projects, but it's also possible to make the compilation buffer names
-project-specific. Currently, this requires that the user explicitly set:
+project-specific. This requires that the user set:
 
 [source,elisp]
 ----
-(setq compilation-buffer-name-function
-      #'projectile-compilation-buffer-name)
-(setq compilation-save-buffers-predicate
-      #'projectile-current-project-buffer-p)
+(setq projectile-per-project-compilation-buffer t)
 ----
 
 Both of these degrade properly when not inside a project.

--- a/projectile.el
+++ b/projectile.el
@@ -753,6 +753,11 @@ It assumes the test/ folder is at the same level as src/."
   :group 'projectile
   :type 'boolean)
 
+(defcustom projectile-per-project-compilation-buffer nil
+  "When non-nil, the compilation command makes the per-project compilation buffer."
+  :group 'projectile
+  :type 'boolean)
+
 (defcustom projectile-after-switch-project-hook nil
   "Hooks run right after project is switched."
   :group 'projectile
@@ -4588,7 +4593,8 @@ The command actually run is returned."
          (default-directory (projectile-compilation-dir))
          (command (projectile-maybe-read-command show-prompt
                                                  command
-                                                 prompt-prefix)))
+                                                 prompt-prefix))
+         compilation-buffer-name-function)
     (when command-map
       (puthash default-directory command command-map)
       (ring-insert (projectile--get-command-history project-root) command))
@@ -4597,6 +4603,8 @@ The command actually run is returned."
                          (lambda ()
                            (projectile-project-buffer-p (current-buffer)
                                                         project-root))))
+    (when projectile-per-project-compilation-buffer
+      (setq compilation-buffer-name-function #'projectile-compilation-buffer-name))
     (unless (file-directory-p default-directory)
       (mkdir default-directory))
     (projectile-run-compilation command use-comint-mode)

--- a/projectile.el
+++ b/projectile.el
@@ -4594,7 +4594,8 @@ The command actually run is returned."
          (command (projectile-maybe-read-command show-prompt
                                                  command
                                                  prompt-prefix))
-         compilation-buffer-name-function)
+         compilation-buffer-name-function
+         compilation-save-buffers-predicate)
     (when command-map
       (puthash default-directory command command-map)
       (ring-insert (projectile--get-command-history project-root) command))
@@ -4604,7 +4605,8 @@ The command actually run is returned."
                            (projectile-project-buffer-p (current-buffer)
                                                         project-root))))
     (when projectile-per-project-compilation-buffer
-      (setq compilation-buffer-name-function #'projectile-compilation-buffer-name))
+      (setq compilation-buffer-name-function #'projectile-compilation-buffer-name)
+      (setq compilation-save-buffers-predicate #'projectile-current-project-buffer-p))
     (unless (file-directory-p default-directory)
       (mkdir default-directory))
     (projectile-run-compilation command use-comint-mode)


### PR DESCRIPTION
Fix #1517 
continue #1535 PR

I made it easy to per-project compilation buffer configures!

To make per-project  compilation buffer, currently require user set:
```emacs lisp
(setq compilation-buffer-name-function
      #'projectile-compilation-buffer-name)
(setq compilation-save-buffers-predicate
      #'projectile-current-project-buffer-p)
```

Proposing changes can set:
```emacs lisp
(setq projectile-per-project-compilation-buffer t)
```

- Easy to set.
- Do not affect the other packages compilation buffer.

Thank you!

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
