### PR TITLE
Use 'project-file as category metadata in completing read

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2079,7 +2079,7 @@ project-root for every file."
                                                  ;; embark to enhance how they
                                                  ;; present candidates
                                                  ((eq action 'metadata)
-                                                  '(metadata . ((category . file))))
+                                                  '(metadata . ((category . project-file))))
                                                  (t
                                                   (complete-with-action action choices string pred))))
                                        nil nil initial-input))


### PR DESCRIPTION
project-file is a more suitable category for the completion (also used by project.el).

'vertico-prescient-completion-category-overrides changes the completion style for 'file to '(basic partial-completion) and limits completion to prefix matches.

Fixes #1902



-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
