### PR TITLE
feat: add python PEP621/PEP5128 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#1821](https://github.com/bbatsov/projectile/pull/1821): Add `pyproject.toml` discovery for python projects.
+
 ## 2.7.0 (2022-11-22)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -3320,6 +3320,12 @@ a manual COMMAND-TYPE command is created with
                                   :test "poetry run python -m unittest discover"
                                   :test-prefix "test_"
                                   :test-suffix "_test")
+(projectile-register-project-type 'python-toml '("pyproject.toml")
+                                  :project-file "pyproject.toml"
+                                  :compile "python -m build"
+                                  :test "python -m unittest discover"
+                                  :test-prefix "test_"
+                                  :test-suffix "_test")
 ;; Java & friends
 (projectile-register-project-type 'maven '("pom.xml")
                                   :project-file "pom.xml"


### PR DESCRIPTION
Hi there, 

This PR add support for [PEP621](https://peps.python.org/pep-0621/) python projects, by detecting the standardized `pyproject.toml` file.

I must admit that I am not confortable with the eldev test framework, and I could not find out if and how i could write a test for this new setup. 

Thank you for all the work on this essential package.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- ~~[ ] You've added tests (if possible) to cover your change(s)~~
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- ~~[ ] You've updated the readme (if adding/changing user-visible functionality)~~

Thanks!
