### PR TITLE
Fix #1788: Add notes about minimal version of `fd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ See the [online documentation](https://docs.projectile.mx) for more details.
 ## Caveats
 
 * Some operations like search (grep) depend (presently) on external
-  utilities such as `find`.
+  utilities such as `find` or `fd` (version 8.3.0+).
+  * for older `fd` version add `(setq projectile-generic-command "fd . -0 --type f --color=never")` to your init-file
 * Commands depending on external utilities might misbehave on the `fish` shell.
 * Using Projectile over TRAMP might be slow in certain cases.
 * Some commands might misbehave on complex project setups (e.g. a git project with submodules).

--- a/projectile.el
+++ b/projectile.el
@@ -716,6 +716,7 @@ Set to nil to disable listing submodules contents."
 (defcustom projectile-generic-command
   (cond
    ;; we prefer fd over find
+   ;; note that --strip-cwd-prefix is only available in version 8.3.0+
    ((executable-find "fd")
     "fd . -0 --type f --color=never --strip-cwd-prefix")
    ;; fd's executable is named fdfind is some Linux distros (e.g. Ubuntu)


### PR DESCRIPTION
Update readme and projectile.el with the minimal version of `fd` supported by projectile.

Issue ref - https://github.com/bbatsov/projectile/issues/1788

p.s.
I haven't updated the changelog file since there are no changes really. Let me know if I should do so. 
