### PR TITLE
feat: add optional argument to `projectile-test-projectile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1775](https://github.com/bbatsov/projectile/pull/1775): Add optional argument to projectile-test-project
 * [#1790](https://github.com/bbatsov/projectile/pull/1790): Add `src-dir` and `test-dir` properties for the mill project type.
 * [#1778](https://github.com/bbatsov/projectile/pull/1778): Allow `projectile-replace` to select file extensions when using prefix arg (`C-u`).
 * [#1757](https://github.com/bbatsov/projectile/pull/1757): Add support for the Pijul VCS.

--- a/projectile.el
+++ b/projectile.el
@@ -5076,15 +5076,16 @@ with a prefix ARG."
                                  :use-comint-mode projectile-compile-use-comint-mode)))
 
 ;;;###autoload
-(defun projectile-test-project (arg)
+(defun projectile-test-project (arg &optional cmd)
   "Run project test command.
-
+Optional argument CMD s the first in command priority to be used.
 Normally you'll be prompted for a compilation command, unless
-variable `compilation-read-command'.  You can force the prompt
-with a prefix ARG."
+variable `compilation-read-command' or if CMD is passed.
+You can force the prompt with a prefix ARG."
   (interactive "P")
-  (let ((command (projectile-test-command (projectile-compilation-dir)))
-        (command-map (if (projectile--cache-project-commands-p) projectile-test-cmd-map)))
+  (let ((command (or cmd (projectile-test-command (projectile-compilation-dir))))
+        (command-map (if (projectile--cache-project-commands-p) projectile-test-cmd-map))
+				(compilation-read-command (if cmd nil compilation-read-command)))
     (projectile--run-project-cmd command command-map
                                  :show-prompt arg
                                  :prompt-prefix "Test command: "

--- a/projectile.el
+++ b/projectile.el
@@ -5078,7 +5078,7 @@ with a prefix ARG."
 ;;;###autoload
 (defun projectile-test-project (arg &optional cmd)
   "Run project test command.
-Optional argument CMD s the first in command priority to be used.
+CMD overrides the default test command for a project.
 Normally you'll be prompted for a compilation command, unless
 variable `compilation-read-command' or if CMD is passed.
 You can force the prompt with a prefix ARG."

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -137,6 +137,21 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
 (add-to-list 'file-name-handler-alist (cons "^#" 'file-handler-for-tests))
 
 ;;; Tests
+
+(describe "projectile-test-project"
+  (describe "when optional argument CMD is given"
+    (before-each
+      (spy-on 'projectile--run-project-cmd)
+      (projectile-test-project nil "some command"))
+    (it "should use it to test the project"
+      (expect 'projectile--run-project-cmd :to-have-been-called-with
+              "some command"
+              projectile-test-cmd-map
+              :show-prompt nil
+              :prompt-prefix "Test command: "
+              :save-buffers t
+              :use-comint-mode projectile-test-use-comint-mode))))
+
 (describe "projectile-project-name"
   (it "return projectile-project-name when present"
     (let ((projectile-project-name "name"))


### PR DESCRIPTION
### Objective

Add an optional `cmd` parameter to `projectile-test-project`

### My Motivation

When using some test frameworks, for instance jest for javascript/typescript, we might want to pass a specific command to test the project in an automated way.

For instance: testing a single file in jest could be done with

```emacs-lisp
(defun jest-test-this-file ()
  (interactive)
  (projectile-test-project nil (concat "npm test -- " (buffer-file-name)))
```

Trying to set `projectile-test-cmd` dont always work because of the priority order 

```emacs-lisp
(defun jest-test-this-file ()
  (interactive)
  (let ((compilation-read-command nil)
        (projectile-project-test-cmd (concat "npm test -- "
                                             (buffer-file-name))))
    (funcall-interactively 'projectile-test-project nil)))
 ```
 This doesn't work if the `projectile-project-command-history` isn't empty, so I thought using an optional argument would solve the problem without bigger changes in the project or functions' flow.
    
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
