### PR TITLE
docs/configuration: Grammar nit

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -14,14 +14,12 @@ known as the `native indexing method`) and the other two (`hybrid` and
 `alien`) rely on external commands like `find`, `git`, etc to
 obtain the list of files in a project.
 
-The `alien` indexing method optimizes to the limit the speed of
-the `hybrid` indexing method.  This means that Projectile will not do
-any processing or sorting of the files returned by the external commands
-and you're going to get the maximum performance possible.  This behaviour
-makes a lot of sense for most people, as they'd typically be putting
-ignores in their VCS config (e.g. `.gitignore`) and won't care about
-any additional ignores/unignores/sorting that Projectile might also
-provide.
+The `alien` indexing method maximizes the speed of the `hybrid` indexing
+method.  This means that Projectile will not do any processing or sorting
+of the files returned by the external commands and you're going to get
+the maximum performance possible.  This behaviour makes a lot of sense for
+most people, as they'd typically be putting ignores in their VCS config (e.g. `.gitignore`) and won't care about any additional ignores/unignores/sorting
+that Projectile might also provide.
 
 NOTE: By default the `alien` method is used on all operating systems except Windows.
  Prior to Projectile 2.0 `hybrid` used to be the default (but to make things


### PR DESCRIPTION
This PR fixes a small grammar mistake on the docs/configuration page

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
