### PR TITLE
projectile-current-project-on-switch 'keep moves current project to front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#1875](https://github.com/bbatsov/projectile/pull/1875): Add support for Sapling VCS.
 * [#1876](https://github.com/bbatsov/projectile/pull/1876): Add support for Jujutsu VCS.
 * [#1877](https://github.com/bbatsov/projectile/pull/1877): Add custom variable `projectile-cmd-hist-ignoredups`.
+* [#1879](https://github.com/bbatsov/projectile/pull/1879): Modify the keep projectile-current-project-on-switch to move the current project to the front.
 * Add support for Eask projects.
 
 ### Bugs fixed

--- a/projectile.el
+++ b/projectile.el
@@ -862,7 +862,8 @@ position."
   :type '(radio
           (const :tag "Remove" remove)
           (const :tag "Move to end" move-to-end)
-          (const :tag "Keep" keep)))
+          (const :tag "Keep" keep)
+          (const :tag "Move to front" front)))
 
 (defcustom projectile-max-file-buffer-count nil
   "Maximum number of file buffers per project that are kept open.
@@ -5468,12 +5469,21 @@ An open project is a project with any open buffers."
        (list (abbreviate-file-name project)))
     projects))
 
+(defun projectile--move-current-project-to-front (projects)
+  "Move current project (if any) to the start of list in the list of PROJECTS."
+  (if-let ((project (projectile-project-root)))
+      (append
+       (list (abbreviate-file-name project))
+       (projectile--remove-current-project projects))
+    projects))
+
 (defun projectile-relevant-known-projects ()
   "Return a list of known projects."
   (pcase projectile-current-project-on-switch
     ('remove (projectile--remove-current-project projectile-known-projects))
     ('move-to-end (projectile--move-current-project-to-end projectile-known-projects))
-    ('keep projectile-known-projects)))
+    ('keep projectile-known-projects)
+    ('front (projectile--move-current-project-to-front projectile-known-projects))))
 
 (defun projectile-relevant-open-projects ()
   "Return a list of open projects."
@@ -5481,7 +5491,8 @@ An open project is a project with any open buffers."
     (pcase projectile-current-project-on-switch
       ('remove (projectile--remove-current-project open-projects))
       ('move-to-end (projectile--move-current-project-to-end open-projects))
-      ('keep open-projects))))
+      ('keep open-projects)
+      ('front (projectile--move-current-project-to-front open-projects)))))
 
 ;;;###autoload
 (defun projectile-switch-project (&optional arg)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1832,7 +1832,21 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
       (spy-on 'projectile-project-root :and-return-value "~/foo/")
       (let ((projectile-current-project-on-switch 'keep)
             (projectile-known-projects known-projects))
-        (expect (projectile-relevant-known-projects) :to-equal '("~/foo/" "~/bar/" "~/baz/"))))))
+        (expect (projectile-relevant-known-projects) :to-equal '("~/foo/" "~/bar/" "~/baz/")))))
+
+  (describe "when projectile-current-project-on-switch is 'front; find-file hook not run"
+    (it "returns projectile-known-projects"
+      (spy-on 'projectile-project-root :and-return-value "~/qux/")
+      (let ((projectile-current-project-on-switch 'front)
+            (projectile-known-projects known-projects))
+        (expect (projectile-relevant-known-projects) :to-equal '("~/qux/" "~/foo/" "~/bar/" "~/baz/")))))
+
+  (describe "when projectile-current-project-on-switch is 'front"
+    (it "returns projectile-known-projects"
+      (spy-on 'projectile-project-root :and-return-value "~/bar/")
+      (let ((projectile-current-project-on-switch 'front)
+            (projectile-known-projects known-projects))
+        (expect (projectile-relevant-known-projects) :to-equal '("~/bar/" "~/foo/" "~/baz/"))))))
 
 (describe "projectile-relevant-open-projects"
   (describe "when projectile-current-project-on-switch is 'remove"


### PR DESCRIPTION
## Problem

There are certain modes for which the
`projectile-find-file-hook-function` function does not run by
default. This includes, `shell`, `eshell`, and `magit`. If one
navigates directly to one of these buffers and calls
`projectile-relevant-known-projects` while
`projectile-current-project-on-switch` is set to `'keep` they will
notice that the first repository in the list is not the one that they
expect

## Solution

There are three possible solutions that come immediately to mind. I
want to mention all three of them for consideration though naturally
this PR only implements one of them:
1. Have users instrument all modes to call `projectile-find-file-hook-function`
2. Modify this code to do what is "expected"
3. Modify `projectile-mode` to add the hook to all possible modes

I've opted with Solution `2` because it feels more robust in the long
term, as new modes appear more changes will not be required. It also
provides less of burden on package users.

The principle drawback is that it will _not_ be added to the projects
list in this case so navigating to a different buffer will not save
the position of this project. This issue can be solved by a further
modification where any call to `projectile-relevant-known-projects`
(or any other function in this call chain) will lead to an update to
the list of projects. I'd be willing to take that on as well.

Solution `3` also feel promising, not sure if we could do something
with `eval-after-load`

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
      I've added a new test that was failing before my change and passes now
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
      All existing tests continue to pass without modification implying that
      no defined behavior was chagned
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!