### PR TITLE
Add category metadata to completing-read

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2072,7 +2072,13 @@ project-root for every file."
                       ((bound-and-true-p ivy-mode)  'ivy)
                       (t 'default))
                    projectile-completion-system)
-            ('default (completing-read prompt choices nil nil initial-input))
+            ('default (completing-read prompt (lambda (string pred action)
+                                                (cond
+                                                 ((eq action 'metadata)
+                                                  '(metadata . ((category . file))))
+                                                 (t
+                                                  (complete-with-action action choices string pred))))
+                                       nil nil initial-input))
             ('ido (ido-completing-read prompt choices nil nil initial-input))
             ('helm
              (if (and (fboundp 'helm)


### PR DESCRIPTION
I added the metadata only to the default Emacs `completing-read`. as I am not familiar with the 3rd party systems helm and ivy.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

I'm not sure about checking the last 2 checkboxes. The changes are only ***visible*** if using third-party packages like
[marginalia](https://github.com/minad/marginalia) and [embark](https://github.com/oantolin/embark) which use the metadata.

`projectile-switch-project` without metadata:

![image](https://github.com/bbatsov/projectile/assets/52547/d65b7123-3580-4a18-ab2d-b0ae7e7e1b9d)

with metadata: 
![image](https://github.com/bbatsov/projectile/assets/52547/6880a342-69c0-48b8-bb86-314200cf3ad9)

