### PR TITLE
Check for project-root before adding overload

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -6155,8 +6155,11 @@ when opening new files."
 ;; it's safe to require this directly, as it was added in Emacs 25.1
 (require 'project)
 
-(cl-defmethod project-root ((project (head projectile)))
-  (cdr project))
+;; Only define an override for project-root if the method exists.  For versions
+;; before emacs 28, project.el provided project-roots instead of project.root.
+(if (fboundp 'project-root)
+    (cl-defmethod project-root ((project (head projectile)))
+      (cdr project)))
 
 (cl-defmethod project-files ((project (head projectile)) &optional _dirs)
   (let ((root (project-root project)))


### PR DESCRIPTION
Prior to emacs 28, the `project.el` package did not provide `project-root`.  By providing an overload for `project-root`, any compatibility checks of `(fboundp 'project-root)` done by other packages will return true, even for versions that do not have `project-root`.

Fixes https://github.com/bbatsov/projectile/issues/1868.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [NA] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [NA] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
