### PR TITLE
Add support for xmake build utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [#1877](https://github.com/bbatsov/projectile/pull/1877): Add custom variable `projectile-cmd-hist-ignoredups`.
 * Add support for Eask projects.
 * [#1892](https://github.com/bbatsov/projectile/pull/1892): Add category metadata to `completing-read`. (it's used by packages like `marginalia` and `embark`)
-
+* [#1899](https://github.com/bbatsov/projectile/pull/1899): Add support for xmake build utility.
 ### Bugs fixed
 
 * [#1881](https://github.com/bbatsov/projectile/issues/1881): Fix `projectile-recentf` when called outside any project.

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -140,6 +140,9 @@ are the configuration files of various build tools. Out of the box the following
 
 | debian/control
 | Debian package dpkg control file
+
+| xmake.lua
+| xmake project
 |===
 
 There's also Projectile's own `.projectile` which serves both as a project marker

--- a/projectile.el
+++ b/projectile.el
@@ -3287,6 +3287,12 @@ a manual COMMAND-TYPE command is created with
 ;; File-based detection project types
 
 ;; Universal
+(projectile-register-project-type 'xmake '("xmake.lua")
+                                  :project-file "xmake.lua"
+                                  :compile "xmake build"
+                                  :test "xmake test"
+                                  :run "xmake run"
+                                  :install "xmake install")
 (projectile-register-project-type 'scons '("SConstruct")
                                   :project-file "SConstruct"
                                   :compile "scons"


### PR DESCRIPTION
Add support for the [xmake](https://xmake.io) build utility. 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
