### PR TITLE
Use literal directory name casing during impl / test toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * [#1285](https://github.com/bbatsov/projectile/pull/1825): By default, use [fd](https://github.com/sharkdp/fd) in Git repositories instead of `git ls-files` when it is installed, in order to solve the problem where deleted files were still shown in `projectile-find-file` until their deletions were staged. The user-facing behavior should be the same, although potentially with different performance characteristics in large Git repositories. The old behavior can be reclaimed by setting `projectile-git-use-fd` to nil.
 * [#1831](https://github.com/bbatsov/projectile/issues/1831): Enable the project.el integration only when `projectile-mode` is active.
+* [#1847](https://github.com/bbatsov/projectile/issues/1847): Use literal directory name casing when toggling between impl and test.
 
 ## 2.7.0 (2022-11-22)
 

--- a/projectile.el
+++ b/projectile.el
@@ -3746,7 +3746,8 @@ Replace STRING in DIR-PATH with REPLACEMENT."
   (let* ((project-root (projectile-project-root))
          (relative-dir (file-name-directory (file-relative-name dir-path project-root))))
     (projectile-expand-root
-     (replace-regexp-in-string string replacement relative-dir))))
+     ;; TODO: Use string-replace once we target emacs 28
+     (replace-regexp-in-string string replacement relative-dir t))))
 
 (defun projectile--create-directories-for (path)
   "Create directories necessary for PATH."


### PR DESCRIPTION
`projectil-complementary-dir` was using `replace-regexp-in-string` allowing case manging during the replacement. That's not what we want here. See #1847

Fixes: #1847 
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
