### PR TITLE
Allow completions for projectile-run{-async,}-shell-command-in-root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Changes
 
 * [#1447](https://github.com/bbatsov/projectile/issues/1447): Restructure the menu.
-
+* [#1716](https://github.com/bbatsov/projectile/pull/1716): Allow completions when reading shell-commands.
 ## 2.5.0 (2021-08-10)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -3970,14 +3970,14 @@ installed to work."
 ;;;###autoload
 (defun projectile-run-shell-command-in-root (command &optional output-buffer error-buffer)
   "Invoke `shell-command' in the project's root."
-  (interactive "sShell command: ")
+  (interactive (list (read-shell-command "Shell command: ")))
   (projectile-with-default-dir (projectile-acquire-root)
     (shell-command command output-buffer error-buffer)))
 
 ;;;###autoload
 (defun projectile-run-async-shell-command-in-root (command &optional output-buffer error-buffer)
   "Invoke `async-shell-command' in the project's root."
-  (interactive "sAsync shell command: ")
+  (interactive (list (read-shell-command "Async shell command: ")))
   (projectile-with-default-dir (projectile-acquire-root)
     (async-shell-command command output-buffer error-buffer)))
 


### PR DESCRIPTION
By using `read-shell-command`.

Fixes #1692 .

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)
