### PR TITLE
Add an explicit dependency on project.el

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * [#1877](https://github.com/bbatsov/projectile/pull/1877): Add custom variable `projectile-cmd-hist-ignoredups`.
 * Add support for Eask projects.
 
+### Changes
+
+* [#1883](https://github.com/bbatsov/projectile/pull/1883): Add an explicit dependency on `project`, so that the latest version will be installed rather than the built-in version, if using a package manager that installs the latest versions of packages by default.
+
 ### Bugs fixed
 
 * [#1881](https://github.com/bbatsov/projectile/issues/1881): Fix `projectile-recentf` when called outside any project.

--- a/Eldev
+++ b/Eldev
@@ -1,1 +1,2 @@
+(eldev-use-package-archive 'gnu-elpa)
 (eldev-use-package-archive 'melpa)

--- a/projectile.el
+++ b/projectile.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/bbatsov/projectile
 ;; Keywords: project, convenience
 ;; Version: 2.9.0-snapshot
-;; Package-Requires: ((emacs "25.1"))
+;; Package-Requires: ((emacs "25.1") (project "0.1"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
This change would resolve https://github.com/radian-software/straight.el/issues/1146. The issue is explained in detail in https://github.com/radian-software/straight.el/issues/1146#issuecomment-1949638006. I think it would be correct for `projectile` to declare an explicit dependency on `project`, since it uses the latter library. This is generally common practice for other packages that depend on built-in Emacs libraries that are also distributed on GNU ELPA, so that it can be communicated what the minimum version requirement is. It has the side effect that package managers like `straight.el` know the dependencies and can correctly determine whether the latest version should be installed, or whether to fall back to the built-in version.

I'm not sure what the minimum required version of `project` is. I set it to the first version that was tagged in GNU ELPA. By specifying a minimum version we reduce the chance of issues, because users of most package managers will be automatically prompted to upgrade to a supported version of `project` if their built-in version is too old. Please feel free to bump this version to a larger value if newer features of `project` are required.

(Will edit PR to address below checkboxes and fix CI.)

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
