### PR TITLE
Ignore errors listing directory files in the project search path

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1046,7 +1046,11 @@ If DEPTH is non-nil recursively descend exactly DEPTH levels below DIRECTORY and
 discover projects there."
   (if (file-directory-p directory)
       (if (and (numberp depth) (> depth 0))
-          (dolist (dir (directory-files directory t))
+          ;; Ignore errors when listing files in the directory, because
+          ;; sometimes that directory is an unreadable one at the root of a
+          ;; volume. This is the case, for example, on macOS with the
+          ;; .Spotlight-V100 directory.
+          (dolist (dir (ignore-errors (directory-files directory t)))
             (when (and (file-directory-p dir)
                        (not (member (file-name-nondirectory dir) '(".." "."))))
               (projectile-discover-projects-in-directory dir (1- depth))))


### PR DESCRIPTION
If the search path is the root of a volume, it can have a spotlight
directory in it that emacs can't necessarily read. This avoids errors
like this:

```
Opening directory: Operation not permitted, /home/offby1/workspace/.Spotlight-V100
```

---

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
