### PR TITLE
Fix projectile-recentf with inactive project (#1881)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * [#1877](https://github.com/bbatsov/projectile/pull/1877): Add custom variable `projectile-cmd-hist-ignoredups`.
 * Add support for Eask projects.
 
+### Bugs fixed
+
+* [#1881](https://github.com/bbatsov/projectile/issues/1881): Fix projectile-recentf when called outside any project
+
 ## 2.8.0 (2023-10-13)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -4933,7 +4933,7 @@ directory to open."
 (defun projectile-recentf-files ()
   "Return a list of recently visited files in a project."
   (and (boundp 'recentf-list)
-       (let ((project-root (projectile-acquire-root)))
+       (let ((project-root (expand-file-name (projectile-acquire-root))))
          (mapcar
           (lambda (f) (file-relative-name f project-root))
           (cl-remove-if-not


### PR DESCRIPTION
projectile-recentf-files expands recentf files to use canonicalized versions, /home/example/project instead of ~/project. However, if the project is not active and projectile-recentf was called, it would return non-canonicalized directory which then fails the comparison with recentf list.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
