### PR TITLE
[#1709] Fix `projectile-project-buffer-p` contain current buffer

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1547,13 +1547,16 @@ If PROJECT is not specified the command acts on the current project."
 (defun projectile-project-buffer-p (buffer project-root)
   "Check if BUFFER is under PROJECT-ROOT."
   (with-current-buffer buffer
-    (and (not (string-prefix-p " " (buffer-name buffer)))
-         (not (projectile-ignored-buffer-p buffer))
-         buffer-file-name
-         (string-equal (file-remote-p (file-name-directory buffer-file-name))
-                       (file-remote-p project-root))
-         (not (string-match-p "^http\\(s\\)?://" (file-name-directory buffer-file-name)))
-         (string-prefix-p project-root (file-truename (file-name-directory buffer-file-name)) (eq system-type 'windows-nt)))))
+    (let ((directory (if buffer-file-name
+                         (file-name-directory buffer-file-name)
+                       default-directory)))
+      (and (not (string-prefix-p " " (buffer-name buffer)))
+           (not (projectile-ignored-buffer-p buffer))
+           directory
+           (string-equal (file-remote-p directory)
+                         (file-remote-p project-root))
+           (not (string-match-p "^http\\(s\\)?://" directory))
+           (string-prefix-p project-root (file-truename directory) (eq system-type 'windows-nt))))))
 
 (defun projectile-ignored-buffer-p (buffer)
   "Check if BUFFER should be ignored.

--- a/projectile.el
+++ b/projectile.el
@@ -1549,11 +1549,11 @@ If PROJECT is not specified the command acts on the current project."
   (with-current-buffer buffer
     (and (not (string-prefix-p " " (buffer-name buffer)))
          (not (projectile-ignored-buffer-p buffer))
-         default-directory
-         (string-equal (file-remote-p default-directory)
+         buffer-file-name
+         (string-equal (file-remote-p (file-name-directory buffer-file-name))
                        (file-remote-p project-root))
-         (not (string-match-p "^http\\(s\\)?://" default-directory))
-         (string-prefix-p project-root (file-truename default-directory) (eq system-type 'windows-nt)))))
+         (not (string-match-p "^http\\(s\\)?://" (file-name-directory buffer-file-name)))
+         (string-prefix-p project-root (file-truename (file-name-directory buffer-file-name)) (eq system-type 'windows-nt)))))
 
 (defun projectile-ignored-buffer-p (buffer)
   "Check if BUFFER should be ignored.

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1687,6 +1687,17 @@ projectile-process-current-project-buffers-current to have similar behaviour"
         (projectile-process-current-project-buffers-current (lambda () (push (current-buffer) list-b)))
         (expect list-a :to-equal list-b))))))
 
+(describe "projectile-project-buffers"
+          (it "return project buffers"
+              (projectile-test-with-sandbox
+               (projectile-test-with-files
+                ("project1/"
+                 "project1/.projectile"
+                 "project1/foo")
+                (cd "project1")
+                (with-current-buffer (find-file-noselect "foo" t))
+                (expect (length (projectile-project-buffers)) :to-equal 1)))))
+
 (describe "projectile--impl-name-for-test-name"
   :var ((mock-projectile-project-types
          '((foo test-suffix "Test")


### PR DESCRIPTION
Fix #1709

## Cause

If `projectile-project-buffer-p` is executed for a non-current project, `default-directory` return current directory.
Since `projectile-project-buffers` contains current buffer, kill current buffer unintentionally.

## Solution

`default-directory` → `(file-name-directory buffer-file-name)`

Seem to it works correctly. 
→ not working https://github.com/bbatsov/projectile/pull/1713#issuecomment-930844738

If `buffer-file-name` is nil, use `default-directory`.

## How to confirm

- `C-u` `projectile-switch-project` {select project}  `k` 
not contain current buffer✔

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
