### PR TITLE
Make any version of `fd` work

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -716,10 +716,10 @@ Set to nil to disable listing submodules contents."
   (cond
    ;; we prefer fd over find
    ((executable-find "fd")
-    "fd . -0 --type f --color=never --strip-cwd-prefix")
+    "fd . --type f --color=never . | cut -c3- | tr '\\n' '\\0'")
    ;; fd's executable is named fdfind is some Linux distros (e.g. Ubuntu)
    ((executable-find "fdfind")
-    "fdfind . -0 --type f --color=never --strip-cwd-prefix")
+    "fdfind . --type f --color=never . | cut -c3- | tr '\\n' '\\0'")
    ;; with find we have to be careful to strip the ./ from the paths
    ;; see https://stackoverflow.com/questions/2596462/how-to-strip-leading-in-unix-find
    (t "find . -type f | cut -c3- | tr '\\n' '\\0'"))


### PR DESCRIPTION
# HOLD ON THIS PLEASE (seems like there is an issue)


Update `fd` in `projectile-generic-command` to NOT use `--strip-cwd-prefix` option because this option appeared in `fd@8.3.0`
which makes projectile to throw an error.  See - https://github.com/bbatsov/projectile/issues/1788

As you can see I also removed `-0` option which was a replacement of `tr '\\n' '\\0'`. We need to remove it in this case because `cut` needs those `\n`s

Those `cut` and `tr` pipes are repeating among all 3 commands which doesn't look great but I decided not to refactor them into a postfix variable. Who knows what other commands will be there and what sort of pipes they will require. 

Tested on the latest `fd@8.4.0` and on `fd@8.2.1`

Feel free to let me know to change/improve anything. 
Thanks. 

P.S. 
I wish I can write some tests for this but I have never used `eldev`. Also feel free to force me to do so