### PR TITLE
[Fix #1835] Reopening existing vterm buffer in other window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@
 * [#1831](https://github.com/bbatsov/projectile/issues/1831): Enable the project.el integration only when `projectile-mode` is active.
 * [#1847](https://github.com/bbatsov/projectile/issues/1847): Use literal directory name casing when toggling between impl and test.
 
-### Bug fixed
+### Bugs fixed
 
 * Fix `fd` inserting color control sequences when used over tramp.
+* [#1835](https://github.com/bbatsov/projectile/issues/1835): Reopening existing vterm buffer in other window
 
 ## 2.7.0 (2022-11-22)
 

--- a/projectile.el
+++ b/projectile.el
@@ -4528,14 +4528,16 @@ be displayed in a different window.
 Switch to the project specific term buffer if it already exists."
   (let* ((project (projectile-acquire-root))
          (buffer (projectile-generate-process-name "vterm" new-process project)))
-    (unless (buffer-live-p (get-buffer buffer))
-      (unless (require 'vterm nil 'noerror)
-        (error "Package 'vterm' is not available"))
+    (unless (require 'vterm nil 'noerror)
+      (error "Package 'vterm' is not available"))
+    (if (buffer-live-p (get-buffer buffer))
+        (if other-window
+            (switch-to-buffer-other-window buffer)
+          (switch-to-buffer buffer))
       (projectile-with-default-dir project
         (if other-window
             (vterm-other-window buffer)
-          (vterm buffer))))
-    (switch-to-buffer buffer)))
+          (vterm buffer))))))
 
 ;;;###autoload
 (defun projectile-run-vterm (&optional arg)


### PR DESCRIPTION
This's a small fix to allow reopening an existing vterm buffer in other window. Changed the behavior to check if there's an existing buffer and take into consideration the `other-window` indication and do the switching accordingly.

-----------------

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)