### PR TITLE
Elm project type added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Add elm project type
+
 ## 2.7.0 (2022-11-22)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -3471,6 +3471,11 @@ a manual COMMAND-TYPE command is created with
                                   :run "dart"
                                   :test-suffix "_test.dart")
 
+;; Elm
+(projectile-register-project-type 'elm '("elm.json")
+                                  :project-file "elm.json"
+                                  :compile "elm make")
+
 ;; OCaml
 (projectile-register-project-type 'ocaml-dune '("dune-project")
                                   :project-file "dune-project"


### PR DESCRIPTION
Elm has a standardized project hierarchy and it's missing from projectile creating this kind of issues: https://github.com/emacs-lsp/lsp-mode/issues/3936

Fixes https://github.com/emacs-lsp/lsp-mode/issues/3936

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
