### PR TITLE
Detect Nimble projects for Nim programming language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1828](https://github.com/bbatsov/projectile/pull/1828): Add Nimble-based Nim project discovery.
 * Add elm project type.
 * [#1821](https://github.com/bbatsov/projectile/pull/1821): Add `pyproject.toml` discovery for python projects.
 

--- a/projectile.el
+++ b/projectile.el
@@ -3192,10 +3192,10 @@ a manual COMMAND-TYPE command is created with
                                   :test "dotnet test")
 (projectile-register-project-type 'nim-nimble #'projectile-nimble-project-p
                                   :project-file "?*.nimble"
-                                  :compile "nimble --noColor build"
-                                  :install "nimble --noColor install"
-                                  :test "nimble --noColor test"
-                                  :run "nimble --noColor run"
+                                  :compile "nimble --noColor build --colors:off"
+                                  :install "nimble --noColor install --colors:off"
+                                  :test "nimble --noColor test -d:nimUnittestColor:off --colors:off"
+                                  :run "nimble --noColor run --colors:off"
                                   :src-dir "src"
                                   :test-dir "tests")
 ;; File-based detection project types

--- a/projectile.el
+++ b/projectile.el
@@ -3004,6 +3004,13 @@ it acts on the current project."
   :type 'function
   :package-version '(projectile . "1.0.0"))
 
+(defun projectile-nimble-project-p (&optional dir)
+  "Check if a project contains a Nimble project marker.
+Nim projects that use Nimble contain a <projectname>.nimble file.
+When DIR is specified it checks DIR's project, otherwise
+it acts on the current project."
+  (projectile-verify-file-wildcard "?*.nimble" dir))
+
 ;;;; Constant signifying opting out of CMake preset commands.
 (defconst projectile--cmake-no-preset "*no preset*")
 
@@ -3183,6 +3190,14 @@ a manual COMMAND-TYPE command is created with
                                   :compile "dotnet build"
                                   :run "dotnet run"
                                   :test "dotnet test")
+(projectile-register-project-type 'nim-nimble #'projectile-nimble-project-p
+                                  :project-file "?*.nimble"
+                                  :compile "nimble --noColor build"
+                                  :install "nimble --noColor install"
+                                  :test "nimble --noColor test"
+                                  :run "nimble --noColor run"
+                                  :src-dir "src"
+                                  :test-dir "tests")
 ;; File-based detection project types
 
 ;; Universal


### PR DESCRIPTION
[https://github.com/nim-lang/nimble](Nimble) is the default package manager for Nim programming language projects. They were being picked up as .NET projects due to `src/` being present.

---

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
~~- [ ] You've updated the readme (if adding/changing user-visible functionality)~~