### PR TITLE
fd: explicitly disable colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 * [#1831](https://github.com/bbatsov/projectile/issues/1831): Enable the project.el integration only when `projectile-mode` is active.
 * [#1847](https://github.com/bbatsov/projectile/issues/1847): Use literal directory name casing when toggling between impl and test.
 
+### Bug fixed
+
+* Fix `fd` inserting color control sequences when used over tramp.
+
 ## 2.7.0 (2022-11-22)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -697,7 +697,7 @@ their deletions are staged."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-git-fd-args "-H -0 -E .git -tf --strip-cwd-prefix"
+(defcustom projectile-git-fd-args "-H -0 -E .git -tf --strip-cwd-prefix -c never"
   "Arguments to fd used to re-implement `git ls-files'.
 This is used with `projectile-fd-executable' when `projectile-git-use-fd'
 is non-nil."


### PR DESCRIPTION
Currently fd uses auto mode which inserts colors when used over tramp.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
