### PR TITLE
Fix `projectile-jj-command`

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -727,7 +727,7 @@ Set to nil to disable listing submodules contents."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-jj-command "jj files --no-pager ."
+(defcustom projectile-jj-command "jj files --no-pager . | tr '\\n' '\\0'"
   "Command used by projectile to get the files in a Jujutsu project."
   :group 'projectile
   :type 'string


### PR DESCRIPTION
 Hi, Sorry, i made mistake on my previous PR #1876
  Didn't push latest change :( .
 For correctly parsing file list, This PR added  piped shell command `tr '\\n' '\\0` to `projectile-jj-command` 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
