### PR TITLE
Add helpers for dir-local-variables for 3rd party use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#1699](https://github.com/bbatsov/projectile/pull/1699): `projectile-ripgrep` now supports [`rg.el`](https://github.com/dajva/rg.el).
 * [#1712](https://github.com/bbatsov/projectile/issues/1712): Make it possible to hide Projectile's menu. See `projectile-show-menu`.
 * [#1718](https://github.com/bbatsov/projectile/issues/1718): Add a project type definition for `GNUMakefile`.
+* Add helpers for `dir-local-variables` for 3rd party use.
+  Functions `projectile-add-dir-local-variable` and `projectile-delete-dir-local-variable`
+  wraps their built-in counterparts. They always use `.dir-locals.el` from root of projectile project.
+
 
 ### Bugs fixed
 

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -773,3 +773,6 @@ external command or an Emacs Lisp function:
 ----
 (setq projectile-test-cmd #'custom-test-function)
 ----
+
+3rd party packages may use functions `projectile-add-dir-local-variable`
+and `projectile-delete-dir-local-variable` to store their settings.

--- a/projectile.el
+++ b/projectile.el
@@ -2329,6 +2329,32 @@ With a prefix arg INVALIDATE-CACHE invalidates the cache first."
       (read-only-mode (if val +1 -1))
       (message "[%s] read-only-mode is %s" (projectile-project-name) (if val "on" "off")))))
 
+;;;###autoload
+(defun projectile-add-dir-local-variable (mode variable value)
+  "Run `add-dir-local-variable' with .dir-locals.el in root of project.
+
+Parameters MODE VARIABLE VALUE are passed directly to `add-dir-local-variable'"
+  (let ((inhibit-read-only t)
+        (default-directory (projectile-project-root)))
+    (unless default-directory
+      (error "Setting dir-local variable in non-existing projectile project was requested"))
+    (add-dir-local-variable mode variable value)
+    (save-buffer)
+    (kill-buffer) ))
+
+;;;###autoload
+(defun projectile-delete-dir-local-variable (mode variable)
+  "Run `delete-dir-local-variable' with .dir-locals.el in root of project.
+
+Parameters MODE VARIABLE VALUE are passed directly to `delete-dir-local-variable'"
+  (let ((inhibit-read-only t)
+        (default-directory (projectile-project-root)))
+    (unless default-directory
+      (error "Setting dir-local variable in non-existing projectile project was requested"))
+    (delete-dir-local-variable mode variable)
+    (save-buffer)
+    (kill-buffer) ))
+
 
 ;;;; Sorting project files
 (defun projectile-sort-files (files)


### PR DESCRIPTION
Functions projectile-add-dir-local-variable and projectile-delete-dir-local-variable
wraps their built-in counterparts. They always use `.dir-locals.el` from root of projectile project.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
