### PR TITLE
Fixes projectile-dir-files-alien on macOS

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -716,10 +716,10 @@ Set to nil to disable listing submodules contents."
   (cond
    ;; we prefer fd over find
    ((executable-find "fd")
-    "fd . -0 --type f --color=never")
+    "fd . -0 --type f --color=never --strip-cwd-prefix")
    ;; fd's executable is named fdfind is some Linux distros (e.g. Ubuntu)
    ((executable-find "fdfind")
-    "fdfind . -0 --type f --color=never")
+    "fdfind . -0 --type f --color=never --strip-cwd-prefix")
    ;; with find we have to be careful to strip the ./ from the paths
    ;; see https://stackoverflow.com/questions/2596462/how-to-strip-leading-in-unix-find
    (t "find . -type f | cut -c3- | tr '\\n' '\\0'"))


### PR DESCRIPTION
As I describe in #1783, the function `projectile-dir-files-alien` is not returning the same value in macOS as the function `projectile-dir-files-native` because it returns values with a leading "./". This PR fixes this, ensuring both functions return values without a leading dot directory and fixing the issue reported in https://github.com/doomemacs/doomemacs/issues/6504.
