### PR TITLE
Add a progress reporter to recursive progress discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#1447](https://github.com/bbatsov/projectile/issues/1447): Restructure the menu.
 * [#1692](https://github.com/bbatsov/projectile/issues/1692): Enable minibuffer completions when reading shell-commands.
 * Change the Grails project marker to `application.yml`.
+* [#1789](https://github.com/bbatsov/projectile/pull/1789): Progress reporter for recursive progress discovery
 
 ## 2.5.0 (2021-08-10)
 

--- a/projectile.el
+++ b/projectile.el
@@ -1087,10 +1087,16 @@ discover projects there."
           ;; sometimes that directory is an unreadable one at the root of a
           ;; volume. This is the case, for example, on macOS with the
           ;; .Spotlight-V100 directory.
-          (dolist (dir (ignore-errors (directory-files directory t)))
-            (when (and (file-directory-p dir)
-                       (not (member (file-name-nondirectory dir) '(".." "."))))
-              (projectile-discover-projects-in-directory dir (1- depth))))
+          (let ((progress-reporter
+                 (make-progress-reporter
+                  (format "Projectile is discovering projects in %s..."
+                          (propertize directory 'face 'font-lock-keyword-face)))))
+            (progress-reporter-update progress-reporter)
+            (dolist (dir (ignore-errors (directory-files directory t)))
+              (when (and (file-directory-p dir)
+                         (not (member (file-name-nondirectory dir) '(".." "."))))
+                (projectile-discover-projects-in-directory dir (1- depth))))
+            (progress-reporter-done progress-reporter))
         (when (projectile-project-p directory)
           (let ((dir (abbreviate-file-name (projectile-project-root directory))))
             (unless (member dir projectile-known-projects)


### PR DESCRIPTION
Discovering  a deep recursive directory structure  can take a while to finish. 
Inform user about the progress so the user can estimate remaining time
and clearly see that Emacs is busy working, not hung.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s) ***does not apply***
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality) ***does not apply***

