### PR TITLE
[Fix #1708] Search hidden files with projectile-ripgrep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [#1692](https://github.com/bbatsov/projectile/issues/1692): Enable minibuffer completions when reading shell-commands.
 * Change the Grails project marker to `application.yml`.
 * [#1789](https://github.com/bbatsov/projectile/pull/1789): Progress reporter for recursive progress discovery
+* [#1708](https://github.com/bbatsov/projectile/issues/1708): `projectile-ripgrep` now consistently searches hidden files.
 
 ## 2.5.0 (2021-08-10)
 

--- a/projectile.el
+++ b/projectile.el
@@ -4168,7 +4168,7 @@ installed to work."
                            (projectile-acquire-root)
                            (if arg
                                args
-                             (cons "--fixed-strings" args))))
+                             (cons "--fixed-strings --hidden" args))))
           ;; and then we try rg
           ((require 'rg nil 'noerror)
            (rg-run search-term


### PR DESCRIPTION
This closes #1708. This is a small behaviour change to make the behaviour consistent across different methods of searching files. The issue raised was on how `projectile-ripgrep` did not search through hidden files, while `projectile-grep` does. This also still respects the `.gitignore` and the various excluded directories, so the only change is that it now includes non-specifically excluded hidden files.

Interestingly enough, the behaviour behind using the different ripgrep libraries `rg` and `ripgrep` were actually different here, where `rg` would include hidden files while `ripgrep` would exclude them.

----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
