### PR TITLE
Add ripgrep as a commander method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1851](https://github.com/bbatsov/projectile/pull/1851): Add ripgrep to `projectile-commander` with binding `?p`.
 * [#1833](https://github.com/bbatsov/projectile/pull/1833): Add Julia project discovery.
 * [#1828](https://github.com/bbatsov/projectile/pull/1828): Add Nimble-based Nim project discovery.
 * Add elm project type.

--- a/projectile.el
+++ b/projectile.el
@@ -5753,6 +5753,10 @@ is chosen."
     "Run grep on project."
     (projectile-grep))
 
+  (def-projectile-commander-method ?p
+    "Run ripgrep on project."
+    (call-interactively #'projectile-ripgrep))
+
   (def-projectile-commander-method ?a
     "Run ag on project."
     (call-interactively #'projectile-ag))


### PR DESCRIPTION
Very small PR to add ripgrep as a method to the projectile commander just like Ag is.

No tests added, because I didn't see any suitable tests for commander or Ag.

On the choice of keybinding: I'd prefer `r` but that's already taken and I don't want to introduce a breaking change. The 'p' in 'ripgrep' stands out phonetically so it seemed the best choice to me. Any lower case character would do, I guess.

Changelog not yet adjusted. Would wait for a PR/issue ID to reference.