### PR TITLE
Add support for preset-based installs in CMake projects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1699](https://github.com/bbatsov/projectile/pull/1699): `projectile-ripgrep` now supports [`rg.el`](https://github.com/dajva/rg.el).
 * [#1712](https://github.com/bbatsov/projectile/issues/1712): Make it possible to hide Projectile's menu. See `projectile-show-menu`.
 * [#1718](https://github.com/bbatsov/projectile/issues/1718): Add a project type definition for `GNUMakefile`.
+* [#1747](https://github.com/bbatsov/projectile/pull/1747): Add support for preset-based install-commands for CMake projects.
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -2916,7 +2916,8 @@ select a name of a command preset, or opt a manual command by selecting
 (defconst projectile--cmake-manual-command-alist
   '((:configure-command . "cmake -S . -B build")
     (:compile-command . "cmake --build build")
-    (:test-command . "cmake --build build --target test")))
+    (:test-command . "cmake --build build --target test")
+    (:install-command . "cmake --build build --target install")))
 
 (defun projectile--cmake-manual-command (command-type)
   "Create maunual CMake COMMAND-TYPE command."
@@ -2925,7 +2926,8 @@ select a name of a command preset, or opt a manual command by selecting
 (defconst projectile--cmake-preset-command-alist
   '((:configure-command . "cmake . --preset %s")
     (:compile-command . "cmake --build --preset %s")
-    (:test-command . "ctest --preset %s")))
+    (:test-command . "ctest --preset %s")
+    (:install-command . "cmake --build --preset %s --target install")))
 
 (defun projectile--cmake-preset-command (command-type preset)
   "Create CMake COMMAND-TYPE command using PRESET."
@@ -2958,6 +2960,10 @@ a manual COMMAND-TYPE command is created with
 (defun projectile--cmake-test-command ()
   "CMake test command."
   (projectile--cmake-command :test-command))
+
+(defun projectile--cmake-install-command ()
+  "CMake install command."
+  (projectile--cmake-command :install-command))
 
 ;;; Project type registration
 ;;
@@ -3032,7 +3038,7 @@ a manual COMMAND-TYPE command is created with
                                   :configure #'projectile--cmake-configure-command
                                   :compile #'projectile--cmake-compile-command
                                   :test #'projectile--cmake-test-command
-                                  :install "cmake --build build --target install"
+                                  :install #'projectile--cmake-install-command
                                   :package "cmake --build build --target package")
 ;; PHP
 (projectile-register-project-type 'php-symfony '("composer.json" "app" "src" "vendor")


### PR DESCRIPTION
Adds support for preset-based installs in CMake-projects as suggested in https://gitlab.kitware.com/cmake/cmake/-/issues/23117#note_1137638.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
