### PR TITLE
Remove Bloop from Project File List

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3496,13 +3496,7 @@ a manual COMMAND-TYPE command is created with
 (projectile-register-project-type 'clojure-cli '("deps.edn")
                                   :project-file "deps.edn"
                                   :test-suffix "_test")
-(projectile-register-project-type 'bloop '(".bloop")
-                                  :project-file ".bloop"
-                                  :compile "bloop compile root"
-                                  :test "bloop test --propagate --reporter scalac root"
-                                  :src-dir "src/main/"
-                                  :test-dir "src/test/"
-                                  :test-suffix "Spec")
+
 ;; Ruby
 (projectile-register-project-type 'ruby-rspec '("Gemfile" "lib" "spec")
                                   :project-file "Gemfile"

--- a/projectile.el
+++ b/projectile.el
@@ -3477,6 +3477,14 @@ a manual COMMAND-TYPE command is created with
                                   :test "mill __.test"
                                   :test-suffix "Test")
 
+(projectile-register-project-type 'bloop '(".bloop/bloop.settings.json")
+                                  :project-file ".bloop/bloop.settings.json"
+                                  :compile "bloop compile root"
+                                  :test "bloop test --propagate --reporter scalac root"
+                                  :src-dir "src/main/"
+                                  :test-dir "src/test/"
+                                  :test-suffix "Spec")
+
 ;; Clojure
 (projectile-register-project-type 'lein-test '("project.clj")
                                   :project-file "project.clj"

--- a/projectile.el
+++ b/projectile.el
@@ -3477,9 +3477,7 @@ a manual COMMAND-TYPE command is created with
                                   :test "mill __.test"
                                   :test-suffix "Test")
 
-(projectile-register-project-type 'bloop '(".bloop/bloop.settings.json")
-                                  :project-file ".bloop/bloop.settings.json"
-                                  :compile "bloop compile root"
+(projectile-register-project-type 'bloop '(".bloop/bloop.settings.json")                                          :compile "bloop compile root"
                                   :test "bloop test --propagate --reporter scalac root"
                                   :src-dir "src/main/"
                                   :test-dir "src/test/"


### PR DESCRIPTION
**Bloop file is always present in Home Directory**

Hey Bbatsov, love all of your work. I was having an issue with my home directory being indexed on multiple computers, and I couldn't figure out why until I manually went through and checked against all of the `projectile-project-root-files`, since I checked against the obvious suspects and couldn't find it.

Anyway, the culprit was a `.bloop` directory in my home directory, so I checked on why this was there. According to the Bloop [documentation](https://scalacenter.github.io/bloop/docs/server-reference), this is where the bloop server places its config by default.

This was the most obvious solution to me, which is to remove this by default, since mill and sbt projects are already covered. 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
