### PR TITLE
Allow specifying project name in the dirconfig file

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1308,8 +1308,18 @@ explicitly."
 (defun projectile-default-project-name (project-root)
   "Default function used to create the project name.
 The project name is based on the value of PROJECT-ROOT."
-  (or (let ((default-directory project-root))
-        (nth 3 (projectile-parse-dirconfig-file)))
+  (or (when-let*
+          ((comment-prefix projectile-dirconfig-comment-prefix)
+           (name-prefix projectile-dirconfig-name-prefix)
+           (default-directory project-root)
+           (dirconfig (projectile-dirconfig-file)))
+        (when (projectile-file-exists-p dirconfig)
+          (with-temp-buffer
+            (insert-file-contents dirconfig)
+            (when (re-search-forward
+                   (format "^%c%c\\(.*\\)$" comment-prefix name-prefix)
+                   nil t)
+              (match-string 1)))))
       (file-name-nondirectory (directory-file-name project-root))))
 
 (defun projectile-project-name (&optional project)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -422,7 +422,7 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
 							   "no-prefix"
 							   "left-wspace"
 							   "right-wspace")
-                                                          nil))
+                                                          nil nil))
     ;; same test - but with comment lines enabled using prefix '#'
     (let ((projectile-dirconfig-comment-prefix ?#))
       (expect (projectile-parse-dirconfig-file) :to-equal '(("include/")
@@ -430,7 +430,7 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
 							     "no-prefix"
 							     "left-wspace"
 							     "right-wspace")
-							    nil)))
+							    nil nil)))
     ))
 
 (describe "projectile-get-project-directories"


### PR DESCRIPTION
This allows specifying the project name in the .projectile file.

It is backwards compatible as the older versions will parse the name as a comment.

All tests except one that also fails on origin are passing so I marked them as such.
There should be a new test added to actually check that the project name is being 
parsed properly but it can wait until the rest of the change is finalized, similarly for the
readme and the changelog.

----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
