### PR TITLE
Escape periods in "projectile-globally-ignored-directories"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bugs fixed
 
+* [#1762](https://github.com/bbatsov/projectile/pull/1762): Fix `projectile-globally-ignored-directories` unescaped regex
 * [#1713](https://github.com/bbatsov/projectile/issues/1731): Fix `projectile-discover-projects-in-directory` reordering known projects.
 * [#1514](https://github.com/bbatsov/projectile/issues/1514): Fix `projectile-ag` global ignores not in effect.
 * [#1714](https://github.com/bbatsov/projectile/issues/1714): Fix `projectile-discover-projects-in-directory` not interactive.

--- a/projectile.el
+++ b/projectile.el
@@ -396,23 +396,23 @@ is set to 'alien'."
   :type '(repeat string))
 
 (defcustom projectile-globally-ignored-directories
-  '("\\.idea"
-    "\\.vscode"
-    "\\.ensime_cache"
-    "\\.eunit"
-    "\\.git"
-    "\\.hg"
-    "\\.fslckout"
-    "_FOSSIL_"
-    "\\.bzr"
-    "_darcs"
-    "\\.pijul"
-    "\\.tox"
-    "\\.svn"
-    "\\.stack-work"
-    "\\.ccls-cache"
-    "\\.cache"
-    "\\.clangd")
+  '("^\\.idea$"
+    "^\\.vscode$"
+    "^\\.ensime_cache$"
+    "^\\.eunit$"
+    "^\\.git$"
+    "^\\.hg$"
+    "^\\.fslckout$"
+    "^_FOSSIL_$"
+    "^\\.bzr$"
+    "^_darcs$"
+    "^\\.pijul$"
+    "^\\.tox$"
+    "^\\.svn$"
+    "^\\.stack-work$"
+    "^\\.ccls-cache$"
+    "^\\.cache$"
+    "^\\.clangd$")
   "A list of directories globally ignored by projectile.
 Regular expressions can be used.
 

--- a/projectile.el
+++ b/projectile.el
@@ -396,23 +396,23 @@ is set to 'alien'."
   :type '(repeat string))
 
 (defcustom projectile-globally-ignored-directories
-  '(".idea"
-    ".vscode"
-    ".ensime_cache"
-    ".eunit"
-    ".git"
-    ".hg"
-    ".fslckout"
+  '("\\.idea"
+    "\\.vscode"
+    "\\.ensime_cache"
+    "\\.eunit"
+    "\\.git"
+    "\\.hg"
+    "\\.fslckout"
     "_FOSSIL_"
-    ".bzr"
+    "\\.bzr"
     "_darcs"
-    ".pijul"
-    ".tox"
-    ".svn"
-    ".stack-work"
-    ".ccls-cache"
-    ".cache"
-    ".clangd")
+    "\\.pijul"
+    "\\.tox"
+    "\\.svn"
+    "\\.stack-work"
+    "\\.ccls-cache"
+    "\\.cache"
+    "\\.clangd")
   "A list of directories globally ignored by projectile.
 Regular expressions can be used.
 


### PR DESCRIPTION
The unescaped periods were causing unexpected directories to be ignored.

E.g. for the following go project, the configitem directory was ignored because it matched the regex ".git":
```
$ find pkg -type f
pkg/metrics/argus.go
pkg/secrets/secrets.go
pkg/dynamo/dynamo.go
pkg/utils/types.go
pkg/utils/utils.go
pkg/utils/errors.go
pkg/configitem/configitem.go
pkg/api/handlers.go
pkg/api/middleware.go
```

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
