### PR TITLE
If the file already exists, attempt to navigate to it directly instea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#1874](https://github.com/bbatsov/projectile/pull/1874): Changes `compilation-find-file-projectile-find-compilation-buffer` to navigate directly to the file if already present on disk to help improve performance in scenarios where there are a large number of project directories.
 * [#1870](https://github.com/bbatsov/projectile/pull/1870): Add package command for CMake projects.
 
 ## 2.8.0 (2023-10-13)

--- a/projectile.el
+++ b/projectile.el
@@ -5384,14 +5384,18 @@ We enhance its functionality by appending the current project's directories
 to its search path. This way when filenames in compilation buffers can't be
 found by compilation's normal logic they are searched for in project
 directories."
-  (let* ((root (projectile-project-root))
-         (compilation-search-path
-          (if (projectile-project-p)
-              (append compilation-search-path (list root)
-                      (mapcar (lambda (f) (expand-file-name f root))
-                              (projectile-current-project-dirs)))
-            compilation-search-path)))
-    (apply orig-fun `(,marker ,filename ,directory ,@formats))))
+  ; If the file already exists, don't bother running the extra logic as the project directories might be massive (i.e. Unreal-sized).
+  (if (file-exists-p filename)
+      (apply orig-fun `(,marker ,filename ,directory ,@formats))
+
+    (let* ((root (projectile-project-root))
+           (compilation-search-path
+            (if (projectile-project-p)
+                (append compilation-search-path (list root)
+                        (mapcar (lambda (f) (expand-file-name f root))
+                                (projectile-current-project-dirs)))
+              compilation-search-path)))
+      (apply orig-fun `(,marker ,filename ,directory ,@formats)))))
 
 (defun projectile-open-projects ()
   "Return a list of all open projects.


### PR DESCRIPTION
This tiny PR proposes to improve how `compilation-find-file-projectile-find-compilation-buffer` works by directly navigating to the file if already present on disk. On projects with a very large number of directories (i.e. where the projectile cache exceeds 2GB, as is common when working on Unreal projects), this can make the difference between navigating to a file from the compilation buffer instantly VS waiting for potentially upwards of 30s.
