### PR TITLE
Support `projectile-replace` to select file extension on C-u

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1778](https://github.com/bbatsov/projectile/pull/1778): Allow `projectile-replace` to select file extensions when using prefix arg (`C-u`).
 * [#1757](https://github.com/bbatsov/projectile/pull/1757): Add support for the Pijul VCS.
 * [#1745](https://github.com/bbatsov/projectile/pull/1745): Allow `projectile-update-project-type` to change project type precendence and remove project options.
 * [#1699](https://github.com/bbatsov/projectile/pull/1699): `projectile-ripgrep` now supports [rg.el](https://github.com/dajva/rg.el).

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -293,7 +293,7 @@ With this setting, after selecting a project to switch to, you'll be prompted to
 | Run multi-occur on project buffers.
 
 | kbd:[r]
-| Replace a string in the project.
+| Replace a string in the project (running with kbd:[C-u] will allow users to select file name patterns and extensions).
 
 | kbd:[s]
 | Switch project.

--- a/projectile.el
+++ b/projectile.el
@@ -4468,8 +4468,8 @@ files in the project."
 (defun projectile-replace (&optional arg)
   "Replace literal string in project using non-regexp `tags-query-replace'.
 
-With a prefix argument ARG prompts you for a directory on which
-to run the replacement."
+With a prefix argument ARG prompts you for a directory and file name patterns
+on which to run the replacement."
   (interactive "P")
   (let* ((directory (if arg
                         (file-name-as-directory

--- a/projectile.el
+++ b/projectile.el
@@ -4410,11 +4410,12 @@ to run the replacement."
                          (read-directory-name "Replace in directory: "))
                       (projectile-acquire-root)))
          (file-ext (if arg
-                        (if (fboundp #'helm-grep-get-file-extensions)
-                            (car (helm-grep-get-file-extensions (list directory)))
-                          (read-string
-                           (format "Replace in files with extension: ")))
-                      nil))
+                       (if (fboundp #'helm-grep-get-file-extensions)
+                           (car (helm-grep-get-file-extensions (list directory)))
+                         (read-string
+                          (projectile-prepend-project-name
+                           "Replace in files with extension: ")))
+                     nil))
          (old-text (read-string
                     (projectile-prepend-project-name "Replace: ")
                     (projectile-symbol-or-selection-at-point)))

--- a/projectile.el
+++ b/projectile.el
@@ -4358,7 +4358,7 @@ Returns a list of expanded filenames."
     ;; -I: no binary files
     (grep . "grep -rHlI %s .")))
 
-(defun projectile--rg-construct-command (file-ext search-term)
+(defun projectile--rg-construct-command (search-term &optional file-ext)
   "Construct Rg option to search files by the extension FILE-EXT."
   (if (stringp file-ext)
       (concat (cdr (assoc 'rg projectile-files-with-string-commands))
@@ -4367,9 +4367,9 @@ Returns a list of expanded filenames."
               "' "
               search-term)
     (concat (cdr (assoc 'rg projectile-files-with-string-commands))
-            ;; search-term)))
+            search-term)))
 
-(defun projectile--ag-construct-command (file-ext search-term)
+(defun projectile--ag-construct-command (search-term &optional file-ext)
   "Construct Ag option to search files by the extension FILE-EXT."
   (if (stringp file-ext)
       (concat (cdr (assoc 'ag projectile-files-with-string-commands))
@@ -4382,7 +4382,7 @@ Returns a list of expanded filenames."
     (concat (cdr (assoc 'ag projectile-files-with-string-commands))
             search-term)))
 
-(defun projectile--ack-construct-command (file-ext search-term)
+(defun projectile--ack-construct-command (search-term &optional file-ext)
   "Construct Ack option to search files by the extension FILE-EXT."
   (if (stringp file-ext)
       (concat "ack -g '"
@@ -4396,7 +4396,7 @@ Returns a list of expanded filenames."
     (concat (cdr (assoc 'ack projectile-files-with-string-commands))
             search-term)))
 
-(defun projectile--git-grep-construct-command (file-ext search-term)
+(defun projectile--git-grep-construct-command (search-term &optional file-ext)
   "Construct Grep option to search files by the extension FILE-EXT."
   (if (stringp file-ext)
       (concat (cdr (assoc 'git projectile-files-with-string-commands))
@@ -4407,7 +4407,7 @@ Returns a list of expanded filenames."
     (concat (cdr (assoc 'git projectile-files-with-string-commands))
             search-term)))
 
-(defun projectile--grep-construct-command (file-ext search-term)
+(defun projectile--grep-construct-command (search-term &optional file-ext)
   "Construct Grep option to search files by the extension FILE-EXT."
   (if (stringp file-ext)
       (concat (format (cdr (assoc 'grep projectile-files-with-string-commands))
@@ -4427,15 +4427,16 @@ files in the project."
   (if (projectile-unixy-system-p)
       (let* ((search-term (shell-quote-argument string))
              (cmd (cond ((executable-find "rg")
-                         (projectile--rg-construct-command file-ext search-term))
+                         (projectile--rg-construct-command search-term file-ext))
                         ((executable-find "ag")
-                         (projectile--ag-construct-command file-ext search-term))
+                         (projectile--ag-construct-command search-term file-ext))
                         ((executable-find "ack")
-                         (projectile--ack-construct-command file-ext search-term))
+                         (projectile--ack-construct-command search-term file-ext))
                         ((and (executable-find "git")
                               (eq (projectile-project-vcs) 'git))
-                         (concat (cdr (assoc 'git projectile-files-with-string-commands)) search-term))
-                        (t (projectile--grep-construct-command file-ext search-term)))))
+                         (projectile--git-grep-construct-command search-term file-ext))
+                        (t
+                         (projectile--grep-construct-command search-term file-ext)))))
         (projectile-files-from-cmd cmd directory))
     ;; we have to reject directories as a workaround to work with git submodules
     (cl-remove-if
@@ -4459,7 +4460,7 @@ to run the replacement."
                            (car (helm-grep-get-file-extensions (list directory)))
                          (read-string
                           (projectile-prepend-project-name
-                           "Replace in files with extension: ")))
+                           "With file extension (empty string means all files): ")))
                      nil))
          (old-text (read-string
                     (projectile-prepend-project-name "Replace: ")

--- a/projectile.el
+++ b/projectile.el
@@ -77,6 +77,7 @@
 (declare-function fileloop-continue "fileloop")
 (declare-function fileloop-initialize-replace "fileloop")
 (declare-function tramp-archive-file-name-p "tramp-archive")
+(declare-function helm-grep-get-file-extensions "helm-grep")
 
 (declare-function ggtags-ensure-project "ext:ggtags")
 (declare-function ggtags-update-tags "ext:ggtags")


### PR DESCRIPTION
Hi,

I created this PR to enable users to select file name pattern and extension when performing `projectile-replace` with `C-u`.

This is to prevent `projectile-replace` from searching on very large files of a project (my Emacs hangs when projectile search on a 1MB Javascript library file, while I only wanted to search and replace on Rust code).

Currently, the file extension filtering is supported only by `ag` (using the option `-G <file-ext-pattern>`). 

I don't use `rg`, hence I haven't been able to add the corresponding option for it (and also for `ack` and `grep`).

Can you take a look and advise if this PR can be merged?

Thank you!

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- ~~[ ] You've added tests (if possible) to cover your change(s)~~
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x]  The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
