### PR TITLE
Give the project type "go" higher precedence than universal types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Changes
 
+* [#1785](https://github.com/bbatsov/projectile/pull/1785): Give the project type "go" higher precedence than universal types, namely "make".
 * [#1447](https://github.com/bbatsov/projectile/issues/1447): Restructure the menu.
 * [#1692](https://github.com/bbatsov/projectile/issues/1692): Enable minibuffer completions when reading shell-commands.
 * Change the Grails project marker to `application.yml`.

--- a/projectile.el
+++ b/projectile.el
@@ -3074,10 +3074,6 @@ a manual COMMAND-TYPE command is created with
                                   :compile "dotnet build"
                                   :run "dotnet run"
                                   :test "dotnet test")
-(projectile-register-project-type 'go projectile-go-project-test-function
-                                  :compile "go build"
-                                  :test "go test ./..."
-                                  :test-suffix "_test")
 ;; File-based detection project types
 
 ;; Universal
@@ -3128,6 +3124,11 @@ a manual COMMAND-TYPE command is created with
                                   :test #'projectile--cmake-test-command
                                   :install #'projectile--cmake-install-command
                                   :package "cmake --build build --target package")
+;; Go
+(projectile-register-project-type 'go projectile-go-project-test-function
+                                  :compile "go build"
+                                  :test "go test ./..."
+                                  :test-suffix "_test")
 ;; PHP
 (projectile-register-project-type 'php-symfony '("composer.json" "app" "src" "vendor")
                                   :project-file "composer.json"

--- a/projectile.el
+++ b/projectile.el
@@ -3124,7 +3124,7 @@ a manual COMMAND-TYPE command is created with
                                   :test #'projectile--cmake-test-command
                                   :install #'projectile--cmake-install-command
                                   :package "cmake --build build --target package")
-;; Go
+;; Go should take higher precedence than Make because Go projects often have a Makefile.
 (projectile-register-project-type 'go projectile-go-project-test-function
                                   :compile "go build"
                                   :test "go test ./..."


### PR DESCRIPTION
It is so common for a Go-based project to have a Makefile.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
