### PR TITLE
Add src-dir and test-dir Properties to mill Project Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1790](https://github.com/bbatsov/projectile/pull/1790): Add `src-dir` and `test-dir` properties for the mill project type.
 * [#1757](https://github.com/bbatsov/projectile/pull/1757): Add support for the Pijul VCS.
 * [#1745](https://github.com/bbatsov/projectile/pull/1745): Allow `projectile-update-project-type` to change project type precedence and remove project options.
 * [#1699](https://github.com/bbatsov/projectile/pull/1699): `projectile-ripgrep` now supports [rg.el](https://github.com/dajva/rg.el).

--- a/projectile.el
+++ b/projectile.el
@@ -3239,6 +3239,8 @@ a manual COMMAND-TYPE command is created with
 
 (projectile-register-project-type 'mill '("build.sc")
                                   :project-file "build.sc"
+                                  :src-dir "src/"
+                                  :test-dir "test/src/"
                                   :compile "mill all __.compile"
                                   :test "mill all __.test"
                                   :test-suffix "Test")


### PR DESCRIPTION
Hi, this PR adds src-dir and test-dir Properties to the mill Project Type (see https://com-lihaoyi.github.io/mill/mill/Common_Project_Layouts.html), so this should help with default test/implementation toggling etc.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
