### PR TITLE
Make projectile--find-matching-test Use src-dir/test-dir Properties

### DIFF
--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -483,34 +483,54 @@ This will keep all existing options for the `sbt` project type, but change the v
 
 === `:test-dir`/`:src-dir` vs `:related-files-fn`
 
-Setting the `:test-dir` and `:src-dir` options to functions is useful if the
-test location for a given implementation file is almost always going to be in
-the same place across all projects belonging to a given project type, `maven`
-projects are an example of this:
+Whilst setting the `:test-dir` and `:src-dir` to strings is sufficient for most
+purposes, using functions can give more flexibility.  As an example consider
+(also using `f.el`):
+
+[source,elisp]
+----
+(defun my-get-python-test-file (impl-file-path)
+  "Return the corresponding test file directory for IMPL-FILE-PATH"
+  (let* ((rel-path (f-relative impl-file-path (projectile-project-root)))
+         (src-dir (car (f-split rel-path))))
+    (cond ((f-exists-p (f-join (projectile-project-root) "test"))
+           (projectile-complementary-dir impl-file-path src-dir "test"))
+          ((f-exists-p (f-join (projectile-project-root) "tests"))
+           (projectile-complementary-dir impl-file-path src-dir "tests"))
+          (t (error "Could not locate a test file for %s!" impl-file-path)))))
+
+(defun my-get-python-impl-file (test-file-path)
+  "Return the corresponding impl file directory for TEST-FILE-PATH"
+  (if-let* ((root (projectile-project-root))
+            (rel-path (f-relative test-file-path root))
+            (src-dir-guesses `(,(f-base root) ,(downcase (f-base root)) "src"))
+            (src-dir (cl-find-if (lambda (d) (f-exists-p (f-join root d)))
+                                 src-dir-guesses)))
+      (projectile-complementary-dir test-file-path "tests?" src-dir)
+    (error "Could not locate a impl file for %s!" test-file-path)))
+
+(projectile-update-project-type
+ 'python-pkg
+ :src-dir #'my-get-python-impl-dir
+ :test-dir #'my-get-python-test-dir)
+----
+
+This attempts to recognise projects using both `test` and `tests` as top level
+directories for test files. An alternative using the `related-files-fn` option
+could be:
 
 [source,elisp]
 ----
 (projectile-update-project-type
- 'maven
- :src-dir
- (lambda (file-path) (projectile-complementary-dir file-path "test" "main"))
- :test-dir
- (lambda (file-path) (projectile-complementary-dir file-path "main" "test")))
-----
-
-If instead you work on a lot of elisp projects using `eldev`, the
-`:related-files-fn` option may be more appropriate since the test locations tend
-to vary across projects:
-
-[source,elisp]
-----
-(projectile-update-project-type
- 'emacs-eldev
+ 'python-pkg
  :related-files-fn
  (list
-  (projectile-related-files-fn-test-with-suffix "el" "-test")
-  (projectile-related-files-fn-test-with-prefix "el" "test-")))
+  (projectile-related-files-fn-test-with-suffix "py" "_test")
+  (projectile-related-files-fn-test-with-prefix "py" "test_")))
 ----
+
+In fact this is a lot more flexible in terms of finding test files in different
+locations, but will not create test files for you.
 
 == Customizing Project Detection
 

--- a/projectile.el
+++ b/projectile.el
@@ -3385,8 +3385,10 @@ string) are replaced with the current project type's src-dir property
  (which should be a string) to obtain the new directory.
 
 Nil is returned if either the src-dir or test-dir properties are not strings."
-  (let ((test-dir (projectile-test-directory (projectile-project-type)))
-        (impl-dir (projectile-src-directory (projectile-project-type))))
+  (let ((test-dir (projectile-project-type-attribute
+                   (projectile-project-type) 'test-dir))
+        (impl-dir (projectile-project-type-attribute
+                   (projectile-project-type) 'src-dir)))
     (when (and (stringp test-dir) (stringp impl-dir))
       (projectile-complementary-dir test-dir-path test-dir impl-dir))))
 
@@ -3398,8 +3400,10 @@ string) are replaced with the current project type's test-dir property
  (which should be a string) to obtain the new directory.
 
 Nil is returned if either the src-dir or test-dir properties are not strings."
-  (let ((test-dir (projectile-test-directory (projectile-project-type)))
-        (impl-dir (projectile-src-directory (projectile-project-type))))
+  (let ((test-dir (projectile-project-type-attribute
+                   (projectile-project-type) 'test-dir))
+        (impl-dir (projectile-project-type-attribute
+                   (projectile-project-type) 'src-dir)))
     (when (and (stringp test-dir) (stringp impl-dir))
       (projectile-complementary-dir impl-dir-path impl-dir test-dir))))
 
@@ -3424,6 +3428,7 @@ Nil is returned if either the src-dir or test-dir properties are not strings."
 If `projectile-create-missing-test-files' is non-nil, create the missing
 test file."
   (unless file-name (error "The current buffer is not visiting a file"))
+  (unless (projectile-project-type) (projectile-ensure-project nil))
   (if (projectile-test-file-p file-name)
       ;; find the matching impl file
       (let ((impl-file (projectile-find-matching-file file-name)))
@@ -3438,11 +3443,11 @@ test file."
                           (projectile-project-type)))
               (test-file (projectile-find-matching-test file-name))
               (expanded-test-file (projectile-expand-root test-file)))
-      (cond ((file-exists-p expanded-test-file) expanded-test-file)
-            (projectile-create-missing-test-files
-             (projectile--create-directories-for expanded-test-file)
-             expanded-test-file)
-            (t (error error-msg)))
+        (cond ((file-exists-p expanded-test-file) expanded-test-file)
+              (projectile-create-missing-test-files
+               (projectile--create-directories-for expanded-test-file)
+               expanded-test-file)
+              (t (progn (error error-msg))))
       (error error-msg))))
 
 ;;;###autoload
@@ -3542,25 +3547,29 @@ Fallback to DEFAULT-VALUE for missing attributes."
   "Apply DIR-FN and FILENAME-FN to the directory and name of FILE-PATH.
 
 More specifically, return DIR-FN applied to the directory of FILE-PATH
-concatenated with FILENAME-FN applied to the file name of FILE-PATH."
-  (let* ((filename (file-name-nondirectory file-path))
-         (complementary-filename (funcall filename-fn filename))
-         (dir (funcall dir-fn (file-name-directory file-path))))
+concatenated with FILENAME-FN applied to the file name of FILE-PATH.
+
+If either function returns nil, return nil."
+  (when-let* ((filename (file-name-nondirectory file-path))
+              (complementary-filename (funcall filename-fn filename))
+              (dir (funcall dir-fn (file-name-directory file-path))))
     (concat (file-name-as-directory dir) complementary-filename)))
 
 (defun projectile--impl-file-from-src-dir-str (file-name)
-  "Attempt to build a path for the impl file of FILE-NAME using the src-dir and test-dir properties of the current project type which should be strings, nil returned if this is not the case."
-  (projectile--complementary-file
-   file-name
-   #'projectile--test-to-impl-dir
-   #'projectile--impl-name-for-test-name))
+  "Return a path relative to the project root for the impl file of FILE-NAME using the src-dir and test-dir properties of the current project type which should be strings, nil returned if this is not the case."
+  (when-let ((complementary-file (projectile--complementary-file
+                                  file-name
+                                  #'projectile--test-to-impl-dir
+                                  #'projectile--impl-name-for-test-name)))
+    (file-relative-name complementary-file (projectile-project-root))))
 
 (defun projectile--test-file-from-test-dir-str (file-name)
-  "Attempt to build a path for the test file of FILE-NAME using the src-dir and test-dir properties of the current project type which should be strings, nil returned if this is not the case."
-  (projectile--complementary-file
-   file-name
-   #'projectile--impl-to-test-dir
-   #'projectile--test-name-for-impl-name))
+  "Return a path relative to the project root for the test file of FILE-NAME using the src-dir and test-dir properties of the current project type which should be strings, nil returned if this is not the case."
+  (when-let (complementary-file (projectile--complementary-file
+                                 file-name
+                                 #'projectile--impl-to-test-dir
+                                 #'projectile--test-name-for-impl-name))
+    (file-relative-name complementary-file (projectile-project-root))))
 
 (defun projectile--impl-file-from-src-dir-fn (test-file)
   "Return the implementation file path for the absolute path TEST-FILE relative to the project root in the case the current project type's src-dir has been set to a custom function, return nil if this is not the case or the path points to a file that does not exist."
@@ -3585,13 +3594,21 @@ concatenated with FILENAME-FN applied to the file name of FILE-PATH."
        (projectile-project-root)))))
 
 (defun projectile--find-matching-test (impl-file)
-  "Return a list of test files for IMPL-FILE."
+  "Return a list of test files for IMPL-FILE.
+
+The precendence for determining test files to return is:
+
+1. Use the project type's test-dir property if it's set to a function
+2. Use the project type's related-files-fn property if set
+3. Use the project type's test-dir property if it's set to a string
+4. Default to a fallback which matches all project files against
+   `projectile--impl-to-test-predicate'"
   (if-let ((test-file-from-test-dir-fn
             (projectile--test-file-from-test-dir-fn impl-file)))
       (list test-file-from-test-dir-fn)
     (if-let ((plist (projectile--related-files-plist-by-kind impl-file :test)))
         (projectile--related-files-from-plist plist)
-      (if-let (test-file (projectile--test-file-from-test-dir-str impl-file))
+      (if-let ((test-file (projectile--test-file-from-test-dir-str impl-file)))
           (list test-file)
         (when-let ((predicate (projectile--impl-to-test-predicate impl-file)))
           (projectile--best-or-all-candidates-based-on-parents-dirs
@@ -3608,17 +3625,25 @@ concatenated with FILENAME-FN applied to the file name of FILE-PATH."
             (when test-suffix (string-equal (concat name test-suffix) basename)))))))
 
 (defun projectile--find-matching-file (test-file)
-  "Return a list of impl files tested by TEST-FILE."
+  "Return a list of impl files tested by TEST-FILE.
+
+The precendence for determining implementation files to return is:
+
+1. Use the project type's src-dir property if it's set to a function
+2. Use the project type's related-files-fn property if set
+3. Use the project type's src-dir property if it's set to a string
+4. Default to a fallback which matches all project files against
+   `projectile--test-to-impl-predicate'"
   (if-let ((impl-file-from-src-dir-fn
             (projectile--impl-file-from-src-dir-fn test-file)))
       (list impl-file-from-src-dir-fn)
     (if-let ((plist (projectile--related-files-plist-by-kind test-file :impl)))
         (projectile--related-files-from-plist plist)
-      (if-let (impl-file (projectile--impl-file-from-impl-dir-str test-file))
+      (if-let ((impl-file (projectile--impl-file-from-src-dir-str test-file)))
           (list impl-file)
         (when-let ((predicate (projectile--test-to-impl-predicate test-file)))
-            (projectile--best-or-all-candidates-based-on-parents-dirs
-             test-file (cl-remove-if-not predicate (projectile-current-project-files))))))))
+          (projectile--best-or-all-candidates-based-on-parents-dirs
+           test-file (cl-remove-if-not predicate (projectile-current-project-files))))))))
 
 (defun projectile--choose-from-candidates (candidates)
   "Choose one item from CANDIDATES."

--- a/projectile.el
+++ b/projectile.el
@@ -3440,17 +3440,17 @@ test file."
            "No matching source file found for project type `%s'"
            (projectile-project-type))))
     ;; find the matching test file
-    (if-let* ((error-msg (format
-                          "No matching test file found for project type `%s'"
-                          (projectile-project-type)))
-              (test-file (projectile-find-matching-test file-name))
-              (expanded-test-file (projectile-expand-root test-file)))
-        (cond ((file-exists-p expanded-test-file) expanded-test-file)
-              (projectile-create-missing-test-files
-               (projectile--create-directories-for expanded-test-file)
-               expanded-test-file)
-              (t (progn (error error-msg))))
-      (error error-msg))))
+    (let* ((error-msg (format
+                       "No matching test file found for project type `%s'"
+                       (projectile-project-type)))
+           (test-file (or (projectile-find-matching-test file-name)
+                          (error error-msg)))
+           (expanded-test-file (projectile-expand-root test-file)))
+      (cond ((file-exists-p expanded-test-file) expanded-test-file)
+            (projectile-create-missing-test-files
+             (projectile--create-directories-for expanded-test-file)
+             expanded-test-file)
+            (t (progn (error error-msg)))))))
 
 ;;;###autoload
 (defun projectile-find-implementation-or-test-other-window ()
@@ -3552,10 +3552,10 @@ More specifically, return DIR-FN applied to the directory of FILE-PATH
 concatenated with FILENAME-FN applied to the file name of FILE-PATH.
 
 If either function returns nil, return nil."
-  (when-let* ((filename (file-name-nondirectory file-path))
-              (complementary-filename (funcall filename-fn filename))
-              (dir (funcall dir-fn (file-name-directory file-path))))
-    (concat (file-name-as-directory dir) complementary-filename)))
+  (let ((filename (file-name-nondirectory file-path)))
+    (when-let ((complementary-filename (funcall filename-fn filename))
+               (dir (funcall dir-fn (file-name-directory file-path))))
+     (concat (file-name-as-directory dir) complementary-filename))))
 
 (defun projectile--impl-file-from-src-dir-str (file-name)
   "Return a path relative to the project root for the impl file of FILE-NAME using the src-dir and test-dir properties of the current project type which should be strings, nil returned if this is not the case."

--- a/projectile.el
+++ b/projectile.el
@@ -3133,6 +3133,8 @@ a manual COMMAND-TYPE command is created with
 ;; Scala
 (projectile-register-project-type 'sbt '("build.sbt")
                                   :project-file "build.sbt"
+                                  :src-dir "main"
+                                  :test-dir "test"
                                   :compile "sbt compile"
                                   :test "sbt test"
                                   :test-suffix "Spec")


### PR DESCRIPTION
Hi!  This PR is in response to a discussion in https://github.com/bbatsov/projectile/issues/1650#issuecomment-987977517, basically it's a fix for the `src-dir` and `test-dir` properties being prematurely circumvented if they are set to strings when switching from/to test/impl files.  Essentially the function for finding a test/impl file using `src-dir` and `test-dir` (set as strings) was called in `projectile--find-matching-test`, but a fallback already existed in `projectile-find-implementation-or-test` which was being used in preference.

This PR hopes to fix and simplify the above by making impl/test switching wholly contained in `projectile--find-matching-file`/`projectile--find-matching-test`.

I've also updated the doc tweaking the `src-dir`/`test-dir` as a function example since I think that situation is better handled by setting `src-dir`/`test-dir` to strings (as pointed out by the issue author in the link).

Thanks!

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
