### PR TITLE
Show a warning if the projectile cache is not writable

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -860,9 +860,10 @@ specify a project explicitly via the optional PROJECT param."
   "Serialize DATA to FILENAME.
 
 The saved data can be restored with `projectile-unserialize'."
-  (when (file-writable-p filename)
+  (if (file-writable-p filename)
     (with-temp-file filename
-      (insert (let (print-length) (prin1-to-string data))))))
+      (insert (let (print-length) (prin1-to-string data))))
+    (message "Projectile cache '%s' not writeable" filename)))
 
 (defun projectile-unserialize (filename)
   "Read data serialized by `projectile-serialize' from FILENAME."


### PR DESCRIPTION
I had a misconfiguration where my cache-file variable was pointing to nowhere (actually not even the parent folder was there, so the file was also not createable which leads `file-writeable-p` to always return false).
The cache was always invalid and recalculated, because the file was not there
and `projectile-maybe-invalidate-cache` would always call `projectile-invalidate-cache`.

With this patch at least a warning is printed to `*Messages*` that something is not quite right.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [-] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [-] The new code is not generating bytecode or `M-x checkdoc` warnings
- [-] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [-] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
