### PR TITLE
Obey `projectile-project-test-dir` (and similarly for src dir) when toggling between impl and test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changes
 
+* [#1839](https://github.com/bbatsov/projectile/issues/1839): Ensure `projectile-toggle-between-implementation-and-test` also obeys `projectile-project-test-dir` and `projectile-project-src-dir`.
 * [#1285](https://github.com/bbatsov/projectile/pull/1825): By default, use [fd](https://github.com/sharkdp/fd) in Git repositories instead of `git ls-files` when it is installed, in order to solve the problem where deleted files were still shown in `projectile-find-file` until their deletions were staged. The user-facing behavior should be the same, although potentially with different performance characteristics in large Git repositories. The old behavior can be reclaimed by setting `projectile-git-use-fd` to nil.
 * [#1831](https://github.com/bbatsov/projectile/issues/1831): Enable the project.el integration only when `projectile-mode` is active.
 

--- a/projectile.el
+++ b/projectile.el
@@ -3675,8 +3675,8 @@ string) are replaced with the current project type's src-dir property
 
 Nil is returned if either the src-dir or test-dir properties are not strings."
   (let* ((project-type (projectile-project-type))
-         (test-dir (projectile-project-type-attribute project-type 'test-dir))
-         (impl-dir (projectile-project-type-attribute project-type 'src-dir)))
+         (test-dir (projectile-test-directory project-type))
+         (impl-dir (projectile-src-directory project-type)))
     (when (and (stringp test-dir) (stringp impl-dir))
       (if (not (string-match-p test-dir (file-name-directory test-dir-path)))
           (error "Attempted to find a implementation file by switching this project type's (%s) test-dir property \"%s\" with this project type's src-dir property \"%s\", but %s does not contain \"%s\""
@@ -3732,8 +3732,8 @@ signalled.
 
 Nil is returned if either the src-dir or test-dir properties are not strings."
   (let* ((project-type (projectile-project-type))
-         (test-dir (projectile-project-type-attribute project-type 'test-dir))
-         (impl-dir (projectile-project-type-attribute project-type 'src-dir)))
+         (test-dir (projectile-test-directory project-type))
+         (impl-dir (projectile-src-directory project-type)))
     (when (and (stringp test-dir) (stringp impl-dir))
       (if (not (string-match-p impl-dir (file-name-directory impl-dir-path)))
           (error "Attempted to find a test file by switching this project type's (%s) src-dir property \"%s\" with this project type's test-dir property \"%s\", but %s does not contain \"%s\""

--- a/projectile.el
+++ b/projectile.el
@@ -3845,14 +3845,12 @@ Fallback to DEFAULT-VALUE for missing attributes."
 (defun projectile-src-directory (project-type)
   "Find default src directory based on PROJECT-TYPE."
   (or projectile-project-src-dir
-      (projectile-project-type-attribute
-       project-type 'src-dir projectile-default-src-directory)))
+      (projectile-project-type-attribute project-type 'src-dir)))
 
 (defun projectile-test-directory (project-type)
   "Find default test directory based on PROJECT-TYPE."
   (or projectile-project-test-dir
-      (projectile-project-type-attribute
-       project-type 'test-dir projectile-default-test-directory)))
+      (projectile-project-type-attribute project-type 'test-dir)))
 
 (defun projectile-dirname-matching-count (a b)
   "Count matching dirnames ascending file paths in A and B."


### PR DESCRIPTION
Uses the existing `projectile-test-directory` function when looking up test directory (and right beside these are calls looking up the src-dir attribute that should also be using the existing `projectile-src-directory` function.

Note, that this seems to require the trailing slash on the `projectile-project-test-dir` value. I'm not sure if that is OK. It seems consistent with what is declared in the various project types, but is not mentioned in the variable documentation.

Fixes #1839
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
