### PR TITLE
vcs: add Sapling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * [#1870](https://github.com/bbatsov/projectile/pull/1870): Add package command for CMake projects.
+* [#1875](https://github.com/bbatsov/projectile/pull/1875): Add support for Sapling VCS.
 
 ## 2.8.0 (2023-10-13)
 

--- a/doc/modules/ROOT/pages/faq.adoc
+++ b/doc/modules/ROOT/pages/faq.adoc
@@ -59,7 +59,7 @@ automatically used when appropriate to improve performance.
 
 Inside version control repositories, VC tools are used when installed
 to list files more efficiently. The supported tools include git, hg,
-fossil, bzr, darcs, pijul, and svn.
+fossil, bzr, darcs, pijul, svn, and sapling.
 
 Outside version control repositories, file search tools are used when
 installed for a faster search than pure Elisp. The supported tools

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -31,6 +31,7 @@ a project. Out of the box Projectile supports:
 * CVS
 * Fossil
 * Darcs
+* Sapling
 
 === File markers
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -52,7 +52,7 @@ automatically used when appropriate to improve performance.
 
 Inside version control repositories, VC tools are used when installed
 to list files more efficiently. The supported tools include git, hg,
-fossil, bzr, darcs, pijul, and svn.
+fossil, bzr, darcs, pijul, svn, and sapling.
 
 Outside version control repositories, file search tools are used when
 installed for a faster search than pure Elisp. The supported tools

--- a/projectile.el
+++ b/projectile.el
@@ -331,6 +331,7 @@ See `projectile-register-project-type'."
     ".bzr"        ; Bazaar VCS root dir
     "_darcs"      ; Darcs VCS root dir
     ".pijul"      ; Pijul VCS root dir
+    ".sl"         ; Sapling VCS root dir
     )
   "A list of files considered to mark the root of a project.
 The bottommost (parentmost) match has precedence."
@@ -424,7 +425,8 @@ is set to `alien'."
     "^\\.stack-work$"
     "^\\.ccls-cache$"
     "^\\.cache$"
-    "^\\.clangd$")
+    "^\\.clangd$"
+    "^\\.sl$")
   "A list of directories globally ignored by projectile.
 Regular expressions can be used.
 
@@ -720,6 +722,11 @@ Set to nil to disable listing submodules contents."
 
 (defcustom projectile-hg-command "hg locate -f -0 -I ."
   "Command used by projectile to get the files in a hg project."
+  :group 'projectile
+  :type 'string)
+
+(defcustom projectile-sapling-command "sl locate -0 -I ."
+  "Command used by projectile to get the files in a Sapling project."
   :group 'projectile
   :type 'string)
 
@@ -1460,6 +1467,7 @@ Fallback to a generic command when not in a VCS-controlled project."
     ('darcs projectile-darcs-command)
     ('pijul projectile-pijul-command)
     ('svn projectile-svn-command)
+    ('sapling projectile-sapling-command)
     (_ projectile-generic-command)))
 
 (defun projectile-get-sub-projects-command (vcs)
@@ -3649,6 +3657,7 @@ the variable `projectile-project-root'."
    ((projectile-file-exists-p (expand-file-name "_darcs" project-root)) 'darcs)
    ((projectile-file-exists-p (expand-file-name ".pijul" project-root)) 'pijul)
    ((projectile-file-exists-p (expand-file-name ".svn" project-root)) 'svn)
+   ((projectile-file-exists-p (expand-file-name ".sl" project-root)) 'sapling)
    ;; then we check if there's a VCS marker up the directory tree
    ;; that covers the case when a project is part of a multi-project repository
    ;; in those cases you can still the VCS to get a list of files for
@@ -3661,6 +3670,7 @@ the variable `projectile-project-root'."
    ((projectile-locate-dominating-file project-root "_darcs") 'darcs)
    ((projectile-locate-dominating-file project-root ".pijul") 'pijul)
    ((projectile-locate-dominating-file project-root ".svn") 'svn)
+   ((projectile-locate-dominating-file project-root ".sl") 'sapling)
    (t 'none)))
 
 (defun projectile--test-name-for-impl-name (impl-file-path)


### PR DESCRIPTION
This PR adds support for detecting projects using [Sapling VCS](https://sapling-scm.com/).

Sapling is a Meta maintained fork of Mercurial. It uses `.sl` as the state directory instead of `.hg` to avoid compatibility issues with Mercurial. See this page for comparison with Mercurial: https://sapling-scm.com/docs/introduction/differences-hg

**Testing**

1. Load projectile with changes from this PR
2. Open a project managed with Sapling
3. Run `M-x projectile-project-info`:

<img width="793" alt="image" src="https://github.com/bbatsov/projectile/assets/409951/094d4ee7-9735-4066-ac25-89fcca4b39b5">

4. Run `M-x projectile-find-file`:

<img width="598" alt="image" src="https://github.com/bbatsov/projectile/assets/409951/7bc33918-fc0f-4684-b5d4-6b0a69c04a95">



-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warningsn
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
