### PR TITLE
[Fix #1853] `projectile-generic-command` should use `projectile-fd-executable` to find the path for fd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 * Fix `fd` inserting color control sequences when used over tramp.
 * [#1835](https://github.com/bbatsov/projectile/issues/1835): Reopening existing vterm buffer in other window
+* [#1865](https://github.com/bbatsov/projectile/pull/1865): `projectile-generic-command` should use `projectile-fd-executable` to find the path for fd.
 
 ## 2.7.0 (2022-11-22)
 

--- a/projectile.el
+++ b/projectile.el
@@ -755,11 +755,8 @@ Set to nil to disable listing submodules contents."
   (cond
    ;; we prefer fd over find
    ;; note that --strip-cwd-prefix is only available in version 8.3.0+
-   ((executable-find "fd")
-    "fd . -0 --type f --color=never --strip-cwd-prefix")
-   ;; fd's executable is named fdfind is some Linux distros (e.g. Ubuntu)
-   ((executable-find "fdfind")
-    "fdfind . -0 --type f --color=never --strip-cwd-prefix")
+   (projectile-fd-executable
+    (format "%s . -0 --type f --color=never --strip-cwd-prefix" projectile-fd-executable))
    ;; with find we have to be careful to strip the ./ from the paths
    ;; see https://stackoverflow.com/questions/2596462/how-to-strip-leading-in-unix-find
    (t "find . -type f | cut -c3- | tr '\\n' '\\0'"))


### PR DESCRIPTION
Closes #1853 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
