### PR TITLE
Move Broad Marker Files

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3167,6 +3167,13 @@ a manual COMMAND-TYPE command is created with
 ;;
 ;; Ideally common project types should be checked earlier than exotic ones.
 
+;; Project types with broad marker files
+(projectile-register-project-type 'dotnet-sln '("src")
+                                  :project-file "?*.sln"
+                                  :compile "dotnet build"
+                                  :run "dotnet run"
+                                  :test "dotnet test")
+
 ;; Function-based detection project type
 (projectile-register-project-type 'haskell-cabal #'projectile-cabal-project-p
                                   :compile "cabal build"
@@ -3175,11 +3182,6 @@ a manual COMMAND-TYPE command is created with
                                   :test-suffix "Spec")
 (projectile-register-project-type 'dotnet #'projectile-dotnet-project-p
                                   :project-file '("?*.csproj" "?*.fsproj")
-                                  :compile "dotnet build"
-                                  :run "dotnet run"
-                                  :test "dotnet test")
-(projectile-register-project-type 'dotnet-sln '("src")
-                                  :project-file "?*.sln"
                                   :compile "dotnet build"
                                   :run "dotnet run"
                                   :test "dotnet test")


### PR DESCRIPTION
The `dotnet-sln` project type uses the `src` directory as a marker file, which is blocking `haskell-cabal` from being detected. This moves the broad detection up to its own section, as such a broad rule seems like one of the last ones that should apply.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
