### PR TITLE
Follow includes in CMake files

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -4546,7 +4546,7 @@ Switch to the project specific term buffer if it already exists.
 
 Use a prefix argument ARG to indicate creation of a new process instead."
   (interactive "P")
-  (project--vterm arg))
+  (projectile--vterm arg))
 
 ;;;###autoload
 (defun projectile-run-vterm-other-window (&optional arg)
@@ -4556,7 +4556,7 @@ Switch to the project specific term buffer if it already exists.
 
 Use a prefix argument ARG to indicate creation of a new process instead."
   (interactive "P")
-  (project--vterm arg 'other-window))
+  (projectile--vterm arg 'other-window))
 
 (defun projectile-files-in-project-directory (directory)
   "Return a list of files in DIRECTORY."

--- a/projectile.el
+++ b/projectile.el
@@ -3091,10 +3091,17 @@ it acts on the current project."
 
 (defun projectile--cmake-command-presets (filename command-type)
   "Get CMake COMMAND-TYPE presets from FILENAME."
-  (when-let ((preset (projectile--cmake-read-preset (projectile-expand-root filename))))
-    (cl-remove-if
-     (lambda (preset) (equal (gethash "hidden" preset) t))
-     (gethash (projectile--cmake-command-preset-array-id command-type) preset))))
+  (when-let ((filename (projectile-expand-root filename))
+             (preset (projectile--cmake-read-preset filename)))
+    (append
+     (cl-remove-if
+      (lambda (preset) (equal (gethash "hidden" preset) t))
+      (gethash (projectile--cmake-command-preset-array-id command-type) preset))
+     (mapcar
+      (lambda (included-file) (projectile--cmake-command-presets
+                               (expand-file-name included-file (file-name-directory filename))
+                          command-type))
+      (gethash "include" preset)))))
 
 (defun projectile--cmake-all-command-presets (command-type)
   "Get CMake user and system COMMAND-TYPE presets."


### PR DESCRIPTION
I use conan dependency manager to setup c++ cmake project. It creates/modifies CMakeUserPresets.json by adding includes to generated CMakePresets.json files. The problem is that projectile does not follow those includes when parsing presets files.

Warning: this is my first ever PR in elisp.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
No, but no cmake related code is testes or I was unable to find any tests.
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
No, I had one error but I also had it without my changes.
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
Had many warnings but non related to new code.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
Not sure if this change qualifies for last two checkboxes.
