### PR TITLE
Add project types "yarn" and "pnpm" separate from "npm"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1862](https://github.com/bbatsov/projectile/pull/1862): Add project types "yarn" and "pnpm" separate from "npm".
 * [#1851](https://github.com/bbatsov/projectile/pull/1851): Add ripgrep to `projectile-commander` with binding `?p`.
 * [#1833](https://github.com/bbatsov/projectile/pull/1833): Add Julia project discovery.
 * [#1828](https://github.com/bbatsov/projectile/pull/1828): Add Nimble-based Nim project discovery.

--- a/projectile.el
+++ b/projectile.el
@@ -3321,7 +3321,7 @@ a manual COMMAND-TYPE command is created with
                                   :test "gulp test")
 (projectile-register-project-type 'npm '("package.json" "package-lock.json")
                                   :project-file "package.json"
-                                  :compile "npm install"
+                                  :compile "npm install && npm run build"
                                   :test "npm test"
                                   :test-suffix ".test")
 (projectile-register-project-type 'yarn '("package.json" "yarn.lock")

--- a/projectile.el
+++ b/projectile.el
@@ -3319,10 +3319,15 @@ a manual COMMAND-TYPE command is created with
                                   :project-file "gulpfile.js"
                                   :compile "gulp"
                                   :test "gulp test")
-(projectile-register-project-type 'npm '("package.json")
+(projectile-register-project-type 'npm '("package.json" "package-lock.json")
                                   :project-file "package.json"
                                   :compile "npm install"
                                   :test "npm test"
+                                  :test-suffix ".test")
+(projectile-register-project-type 'yarn '("package.json" "yarn.lock")
+                                  :project-file "package.json"
+                                  :compile "yarn && yarn build"
+                                  :test "yarn test"
                                   :test-suffix ".test")
 ;; Angular
 (projectile-register-project-type 'angular '("angular.json" ".angular-cli.json")

--- a/projectile.el
+++ b/projectile.el
@@ -3329,6 +3329,11 @@ a manual COMMAND-TYPE command is created with
                                   :compile "yarn && yarn build"
                                   :test "yarn test"
                                   :test-suffix ".test")
+(projectile-register-project-type 'pnpm '("package.json" "pnpm-lock.yaml")
+                                  :project-file "package.json"
+                                  :compile "pnpm install && pnpm build"
+                                  :test "pnpm test"
+                                  :test-suffix ".test")
 ;; Angular
 (projectile-register-project-type 'angular '("angular.json" ".angular-cli.json")
                                   :project-file "angular.json"


### PR DESCRIPTION
Yarn and pnpm are two popular alternatives to npm and you can tell which is used in a project by the existence of their respective lock files.

Plus, the `build` script is worth being a default "compile" command for npm-based projects.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
