### PR TITLE
Resurrect Default src-dir and test-dir for project-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#1714](https://github.com/bbatsov/projectile/issues/1714): Fix `projectile-discover-projects-in-directory` not interactive.
 * [#1734](https://github.com/bbatsov/projectile/pull/1734): Make `projectile--find-matching-test` use `src-dir/test-dir` properties.
 * [#1750](https://github.com/bbatsov/projectile/issues/1750): Fix source and test directories for Maven projects.
+* [#1765](https://github.com/bbatsov/projectile/issues/1765): Fix `src-dir`/`test-dir` not defaulting to `"src/"` and `"test/"` with `projectile-toggle-between-implementation-and-test`
 
 ### Changes
 


### PR DESCRIPTION
Hi, this is a proposed fix for #1765, it (re) adds a default value for the `src-dir` and `test-dir` properties for project types (= `"src/"` and `"test/"`).  The main effect is for `projectile-toggle-between-implementation-and-test`, so these defaults will be used as a fallback if no other method can be found for finding an impl/test file.

There was a breaking change in https://github.com/bbatsov/projectile/pull/1734 (sorry!) which removed this fallback, so project types without a `src-dir` or `related-files-fn` property wouldn't have a method for finding corresponding test/impl files, as shown in #1765.  This fallback is not always particularly useful however, for example when your implementation file doesn't contain `"src/"`, this PR throws an error in such cases.

I've also tweaked some error messages around this area to hopefully make debugging a little easier:

| Error | Old Message | New Message |
| --- | --- | --- |
|No method was found for determining the (base) file name for a test/impl file | `"Project type foo not supported!"` | `"Cannot determine a test file name, one of "test-suffix" or "test-prefix" must be set for project type foo"`(or an equivalent message for test -> impl) |
|An appropriate test file was found for an impl file, but `projectile-create-missing-test-files` is not set |`"No matching test file found for project type foo"` | ``"Determined test file to be "foo", which does not exist. Set `projectile-create-missing-test-files' to allow `projectile-find-implementation-or-test' to create new files"`` |
|`src-dir` and `test-dir` are set for a project type, but the impl/test file does not contain these as substrings|No error|`"Attempted to find a test file by switching this project type's (foo) src-dir property "src" with this project type's test-dir property "test", but foo/bar does not contain "src"` (or an equivalent message for test -> impl) |

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
