### PR TITLE
Add new custom variable 'projectile-cmd-hist-ignoredups'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1870](https://github.com/bbatsov/projectile/pull/1870): Add package command for CMake projects.
 * [#1875](https://github.com/bbatsov/projectile/pull/1875): Add support for Sapling VCS.
 * [#1876](https://github.com/bbatsov/projectile/pull/1876): Add support for Jujutsu VCS.
+* [#1877](https://github.com/bbatsov/projectile/pull/1877): Add custom variable `projectile-cmd-hist-ignoredups`.
 
 ## 2.8.0 (2023-10-13)
 

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -838,3 +838,9 @@ external command or an Emacs Lisp function:
 In addition caching of commands can be disabled by setting the variable
 `projectile-project-enable-cmd-caching` is to `nil`. This is useful for
 preset-based CMake projects.
+
+By default, Projectile will not add consecutive duplicate commands to its
+command history.  To alter this behaviour you can use `projectile-cmd-hist-ignoredups`.
+  The default value of `t` means consecutive duplicates are ignore, a value
+of `nil` means nothing is ignored, and a value of `'erase'` means only
+the last duplicate is kept in the command history.


### PR DESCRIPTION
Hi!  This PR adds new custom variable `projectile-cmd-hist-ignoredups`, which can be used to tweak how duplicates are dealt with in projectile's command history.  The custom variable is more or less identical in behaviour to `eshell-hist-ignoredups`.

Specifically, the existing default behavior is maintained with the value of `t`, which means consecutive duplicates are ignored.  A value of `'erase` means only the last duplicate is kept, whilst a value of `nil` means all duplicates are kept.

(PR is an iteration on https://github.com/bbatsov/projectile/pull/1774)

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
