### PR TITLE
[Fix #1731] Only discover NEW projects in search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bugs fixed
 
+* [#1713](https://github.com/bbatsov/projectile/issues/1731): Fix `projectile-discover-projects-in-directory` reordering known projects.
 * [#1514](https://github.com/bbatsov/projectile/issues/1514): Fix `projectile-ag` global ignores not in effect.
 * [#1714](https://github.com/bbatsov/projectile/issues/1714): Fix `projectile-discover-projects-in-directory` not interactive.
 

--- a/projectile.el
+++ b/projectile.el
@@ -1059,7 +1059,9 @@ discover projects there."
                        (not (member (file-name-nondirectory dir) '(".." "."))))
               (projectile-discover-projects-in-directory dir (1- depth))))
         (when (projectile-project-p directory)
-          (projectile-add-known-project (projectile-project-root directory))))
+          (let ((dir (abbreviate-file-name (projectile-project-root directory))))
+            (unless (member dir projectile-known-projects)
+              (projectile-add-known-project dir)))))
     (message "Project search path directory %s doesn't exist" directory)))
 
 ;;;###autoload


### PR DESCRIPTION
Fixes #1731 and also speeds up performance because `projectile-bookmarks.eld` don't have to be merged for every project found in `projectile-project-search-path`:

Benchmarking master:
```
(benchmark 1 '(projectile-discover-projects-in-search-path))
Elapsed time: 28.751600s (7.017759s in 99 GCs)
```

This commit:
```
Elapsed time: 2.622743s (0.502195s in 7 GCs)
```
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
