### PR TITLE
Detect Julia projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#NNNN](https://github.com/bbatsov/projectile/pull/NNNN): Add Julia project discovery.
 * [#1828](https://github.com/bbatsov/projectile/pull/1828): Add Nimble-based Nim project discovery.
 * Add elm project type.
 * [#1821](https://github.com/bbatsov/projectile/pull/1821): Add `pyproject.toml` discovery for python projects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* [#NNNN](https://github.com/bbatsov/projectile/pull/NNNN): Add Julia project discovery.
+* [#1833](https://github.com/bbatsov/projectile/pull/1833): Add Julia project discovery.
 * [#1828](https://github.com/bbatsov/projectile/pull/1828): Add Nimble-based Nim project discovery.
 * Add elm project type.
 * [#1821](https://github.com/bbatsov/projectile/pull/1821): Add `pyproject.toml` discovery for python projects.

--- a/projectile.el
+++ b/projectile.el
@@ -3527,6 +3527,14 @@ a manual COMMAND-TYPE command is created with
                                   :project-file "elm.json"
                                   :compile "elm make")
 
+;; Julia
+(projectile-register-project-type 'julia '("Project.toml")
+                                  :project-file "Project.toml"
+                                  :compile "julia --project=@. -e 'import Pkg; Pkg.precompile(); Pkg.build()'"
+                                  :test "julia --project=@. -e 'import Pkg; Pkg.test()' --check-bounds=yes"
+                                  :src-dir "src"
+                                  :test-dir "test")
+
 ;; OCaml
 (projectile-register-project-type 'ocaml-dune '("dune-project")
                                   :project-file "dune-project"

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1338,7 +1338,24 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
        "project/project.el")
       (let ((projectile-indexing-method 'native))
         (spy-on 'projectile-project-root :and-return-value (file-truename (expand-file-name "project/")))
-        (expect (projectile-detect-project-type) :to-equal 'emacs-eldev))))))
+        (expect (projectile-detect-project-type) :to-equal 'emacs-eldev)))))
+  (it "detects project-type for projects with src dir and no other marker"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/"
+       "project/src/")
+      (let ((projectile-indexing-method 'native))
+        (spy-on 'projectile-project-root :and-return-value (file-truename (expand-file-name "project/")))
+        (expect (projectile-detect-project-type) :to-equal 'dotnet-sln)))))
+  (it "detects project-type for Julia PkgTemplates.jl projects"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/"
+       "project/src/"
+       "project/Project.toml")
+      (let ((projectile-indexing-method 'native))
+        (spy-on 'projectile-project-root :and-return-value (file-truename (expand-file-name "project/")))
+        (expect (projectile-detect-project-type) :to-equal 'julia))))))
 
 (describe "projectile-dirname-matching-count"
   (it "counts matching dirnames ascending file paths"


### PR DESCRIPTION
Julia projects were getting detected as `dotnet-sln`. This template follows the structure created by [PkgTemplates.jl](https://github.com/JuliaCI/PkgTemplates.jl) which is pretty standard, so I didn't bother to be more specific than `julia`.

I also added a Julia detection test and another that confirms only a `src` dir present matches a .NET solution.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
~~- [ ] You've updated the readme (if adding/changing user-visible functionality)~~