### PR TITLE
Add Emacs 28.1 to CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # Earliest supported + latest in each stable branch + snapshot.
-        emacs_version: ['25.1', '25.3', '26.3', '27.1', 'snapshot']
+        emacs_version: ['25.1', '25.3', '26.3', '27.1', '28.1', 'snapshot']
 
     steps:
     - name: Set up Emacs


### PR DESCRIPTION
Now that Emacs 28.1 is released and the latest stable version available, we should include testing with this version in CI.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
