### PR TITLE
Remove 'all' from the mill project type's compile and test commands

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3437,8 +3437,8 @@ a manual COMMAND-TYPE command is created with
                                   :project-file "build.sc"
                                   :src-dir "src/"
                                   :test-dir "test/src/"
-                                  :compile "mill all __.compile"
-                                  :test "mill all __.test"
+                                  :compile "mill __.compile"
+                                  :test "mill __.test"
                                   :test-suffix "Test")
 
 ;; Clojure


### PR DESCRIPTION
Hi!  `mill all __.xyz` is no longer supported, simply removing `all` should be equivalent, and also work on older versions.

Thanks!

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
