### PR TITLE
[Fix #1703] Improve projectile-generic-command default

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -690,9 +690,11 @@ Set to nil to disable listing submodules contents."
   :type 'string)
 
 (defcustom projectile-generic-command
-  (if (executable-find "fd")
-      "fd . -0 --type f --color=never"
-    "find . -type f -print0")
+  (cond ((executable-find "fd")
+         "fd . -0 --type f --color=never")
+        ((executable-find "fdfind")
+         "fdfind . -0 --type f --color=never")
+        (t "find . -type f | cut -c3- | tr '\\n' '\\0'"))
   "Command used by projectile to get the files in a generic project."
   :group 'projectile
   :type 'string)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -747,7 +747,7 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
         ;; After listing all the files, the cache should have been updated.
         (projectile-current-project-files)
         ;; find returns the leading ./ therefore the somewhat odd notation here
-        (dolist (f '("./file1.el" "./file2.el"))
+        (dolist (f '("file1.el" "file2.el"))
           (expect (member f (gethash (projectile-project-root) projectile-projects-cache)) :to-be-truthy))))))
   (it "ensures that we don't cache a project root if the path has changed."
     (projectile-test-with-sandbox


### PR DESCRIPTION
* Use fd/fdfind when available
* Strip leading ./ from paths produced by find
