### PR TITLE
Make projectile-discover-projects-in-directory interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugs fixed
 
 * [#1514](https://github.com/bbatsov/projectile/issues/1514): Fix `projectile-ag` global ignores not in effect.
+* [#1714](https://github.com/bbatsov/projectile/issues/1714): Fix `projectile-discover-projects-in-directory` not interactive.
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -1045,6 +1045,9 @@ The cache is created both in memory and on the hard drive."
 
 If DEPTH is non-nil recursively descend exactly DEPTH levels below DIRECTORY and
 discover projects there."
+  (interactive
+   (list (read-directory-name "Starting directory: ")))
+
   (if (file-directory-p directory)
       (if (and (numberp depth) (> depth 0))
           ;; Ignore errors when listing files in the directory, because


### PR DESCRIPTION
My first attempt to touch emacs packages, so please let me know if I messed something up.

Make `projectile-discover-projects-in-directory` interactive to fix #1714 


Tested this locally and it seems to bring back the old-functionality back where one can set the root-dir where to  find projects.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
