### PR TITLE
Support OSC-SCM

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -41,6 +41,8 @@
 (require 'ibuf-ext)
 (require 'compile)
 (require 'grep)
+(require 'lisp-mnt)
+(require 'xml)
 (eval-when-compile
   (require 'find-dired)
   (require 'subr-x))
@@ -350,6 +352,7 @@ See `projectile-register-project-type'."
     ".pijul"      ; Pijul VCS root dir
     ".sl"         ; Sapling VCS root dir
     ".jj"         ; Jujutsu VCS root dir
+    ".osc"        ; Osc VCS root dir
     )
   "A list of files considered to mark the root of a project.
 The bottommost (parentmost) match has precedence."
@@ -445,7 +448,8 @@ is set to `alien'."
     ".cache"
     ".clangd"
     ".sl"
-    ".jj")
+    ".jj"
+    "*\\.osc$")
   "A list of directories globally ignored by projectile.
 
 Strings that don't start with * are only ignored at the top level
@@ -800,6 +804,10 @@ Set to nil to disable listing submodules contents."
   "Command used by projectile to get the files in a svn project."
   :group 'projectile
   :type 'string)
+(defcustom projectile-osc-command #'projectile-osc-command-files
+    "Command used by projectile to get the files in a svn project."
+  :group 'projectile
+  :type '(function string))
 
 (defcustom projectile-generic-command
   (cond
@@ -1548,7 +1556,21 @@ Fallback to a generic command when not in a VCS-controlled project."
     ('svn projectile-svn-command)
     ('sapling projectile-sapling-command)
     ('jj projectile-jj-command)
+    ('osc projectile-osc-command)
     (_ projectile-generic-command)))
+
+
+(defun projectile-osc-command-files (&optional root)
+  "Return files of osc vcs, return either packages or files belonging to package."
+  (or root (setq root default-directory))
+  (let* ((files_ (car (xml-parse-file (if (file-exists-p ".osc/_files")
+                                          (expand-file-name ".osc/_files")
+                                        (if (file-exists-p ".osc/_packages")
+                                            (expand-file-name ".osc/_packages")
+                                        (error "Directory neither osc package or project"))))))
+         (entries (or (xml-get-children files_ 'entry)
+                      (xml-get-children files_ 'package))))
+    (mapcar (lambda (entry) (xml-get-attribute entry 'name)) entries)))
 
 (defun projectile-get-sub-projects-command (vcs)
   "Get the sub-projects command for VCS.
@@ -1646,12 +1668,15 @@ If `command' is nil or an empty string, return nil.
 This allows commands to be disabled.
 
 Only text sent to standard output is taken into account."
-  (when (stringp command)
+  (when (or (stringp command)
+             (functionp command))
     (let ((default-directory root))
+      (if (functionp command)
+          (funcall command root)
       (with-temp-buffer
         (shell-command command t "*projectile-files-errors*")
         (let ((shell-output (buffer-substring (point-min) (point-max))))
-          (split-string (string-trim shell-output) "\0" t))))))
+          (split-string (string-trim shell-output) "\0" t)))))))
 
 (defun projectile-adjust-files (project vcs files)
   "First remove ignored files from FILES, then add back unignored files."
@@ -3797,6 +3822,7 @@ the variable `projectile-project-root'."
    ((projectile-file-exists-p (expand-file-name ".svn" project-root)) 'svn)
    ((projectile-file-exists-p (expand-file-name ".sl" project-root)) 'sapling)
    ((projectile-file-exists-p (expand-file-name ".jj" project-root)) 'jj)
+   ((projectile-file-exists-p (expand-file-name ".osc" project-root)) 'osc)
    ;; then we check if there's a VCS marker up the directory tree
    ;; that covers the case when a project is part of a multi-project repository
    ;; in those cases you can still the VCS to get a list of files for
@@ -3811,6 +3837,7 @@ the variable `projectile-project-root'."
    ((projectile-locate-dominating-file project-root ".svn") 'svn)
    ((projectile-locate-dominating-file project-root ".sl") 'sapling)
    ((projectile-locate-dominating-file project-root ".jj") 'jj)
+   ((projectile-locate-dominating-file project-root ".osc") 'osc)
    (t 'none)))
 
 (defun projectile--test-name-for-impl-name (impl-file-path)


### PR DESCRIPTION
-------

Support the OSC SCM as used in the open build service.
OSC can be used with vcs-osc in Emacs.

The code is wip but I wanted to post this PR to get some feedback
and show progress working on it.

Osc works a little different than other scms where there two different
types of repositories, one containing packages and the other being a package.
The type that is package works very much like a regular scm where commands
such as those to open project files work as a user would expect.

But for the project type the commands referring to files target the packages the project
contains.

I've implemented the functionality using the builtin XML functionality as that is the easiest
since osc's own files use XML.

I'm not exactly sure how to add test, any help is appreciated.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)