### PR TITLE
[Fix #1754] `projectile-open-projects` lists projects for which all buffers are closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#1591](https://github.com/bbatsov/projectile/issues/1591): Add `project.el` integration that will make Projectile the default provider for project lookup.
 
+### Bug fixed
+
+* [#1799](https://github.com/bbatsov/projectile/pull/1799): Fix `projectile-open-projects` lists projects for which all buffers are closed.
+
 ## 2.6.0 (2022-10-25)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#1591](https://github.com/bbatsov/projectile/issues/1591): Add `project.el` integration that will make Projectile the default provider for project lookup.
+* [#1799](https://github.com/bbatsov/projectile/pull/1799): Make it possible to ignore special project buffers.
 
 ### Bug fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -5192,8 +5192,9 @@ An open project is a project with any open buffers."
    (delq nil
          (mapcar (lambda (buffer)
                    (with-current-buffer buffer
-                     (when (projectile-project-p)
-                       (abbreviate-file-name (projectile-project-root)))))
+                     (when-let ((project-root (projectile-project-root)))
+                       (when (projectile-project-buffer-p buffer project-root)
+                         (abbreviate-file-name project-root)))))
                  (buffer-list)))))
 
 (defun projectile--remove-current-project (projects)

--- a/projectile.el
+++ b/projectile.el
@@ -822,6 +822,27 @@ If the value is nil, there is no limit to the opend buffers count."
   :type 'integer
   :package-version '(projectile . "2.2.0"))
 
+(defcustom projectile-ignore-special-project-buffers t
+  "When t ignore special project buffers.
+
+See `projectile-ignored-project-buffers'."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "2.7.0"))
+
+(defcustom projectile-ignored-project-buffers
+  '(
+    "*scratch*"              ; Lisp Interaction Buffer
+    "*lsp-log*"              ; LSP Mode Troubleshooting Buffer
+    )
+  "A list of buffers considered that should never be killed or
+associated with any specific project.
+
+See `projectile-ignore-special-project-buffers'."
+  :group 'projectile
+  :type '(repeat string)
+  :package-version '(projectile . "2.7.0"))
+
 (defvar projectile-project-test-suffix nil
   "Use this variable to override the current project's test-suffix property.
 It takes precedence over the test-suffix for the project type when set.
@@ -1641,11 +1662,21 @@ If PROJECT is not specified the command acts on the current project."
                        default-directory)))
       (and (not (string-prefix-p " " (buffer-name buffer)))
            (not (projectile-ignored-buffer-p buffer))
+           (not (projectile-ignored-project-buffers-p buffer))
            directory
            (string-equal (file-remote-p directory)
                          (file-remote-p project-root))
            (not (string-match-p "^http\\(s\\)?://" directory))
            (string-prefix-p project-root (file-truename directory) (eq system-type 'windows-nt))))))
+
+(defun projectile-ignored-project-buffers-p (buffer)
+  "Check if BUFFER should never associated with any specific project"
+  (when projectile-ignore-special-project-buffers
+    (with-current-buffer buffer
+      (cl-some
+       (lambda (name)
+         (string-match-p name (buffer-name)))
+       projectile-ignored-project-buffers))))
 
 (defun projectile-ignored-buffer-p (buffer)
   "Check if BUFFER should be ignored.

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1038,6 +1038,20 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
 
           (expect (current-buffer) :to-be (get-file-buffer "project/file")))))))
 
+(describe "projectile-ignored-project-buffers-p"
+  (it "checks if buffer should never associated with any specific project"
+    (let ((projectile-ignore-special-project-buffers t)
+          (projectile-ignored-project-buffers '("*nrepl messages*" "*something*")))
+      (expect (projectile-ignored-project-buffers-p (get-buffer-create "*nrepl messages*")) :to-be-truthy)
+      (expect (projectile-ignored-project-buffers-p (get-buffer-create "*something*")) :to-be-truthy)
+      (expect (projectile-ignored-project-buffers-p (get-buffer-create "test")) :not :to-be-truthy)))
+  (it "check if buffer should not ignored when not enabled"
+    (let ((projectile-ignore-special-project-buffers nil)
+          (projectile-ignored-project-buffers '("*nrepl messages*" "*something*")))
+      (expect (projectile-ignored-project-buffers-p (get-buffer-create "*nrepl messages*")) :not :to-be-truthy)
+      (expect (projectile-ignored-project-buffers-p (get-buffer-create "*something*")) :not :to-be-truthy)
+      (expect (projectile-ignored-project-buffers-p (get-buffer-create "test")) :not :to-be-truthy))))
+
 (describe "projectile-ignored-buffer-p"
   (it "checks if buffer should be ignored"
     (let ((projectile-globally-ignored-buffers '("*nrepl messages*" "*something*")))


### PR DESCRIPTION
1. projectile-open-projects should gets a list of buffers like `projectile-project-buffers`.
2. Make it possible to ignore special project buffers

Closes #1754.
Closes #1804.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
