### PR TITLE
Allow multiple project-files per project type, allow wildcards in the project-file specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add new command `projectile-find-references` (bound to `C-c C-p ?` and `C-c C-p s x`).
 * [#1737](https://github.com/bbatsov/projectile/pull/1737): Add helpers for `dir-local-variables` for 3rd party use. Functions `projectile-add-dir-local-variable` and `projectile-delete-dir-local-variable` wrap their built-in counterparts. They always use `.dir-locals.el` from the root of the current Projectile project.
 * Add a new defcustom (`projectile-dirconfig-file`) controlling the name of the file used as Projectile’s root marker and configuration file.
+* [#1813](https://github.com/bbatsov/projectile/pull/1813): Allow project-files to contain wildcards and allow multiple project-files per project type registration. Add a new project-type for .NET solutions. 
 
 ### Bug fixed
 

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -162,14 +162,27 @@ initialization code
 What this does is:
 
 . add your own type of project, in this case `npm` package.
-. add a list of files and/or folders in a root of the project that helps to identify the type, in this case it is only `package.json`.
-. add _project-file_, which is typically the primary project configuration file. In this case that's `package.json`.
+. add a list of files and/or folders in a root of the project that helps to identify the type, in this case it is only `package.json`. This can also be a function which takes a project root as argument and verifies whether that directory has the correct project structure for the type.
+. add _project-file_, which is typically the primary project configuration file. In this case that's `package.json`. The value can contain wildcards and/or be a list containing multiple project files to look for.
 . add _compile-command_, in this case it is `npm install`.
 . add _test-command_, in this case it is `npm test`.
 . add _run-command_, in this case it is `npm start`.
 . add test files suffix for toggling between implementation/test files, in this case it is `.spec`, so the implementation/test file pair could be `service.js`/`service.spec.js` for example.
 
 Let's see a couple of more complex examples.
+
+[source,elisp]
+----
+;; .NET C# or F# projects
+(projectile-register-project-type 'dotnet #'projectile-dotnet-project-p
+                                  :project-file '("?*.csproj" "?*.fsproj")
+                                  :compile "dotnet build"
+                                  :run "dotnet run"
+                                  :test "dotnet test")
+----
+
+This example uses _projectile-dotnet-project-p_ to validate the project's structure.
+Since C# and F# project files have names containing the name of the project, it uses a list of wildcards to specify the different valid _project-file_ name patterns.
 
 [source,elisp]
 ----

--- a/projectile.el
+++ b/projectile.el
@@ -3174,6 +3174,12 @@ a manual COMMAND-TYPE command is created with
                                   :run "cabal run"
                                   :test-suffix "Spec")
 (projectile-register-project-type 'dotnet #'projectile-dotnet-project-p
+                                  :project-file '("?*.csproj" "?*.fsproj")
+                                  :compile "dotnet build"
+                                  :run "dotnet run"
+                                  :test "dotnet test")
+(projectile-register-project-type 'dotnet-sln '("src")
+                                  :project-file "?*.sln"
                                   :compile "dotnet build"
                                   :run "dotnet run"
                                   :test "dotnet test")

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -165,6 +165,25 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
     (expect (projectile-expand-root "foo/bar") :to-equal "/path/to/project/foo/bar")
     (expect (projectile-expand-root "./foo/bar") :to-equal "/path/to/project/foo/bar")))
 
+(describe "projectile-expand-file-name-wildcard"
+  (it "expands a filename not containing wildcards"
+    (expect (projectile-expand-file-name-wildcard "test" "/path/to/project/")
+            :to-equal "/path/to/project/test"))
+  (it "does not try to resolve wildcards if there are none in the pattern"
+    (spy-on 'file-expand-wildcards)
+    (expect (projectile-expand-file-name-wildcard "foo" "/path/to/project/")
+            :to-equal "/path/to/project/foo")
+    (expect (spy-calls-any 'file-expand-wildcards) :to-equal nil))
+  (it "returns the first wildcard result if any exist"
+    (spy-on 'file-expand-wildcards
+            :and-return-value '("/path/to/project/one"
+                                "/path/to/project/two"))
+    (expect (projectile-expand-file-name-wildcard "*" "/path/to/project")
+            :to-equal "/path/to/project/one"))
+  (it "returns the expanded result if the are no wildcard results"
+    (expect (projectile-expand-file-name-wildcard "*" "/path/to/project-b")
+            :to-equal "/path/to/project-b/*")))
+
 (describe "projectile--combine-plists"
  (it "Items in second plist override elements in first"
    (expect (projectile--combine-plists


### PR DESCRIPTION
Some project types can have different project files name patterns (for example, dotnet projects can have `csproj` or `fsproj` depending on whether they're written in C# or F#)

Related to those two examples, sometimes the project-file does not have a constant name. A C# project named `Foo` will have a project-file named `Foo.csproj`. 

This PR allows project type registrations to specify wildcards for their filenames (like `"*.csproj"`) and multiple project-file specs (like `'("*.csproj" "*.fsproj")`).

I've added some tests to make sure this works and keeps working as expected, and adjusted the type registrations for dotnet projects which benefit directly from this feature.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
