### PR TITLE
Add Local Overrides for more Project Attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#1718](https://github.com/bbatsov/projectile/issues/1718): Add a project type definition for `GNUMakefile`.
 * [#1747](https://github.com/bbatsov/projectile/pull/1747): Add support for preset-based install-commands for CMake projects.
 * [#1768](https://github.com/bbatsov/projectile/pull/1768) Add support for disabling command caching on a per-project basis.
+* [#1797](https://github.com/bbatsov/projectile/pull/1797) Make all project type attributes locally overridable
 
 ### Bugs fixed
 

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -754,7 +754,7 @@ you e.g. test a command-line program with `projectile-run-project`.
 (setq projectile-comint-mode t)
 ----
 
-== Configure a Project's Lifecycle Commands
+== Configure a Project's Lifecycle Commands and Other Attributes
 
 There are a few variables that are intended to be customized via `.dir-locals.el`.
 
@@ -764,6 +764,11 @@ There are a few variables that are intended to be customized via `.dir-locals.el
 * for installation - `projectile-project-install-cmd`
 * for packaging - `projectile-project-package-cmd`
 * for running - `projectile-project-run-cmd`
+* for configuring the test prefix - `projectile-project-test-prefix`
+* for configuring the test suffix - `projectile-project-test-suffix`
+* for configuring the related-files-fn property - `projectile-project-related-files-fn`
+* for configuring the src-dir property - `projectile-project-src-dir`
+* for configuring the test-dir property - `projectile-project-test-dir`
 
 When these variables have their default value of `nil`, Projectile
 runs the default command for the current project type.  You can

--- a/projectile.el
+++ b/projectile.el
@@ -821,6 +821,31 @@ If the value is nil, there is no limit to the opend buffers count."
   :type 'integer
   :package-version '(projectile . "2.2.0"))
 
+(defvar projectile-project-test-suffix nil
+  "Use this variable to override the current project's test-suffix property.
+It takes precedence over the test-suffix for the project type when set.
+Should be set via .dir-locals.el.")
+
+(defvar projectile-project-test-prefix nil
+  "Use this variable to override the current project's test-prefix property.
+It takes precedence over the test-prefix for the project type when set.
+Should be set via .dir-locals.el.")
+
+(defvar projectile-project-related-files-fn nil
+  "Use this variable to override the current project's related-files-fn property.
+It takes precedence over the related-files-fn attribute for the project type
+when set.  Should be set via .dir-locals.el.")
+
+(defvar projectile-project-src-dir nil
+  "Use this variable to override the current project's src-dir property.
+It takes precedence over the src-dir for the project type when set.
+Should be set via .dir-locals.el.")
+
+(defvar projectile-project-test-dir nil
+  "Use this variable to override the current project's test-dir property.
+It takes precedence over the test-dir for the project type when set.
+Should be set via .dir-locals.el.")
+
 
 ;;; Version information
 
@@ -3651,25 +3676,30 @@ Fallback to DEFAULT-VALUE for missing attributes."
 
 (defun projectile-test-prefix (project-type)
   "Find default test files prefix based on PROJECT-TYPE."
-  (projectile-project-type-attribute project-type 'test-prefix))
+  (or projectile-project-test-prefix
+      (projectile-project-type-attribute project-type 'test-prefix)))
 
 (defun projectile-test-suffix (project-type)
   "Find default test files suffix based on PROJECT-TYPE."
-  (projectile-project-type-attribute project-type 'test-suffix))
+  (or projectile-project-test-suffix
+      (projectile-project-type-attribute project-type 'test-suffix)))
 
 (defun projectile-related-files-fn (project-type)
   "Find relative file based on PROJECT-TYPE."
-  (projectile-project-type-attribute project-type 'related-files-fn))
+  (or projectile-project-related-files-fn
+      (projectile-project-type-attribute project-type 'related-files-fn)))
 
 (defun projectile-src-directory (project-type)
   "Find default src directory based on PROJECT-TYPE."
-  (projectile-project-type-attribute
-   project-type 'src-dir projectile-default-src-directory))
+  (or projectile-project-src-dir
+      (projectile-project-type-attribute
+       project-type 'src-dir projectile-default-src-directory)))
 
 (defun projectile-test-directory (project-type)
   "Find default test directory based on PROJECT-TYPE."
-  (projectile-project-type-attribute
-   project-type 'test-dir projectile-default-test-directory))
+  (or projectile-project-test-dir
+      (projectile-project-type-attribute
+       project-type 'test-dir projectile-default-test-directory)))
 
 (defun projectile-dirname-matching-count (a b)
   "Count matching dirnames ascending file paths in A and B."

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -2045,6 +2045,71 @@ projectile-process-current-project-buffers-current to have similar behaviour"
                (projectile--get-command-history projectile-project-root))
               :to-equal '("bar" "foo")))))
 
+(describe "projectile-test-prefix"
+  :var ((mock-projectile-project-types
+         '((foo test-prefix "Test"))))
+  (it "gets set test-prefix"
+    (let ((projectile-project-types mock-projectile-project-types)
+          (projectile-project-type 'foo))
+      (expect (projectile-test-prefix'foo) :to-equal "Test")))
+  (it "uses local override"
+    (let ((projectile-project-types mock-projectile-project-types)
+          (projectile-project-type 'foo)
+          (projectile-project-test-prefix "Spec"))
+      (expect (projectile-test-prefix 'foo) :to-equal "Spec"))))
+
+(describe "projectile-test-suffix"
+  :var ((mock-projectile-project-types
+         '((foo test-suffix "Test"))))
+  (it "gets set test-suffix"
+    (let ((projectile-project-types mock-projectile-project-types)
+          (projectile-project-type 'foo))
+      (expect (projectile-test-suffix'foo) :to-equal "Test")))
+  (it "uses local override"
+    (let ((projectile-project-types mock-projectile-project-types)
+          (projectile-project-type 'foo)
+          (projectile-project-test-suffix "Spec"))
+      (expect (projectile-test-suffix 'foo) :to-equal "Spec"))))
+
+(describe "projectile-related-files-fn"
+  :var ((mock-projectile-project-types
+         '((foo related-files-fn ignore))))
+  (it "gets set related-files-fn"
+    (let ((projectile-project-types mock-projectile-project-types)
+          (projectile-project-type 'foo))
+      (expect (projectile-related-files-fn 'foo) :to-equal #'ignore)))
+  (it "uses local override"
+    (let ((projectile-project-types mock-projectile-project-types)
+          (projectile-project-type 'foo)
+          (projectile-project-related-files-fn #'identity))
+      (expect (projectile-related-files-fn 'foo) :to-equal #'identity))))
+
+(describe "projectile-test-directory"
+  :var ((mock-projectile-project-types
+         '((foo test-dir "test"))))
+  (it "gets set test directory"
+    (let ((projectile-project-types mock-projectile-project-types)
+          (projectile-project-type 'foo))
+      (expect (projectile-test-directory 'foo) :to-equal "test")))
+  (it "uses local override"
+    (let ((projectile-project-types mock-projectile-project-types)
+          (projectile-project-type 'foo)
+          (projectile-project-test-dir "other"))
+      (expect (projectile-test-directory 'foo) :to-equal "other"))))
+
+(describe "projectile-src-directory"
+  :var ((mock-projectile-project-types
+         '((foo src-dir "src"))))
+  (it "gets set src directory"
+    (let ((projectile-project-types mock-projectile-project-types)
+          (projectile-project-type 'foo))
+      (expect (projectile-src-directory 'foo) :to-equal "src")))
+  (it "uses local override"
+    (let ((projectile-project-types mock-projectile-project-types)
+          (projectile-project-type 'foo)
+          (projectile-project-src-dir "other"))
+      (expect (projectile-src-directory 'foo) :to-equal "other"))))
+
 ;; A bunch of tests that make sure Projectile commands handle
 ;; gracefully the case of being run outside of a project.
 (assert-friendly-error-when-no-project projectile-project-info)


### PR DESCRIPTION
Hi!  This PR adds variables intended to be used to be used as local overrides (in the same vein as https://docs.projectile.mx/projectile/projects.html#configure-a-projects-lifecycle-commands) for the project type attributes test-prefix, test-suffix, related-files-fn, src-dir and test-dir.  The intention is that you would no longer have to register a custom project type and set `projectile-project-type` in your `.dir-locals.el` just because you want to override say the test suffix for one particular project.

Thanks!

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
