### PR TITLE
Fix Git submodule command on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fix version extraction logic.
 * [1654](https://github.com/bbatsov/projectile/issues/1654) Fix consecutive duplicates appearing in command history
 * [#1755](https://github.com/bbatsov/projectile/issues/1755) Cache failure to find project root
+* [#1600](https://github.com/bbatsov/projectile/issues/1600): Fix error finding project files with Git submodules on Windows.
 
 ### Changes
 


### PR DESCRIPTION
Projectile produces an error when finding project files in a Git repository with submodules on Windows (#1600). This is because the command to find the submodules is hard-coded, including the quotes. This PR adds a `projectile-get-git-sub-projects-command` function to generate the command with the correct quoting at runtime. It also adds `projectile-git-submodule-command-function`, which is set to `projectile-get-git-sub-projects-command` by default, obsoleting `projectile-git-submodule-command`.

I’m not sure I can add tests for this since it’s specific to the combination of Git, submodules, and Windows. I did run `checkdoc` but it showed a whole lot of unrelated errors.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] ~~You've updated the readme (if adding/changing user-visible functionality)~~

Thanks!
