### PR TITLE
Add 'front option to projectile-current-project-on-switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#1875](https://github.com/bbatsov/projectile/pull/1875): Add support for Sapling VCS.
 * [#1876](https://github.com/bbatsov/projectile/pull/1876): Add support for Jujutsu VCS.
 * [#1877](https://github.com/bbatsov/projectile/pull/1877): Add custom variable `projectile-cmd-hist-ignoredups`.
+* [#1894](https://github.com/bbatsov/projectile/pull/1894): Modify the projectile-current-project-on-switch to support a new 'front option such that the buffers' current project will always be at the front of the known projects.
 * Add support for Eask projects.
 
 ### Bugs fixed

--- a/projectile.el
+++ b/projectile.el
@@ -862,7 +862,8 @@ position."
   :type '(radio
           (const :tag "Remove" remove)
           (const :tag "Move to end" move-to-end)
-          (const :tag "Keep" keep)))
+          (const :tag "Keep" keep)
+          (const :tag "Move to front" front)))
 
 (defcustom projectile-max-file-buffer-count nil
   "Maximum number of file buffers per project that are kept open.
@@ -5468,12 +5469,21 @@ An open project is a project with any open buffers."
        (list (abbreviate-file-name project)))
     projects))
 
+(defun projectile--move-current-project-to-front (projects)
+  "Move current project (if any) to the start of list in the list of PROJECTS."
+  (if-let ((project (projectile-project-root)))
+      (append
+       (list (abbreviate-file-name project))
+       (projectile--remove-current-project projects))
+    projects))
+
 (defun projectile-relevant-known-projects ()
   "Return a list of known projects."
   (pcase projectile-current-project-on-switch
     ('remove (projectile--remove-current-project projectile-known-projects))
     ('move-to-end (projectile--move-current-project-to-end projectile-known-projects))
-    ('keep projectile-known-projects)))
+    ('keep projectile-known-projects)
+    ('front (projectile--move-current-project-to-front projectile-known-projects))))
 
 (defun projectile-relevant-open-projects ()
   "Return a list of open projects."
@@ -5481,7 +5491,8 @@ An open project is a project with any open buffers."
     (pcase projectile-current-project-on-switch
       ('remove (projectile--remove-current-project open-projects))
       ('move-to-end (projectile--move-current-project-to-end open-projects))
-      ('keep open-projects))))
+      ('keep open-projects)
+      ('front (projectile--move-current-project-to-front open-projects)))))
 
 ;;;###autoload
 (defun projectile-switch-project (&optional arg)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1832,7 +1832,21 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
       (spy-on 'projectile-project-root :and-return-value "~/foo/")
       (let ((projectile-current-project-on-switch 'keep)
             (projectile-known-projects known-projects))
-        (expect (projectile-relevant-known-projects) :to-equal '("~/foo/" "~/bar/" "~/baz/"))))))
+        (expect (projectile-relevant-known-projects) :to-equal '("~/foo/" "~/bar/" "~/baz/")))))
+
+  (describe "when projectile-current-project-on-switch is 'front; find-file hook not run"
+    (it "returns projectile-known-projects"
+      (spy-on 'projectile-project-root :and-return-value "~/qux/")
+      (let ((projectile-current-project-on-switch 'front)
+            (projectile-known-projects known-projects))
+        (expect (projectile-relevant-known-projects) :to-equal '("~/qux/" "~/foo/" "~/bar/" "~/baz/")))))
+
+  (describe "when projectile-current-project-on-switch is 'front"
+    (it "returns projectile-known-projects"
+      (spy-on 'projectile-project-root :and-return-value "~/bar/")
+      (let ((projectile-current-project-on-switch 'front)
+            (projectile-known-projects known-projects))
+        (expect (projectile-relevant-known-projects) :to-equal '("~/bar/" "~/foo/" "~/baz/"))))))
 
 (describe "projectile-relevant-open-projects"
   (describe "when projectile-current-project-on-switch is 'remove"


### PR DESCRIPTION
# Foreword

I originally created #1879 but have since deleted that GitHub account,
as such the associated repository and pull request were closed.

This PR reopens that previous PR. #1895 on the other hand implements
Solution 2 of this pull request which I prefer.

# Problem

There are certain modes for which the
`projectile-find-file-hook-function` function does not run by
default. This includes, `shell`, `eshell`, and `magit`. If one
navigates directly to one of these buffers and calls
`projectile-relevant-known-projects` while
`projectile-current-project-on-switch` is set to `'keep` they will
notice that the first repository in the list is not the one that they
expect

# Solution

There are two possible solutions that come immediately to mind. I
want to mention both of them for consideration though naturally
this PR only implements one of them:

 1. Add a new `'front` option for
    `projectile-current-project-on-switch` such that the first item is
    the project associated with the current buffer.
 2. Modify projectile-mode to add the hook to
    `buffer-list-update-hook` such that the current buffer is always
    added to the list of known-projects.

This PR implements solution one as was done in #1879.
#1895 implements Solution 2

## Comparision

The main drawback with Solution 1 is that the newly selected project
will not be added to the projects list.

The main drawback of Solution 2 is that it will not work on versions
of emacs earlier than 28.1 because of how `buffer-list-update-hook`
behaves on those older versions.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
