### PR TITLE
Add project detection for Nix flakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#1680](https://github.com/bbatsov/projectile/pull/1680): Add support for recursive project discovery.
 * [#1671](https://github.com/bbatsov/projectile/pull/1671)/[#1679](https://github.com/bbatsov/projectile/pull/1679) Allow the `:test-dir` and `:src-dir` options of a project to be set to functions for more flexible test switching.
 * [#1672](https://github.com/bbatsov/projectile/pull/1672): Add `projectile-<cmd>-use-comint-mode` variables (where `<cmd>` is `configure`, `compile`, `test`, `install`, `package`, or `run`). These enable interactive compilation buffers.
+* [#1705](https://github.com/bbatsov/projectile/pull/1705): Add project detection for Nix flakes
 
 ### Bugs fixed
 

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -55,6 +55,12 @@ are the configuration files of various build tools. Out of the box the following
 | SConstruct
 | Scons project file
 
+| default.nix
+| Nix project file
+
+| flake.nix
+| Nix flake project file
+
 | pom.xml
 | Maven project file
 

--- a/projectile.el
+++ b/projectile.el
@@ -2980,6 +2980,11 @@ a manual COMMAND-TYPE command is created with
                                   :project-file "default.nix"
                                   :compile "nix-build"
                                   :test "nix-build")
+(projectile-register-project-type 'nix-flake '("flake.nix")
+                                  :project-file "flake.nix"
+                                  :compile "nix build"
+                                  :test "nix flake check"
+                                  :run "nix run")
 (projectile-register-project-type 'bazel '("WORKSPACE")
                                   :project-file "WORKSPACE"
                                   :compile "bazel build"


### PR DESCRIPTION
This change adds support for detecting Nix flakes, a new way of managing Nix projects.

See https://nixos.wiki/wiki/Flakes