### PR TITLE
vcs: add Jujutsu support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#1870](https://github.com/bbatsov/projectile/pull/1870): Add package command for CMake projects.
 * [#1875](https://github.com/bbatsov/projectile/pull/1875): Add support for Sapling VCS.
+* [#1876](https://github.com/bbatsov/projectile/pull/1876): Add support for Jujutsu VCS.
 
 ## 2.8.0 (2023-10-13)
 

--- a/doc/modules/ROOT/pages/faq.adoc
+++ b/doc/modules/ROOT/pages/faq.adoc
@@ -59,7 +59,7 @@ automatically used when appropriate to improve performance.
 
 Inside version control repositories, VC tools are used when installed
 to list files more efficiently. The supported tools include git, hg,
-fossil, bzr, darcs, pijul, svn, and sapling.
+fossil, bzr, darcs, pijul, svn, sapling and jujutsu.
 
 Outside version control repositories, file search tools are used when
 installed for a faster search than pure Elisp. The supported tools

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -32,6 +32,7 @@ a project. Out of the box Projectile supports:
 * Fossil
 * Darcs
 * Sapling
+* Jujutsu
 
 === File markers
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -52,7 +52,7 @@ automatically used when appropriate to improve performance.
 
 Inside version control repositories, VC tools are used when installed
 to list files more efficiently. The supported tools include git, hg,
-fossil, bzr, darcs, pijul, svn, and sapling.
+fossil, bzr, darcs, pijul, svn, sapling and jujutsu.
 
 Outside version control repositories, file search tools are used when
 installed for a faster search than pure Elisp. The supported tools

--- a/projectile.el
+++ b/projectile.el
@@ -332,6 +332,7 @@ See `projectile-register-project-type'."
     "_darcs"      ; Darcs VCS root dir
     ".pijul"      ; Pijul VCS root dir
     ".sl"         ; Sapling VCS root dir
+    ".jj"         ; Jujutsu VCS root dir
     )
   "A list of files considered to mark the root of a project.
 The bottommost (parentmost) match has precedence."
@@ -426,7 +427,8 @@ is set to `alien'."
     "^\\.ccls-cache$"
     "^\\.cache$"
     "^\\.clangd$"
-    "^\\.sl$")
+    "^\\.sl$"
+    "^\\.jj$")
   "A list of directories globally ignored by projectile.
 Regular expressions can be used.
 
@@ -724,6 +726,12 @@ Set to nil to disable listing submodules contents."
   "Command used by projectile to get the files in a hg project."
   :group 'projectile
   :type 'string)
+
+(defcustom projectile-jj-command "jj files --no-pager ."
+  "Command used by projectile to get the files in a Jujutsu project."
+  :group 'projectile
+  :type 'string
+  :package-version '(projectile . "2.9.0"))
 
 (defcustom projectile-sapling-command "sl locate -0 -I ."
   "Command used by projectile to get the files in a Sapling project."
@@ -1469,6 +1477,7 @@ Fallback to a generic command when not in a VCS-controlled project."
     ('pijul projectile-pijul-command)
     ('svn projectile-svn-command)
     ('sapling projectile-sapling-command)
+    ('jj projectile-jj-command)
     (_ projectile-generic-command)))
 
 (defun projectile-get-sub-projects-command (vcs)
@@ -3659,6 +3668,7 @@ the variable `projectile-project-root'."
    ((projectile-file-exists-p (expand-file-name ".pijul" project-root)) 'pijul)
    ((projectile-file-exists-p (expand-file-name ".svn" project-root)) 'svn)
    ((projectile-file-exists-p (expand-file-name ".sl" project-root)) 'sapling)
+   ((projectile-file-exists-p (expand-file-name ".jj" project-root)) 'jj)
    ;; then we check if there's a VCS marker up the directory tree
    ;; that covers the case when a project is part of a multi-project repository
    ;; in those cases you can still the VCS to get a list of files for
@@ -3672,6 +3682,7 @@ the variable `projectile-project-root'."
    ((projectile-locate-dominating-file project-root ".pijul") 'pijul)
    ((projectile-locate-dominating-file project-root ".svn") 'svn)
    ((projectile-locate-dominating-file project-root ".sl") 'sapling)
+   ((projectile-locate-dominating-file project-root ".jj") 'jj)
    (t 'none)))
 
 (defun projectile--test-name-for-impl-name (impl-file-path)


### PR DESCRIPTION
Support for detecting  [Jujutsu](https://martinvonz.github.io/jj/) projects.

[Jujutsu](https://github.com/martinvonz/jj) is a VCS  which designed to working with multiple backend. Jujutsu is designed so that the underlying data and storage model is abstract. Today, it features two [backends](https://martinvonz.github.io/jj/latest/glossary#backend)—one of them uses a Git repository for storage, while the other is a native storage backend[1](https://github.com/bbatsov/projectile/pull/1876#user-content-fn-native-backend-2510681dc52b19e0675a59b0446e2fec).

  *It also  planed to replace Mercurial as an internal monorepo client at Google. (See the [slides](https://docs.google.com/presentation/d/1F8j9_UOOSGUN9MvHxPZX_L4bQ9NMcYOp1isn17kTC_M/view))


**Testing**
Manually verified that `projectile-project-info` and `projectile-find-file`  working properly.
<img width="576" alt="스크린샷 2024-01-20 오후 8 46 00" src="https://github.com/bbatsov/projectile/assets/1310758/d06b7da6-87a3-4993-b9ed-304aa48b8c67">
<img width="584" alt="스크린샷 2024-01-20 오후 8 46 24" src="https://github.com/bbatsov/projectile/assets/1310758/1fa5f097-669b-41c1-acef-9a9f673a930d">

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
