### PR TITLE
Don't add Duplicate Commands to Command History

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#1750](https://github.com/bbatsov/projectile/issues/1750): Fix source and test directories for Maven projects.
 * [#1765](https://github.com/bbatsov/projectile/issues/1765): Fix `src-dir`/`test-dir` not defaulting to `"src/"` and `"test/"` with `projectile-toggle-between-implementation-and-test`.
 * Fix version extraction logic.
+* [1654](https://github.com/bbatsov/projectile/issues/1654) Fix consecutive duplicates appearing in command history
 
 ### Changes
 

--- a/projectile.el
+++ b/projectile.el
@@ -4865,7 +4865,9 @@ The command actually run is returned."
          compilation-save-buffers-predicate)
     (when command-map
       (puthash default-directory command command-map)
-      (ring-insert (projectile--get-command-history project-root) command))
+      (let ((hist (projectile--get-command-history project-root)))
+        (unless (string= (car-safe (ring-elements hist)) command)
+          (ring-insert hist command))))
     (when save-buffers
       (save-some-buffers (not compilation-ask-about-save)
                          (lambda ()


### PR DESCRIPTION
Hi, this PR makes it so that duplicate commands are not added to the command history (a command is only added to the history ring if it doesn't equal the most recent command).  

Related is: https://github.com/bbatsov/projectile/issues/1654, but it has the same effect for `projectile-test-project`, `projectile-compile-project` and so on.

Thanks!


-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
