### PR TITLE
Change Grails app configure file name to application.yml

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3188,7 +3188,7 @@ a manual COMMAND-TYPE command is created with
                                   :compile "./gradlew build"
                                   :test "./gradlew test"
                                   :test-suffix "Spec")
-(projectile-register-project-type 'grails '("application.properties" "grails-app")
+(projectile-register-project-type 'grails '("application.yml" "grails-app")
                                   :project-file "application.properties"
                                   :compile "grails package"
                                   :test "grails test-app"

--- a/projectile.el
+++ b/projectile.el
@@ -3189,7 +3189,7 @@ a manual COMMAND-TYPE command is created with
                                   :test "./gradlew test"
                                   :test-suffix "Spec")
 (projectile-register-project-type 'grails '("application.yml" "grails-app")
-                                  :project-file "application.properties"
+                                  :project-file "application.yml"
                                   :compile "grails package"
                                   :test "grails test-app"
                                   :test-suffix "Spec")


### PR DESCRIPTION
Change Grails app configure file name to application.yml

**As per grails new version (version 4 and 5), the configuration file name has been change to application.yml from application.properties**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
