### PR TITLE
Port projectile-time-seconds to future Emacs

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -955,8 +955,10 @@ to invalidate."
 
 (defun projectile-time-seconds ()
   "Return the number of seconds since the unix epoch."
-  (cl-destructuring-bind (high low _usec _psec) (current-time)
-    (+ (lsh high 16) low)))
+  (if (fboundp 'time-convert)
+      (time-convert nil 'integer)
+    (cl-destructuring-bind (high low _usec _psec) (current-time)
+      (+ (lsh high 16) low))))
 
 (defun projectile-cache-project (project files)
   "Cache PROJECTs FILES.


### PR DESCRIPTION
Don’t assume internal format of Emacs timestamps.

They are documented to change in a future version.
This patch works on older Emacs versions; it can be simplified
to just use time-convert if we assume Emacs 27 or later.
