### PR TITLE
Find project files bottom-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug fixed
 
+* [#1796](https://github.com/bbatsov/projectile/issues/1796): Fix `projectile-root-bottom-up` doesn’t always find bottom-most file
 * [#1799](https://github.com/bbatsov/projectile/pull/1799): Fix `projectile-open-projects` lists projects for which all buffers are closed.
 * [#1806](https://github.com/bbatsov/projectile/pull/1806): Fix `projectile-project-type` to return the correct project type even when we pass it the DIR arg. As a result of the fix,
 `projectile-expand-root`, `projectile-detect-project-type`, `projectile-verify-files` , `projectile-verify-file` `projectile-verify-file-wildcard`, `projectile-cabal-project-p`,

--- a/projectile.el
+++ b/projectile.el
@@ -1206,10 +1206,9 @@ Return the first (bottommost) matched directory or nil if not found."
   (projectile-locate-dominating-file
    dir
    (lambda (directory)
-     (when (file-readable-p directory)
-       (let ((files (mapcar (lambda (file) (expand-file-name file directory))
-                            (or list projectile-project-root-files-bottom-up))))
-         (cl-some (lambda (file) (and file (file-readable-p file))) files))))))
+     (let ((files (mapcar (lambda (file) (expand-file-name file directory))
+                          (or list projectile-project-root-files-bottom-up))))
+       (cl-some (lambda (file) (and file (file-exists-p file))) files)))))
 
 (defun projectile-root-top-down-recurring (dir &optional list)
   "Identify a project root in DIR by recurring top-down search for files in LIST.

--- a/projectile.el
+++ b/projectile.el
@@ -1203,8 +1203,13 @@ Return the first (topmost) matched directory or nil if not found."
   "Identify a project root in DIR by bottom-up search for files in LIST.
 If LIST is nil, use `projectile-project-root-files-bottom-up' instead.
 Return the first (bottommost) matched directory or nil if not found."
-  (cl-some (lambda (name) (projectile-locate-dominating-file dir name))
-           (or list projectile-project-root-files-bottom-up)))
+  (projectile-locate-dominating-file
+   dir
+   (lambda (directory)
+     (when (file-readable-p directory)
+       (let ((files (mapcar (lambda (file) (expand-file-name file directory))
+                            (or list projectile-project-root-files-bottom-up))))
+         (cl-some (lambda (file) (and file (file-readable-p file))) files))))))
 
 (defun projectile-root-top-down-recurring (dir &optional list)
   "Identify a project root in DIR by recurring top-down search for files in LIST.


### PR DESCRIPTION
Previously, the directory it found would depend on the order of
`projectile-project-root-files-bottom-up` (or the provided list).

given a directory structure
```
foo
├── .a
└── bar
    └── .a
    └── baz
        └── .b
```
`(projectile-root-bottom-up ".../foo/bar/baz/" '(".a" ".b"))` would return
`".../foo/bar/"`, because the current definition looks for any `".a"` before it
looks for ".b".

With this change, it traverses the directory structure once, looking for any
element of the list before moving up a level. So now the same call returns
`".../foo/bar/baz/"`, which matches the documented behavior of returning the
bottommost matched directory.

Fixes #1796

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!