### PR TITLE
Fix tests to not modify top level .dir-locals.el file

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2503,9 +2503,10 @@ With a prefix arg INVALIDATE-CACHE invalidates the cache first."
 Parameters MODE VARIABLE VALUE are passed directly to `add-dir-local-variable'."
   (let ((inhibit-read-only t)
         (default-directory (projectile-acquire-root)))
-    (add-dir-local-variable mode variable value)
-    (save-buffer)
-    (kill-buffer)))
+    (save-selected-window
+      (add-dir-local-variable mode variable value)
+      (save-buffer)
+      (kill-buffer))))
 
 ;;;###autoload
 (defun projectile-delete-dir-local-variable (mode variable)
@@ -2515,9 +2516,10 @@ Parameters MODE VARIABLE VALUE are passed directly to
 `delete-dir-local-variable'."
   (let ((inhibit-read-only t)
         (default-directory (projectile-acquire-root)))
-    (delete-dir-local-variable mode variable)
-    (save-buffer)
-    (kill-buffer)))
+    (save-selected-window
+      (delete-dir-local-variable mode variable)
+      (save-buffer)
+      (kill-buffer))))
 
 
 ;;;; Sorting project files

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1051,20 +1051,28 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
                  "project/.projectile")
                 (append-to-file
                  "((nil . ((foo . bar))))" nil "project/.dir-locals.el")
-                (with-current-buffer (find-file-noselect "project/.projectile" t)
-                  (let ((enable-local-variables :all))
-                    (hack-dir-local-variables-non-file-buffer)
+                (let ((enable-local-variables :all))
+                  (with-current-buffer (find-file-noselect "project/.projectile" t)
+                    ;; Reload the file to ensure that this file wasn't already
+                    ;; opened from a previous test
+                    (revert-buffer :ignore-auto :noconfirm)
+                    ;; Heck that the variable is bound
                     (expect (boundp 'foo) :to-be 't)
-
+                    ;; Remove the variable
                     (projectile-delete-dir-local-variable nil 'foo)
-                    (expect (boundp 'foo) :to-be nil) ))))))
+                    ;; Reload the file
+                    (revert-buffer :ignore-auto :noconfirm)
+                    ;; Check that the variable is unbound
+                    (expect (boundp 'foo) :to-be nil)))))))
 
 (describe "projectile-add-dir-local-variable"
           (it "Adds new dir-local variables"
               (projectile-test-with-sandbox
                (projectile-test-with-files
                 ("project/"
+                 "project/.dir-locals.el"
                  "project/.projectile")
+                (append-to-file "()" nil "project/.dir-locals.el")
                 (with-current-buffer (find-file-noselect "project/.projectile" t)
                   (let ((enable-local-variables :all))
                     (expect (boundp 'fooo) :to-be nil)


### PR DESCRIPTION
# Problem

When running the projectile tests locally I noticed that my top-level
`.dir-locals.el` file would get a `fooo . 1` added to it.

# Solution

Modify the test `projectile-add-dir-local-variable` such that it
creates its own `.dir-locals.el` file which it can modify. This was a
little bit finicky because `projectile-add-dir-local-variable` doesn't
restore the selected window and buffer after executing so I've fixed
that function to restore the windows as they were beforehand. When
applying a similar fix to the `...delete...` function I had to improve
that test as well

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
