### PR TITLE
Revert "Add #'projectile-track-known-projects-find-file-hook to 'buff…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#1910](https://github.com/bbatsov/projectile/pull/1910): Reverts [#1895](https://github.com/bbatsov/projectile/pull/1895) as those changes appear to cause a significant performance regression across a number of use-cases.
+
 ### New features
 
 * [#1874](https://github.com/bbatsov/projectile/pull/1874): Changes `compilation-find-file-projectile-find-compilation-buffer` to navigate directly to the file if already present on disk to help improve performance in scenarios where there are a large number of project directories.

--- a/projectile.el
+++ b/projectile.el
@@ -6291,24 +6291,14 @@ Otherwise behave as if called interactively.
       (projectile-discover-projects-in-search-path))
     (add-hook 'project-find-functions #'project-projectile)
     (add-hook 'find-file-hook 'projectile-find-file-hook-function)
-    ;; Add hooks to track which buffer is currently active.
-    ;; Note - In Emacs 28.1 `buffer-list-update-hook' was modified to no
-    ;; longer run on temporary buffers, this allows us to use it to track
-    ;; changes to the active buffer instead of relying on more specific hooks
-    ;; such as `dired-before-readin-hook'.
-    (if (version<= "28.1" emacs-version)
-        (add-hook 'buffer-list-update-hook #'projectile-track-known-projects-find-file-hook t)
-      (add-hook 'projectile-find-dir-hook #'projectile-track-known-projects-find-file-hook t)
-      (add-hook 'dired-before-readin-hook #'projectile-track-known-projects-find-file-hook t t))
-
+    (add-hook 'projectile-find-dir-hook #'projectile-track-known-projects-find-file-hook t)
+    (add-hook 'dired-before-readin-hook #'projectile-track-known-projects-find-file-hook t t)
     (advice-add 'compilation-find-file :around #'compilation-find-file-projectile-find-compilation-buffer)
     (advice-add 'delete-file :before #'delete-file-projectile-remove-from-cache))
    (t
     (remove-hook 'project-find-functions #'project-projectile)
     (remove-hook 'find-file-hook #'projectile-find-file-hook-function)
-    (if (version<= "28.1" emacs-version)
-        (remove-hook 'buffer-list-update-hook #'projectile-track-known-projects-find-file-hook)
-      (remove-hook 'dired-before-readin-hook #'projectile-track-known-projects-find-file-hook t))
+    (remove-hook 'dired-before-readin-hook #'projectile-track-known-projects-find-file-hook t)
     (advice-remove 'compilation-find-file #'compilation-find-file-projectile-find-compilation-buffer)
     (advice-remove 'delete-file #'delete-file-projectile-remove-from-cache))))
 

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1957,40 +1957,6 @@ projectile-process-current-project-buffers-current to have similar behaviour"
                 (with-current-buffer (find-file-noselect "foo" t))
                 (expect (length (projectile-project-buffers)) :to-equal 1)))))
 
-(describe "projectile-mode buffer-list-update-hook"
-          (it "check that the hooks properly update the known projects when changing files or windows"
-              (projectile-test-with-sandbox
-               (projectile-test-with-files
-                ("project1/"
-                 "project1/.projectile"
-                 "project1/foo"
-                 "project2/"
-                 "project2/.projectile"
-                 "project2/bar")
-                (find-file "project1/")
-                (projectile-mode 1)
-
-                ;; Check that opening a file leads to the known-projects being updated
-                (find-file "project1/foo")
-                (expect (mapcar (lambda (x) (file-name-base (directory-file-name x)))  projectile-known-projects)
-                        :to-equal '("project1"))
-
-                ;; Check that opening a file in a different project leads to the known-projects being updated
-                (find-file-other-window "../../project2/bar")
-                (expect (mapcar (lambda (x) (file-name-base (directory-file-name x)))  projectile-known-projects)
-                        :to-equal '("project2" "project1"))
-
-                ;; Check that selecting a different buffer also updates the known-projects
-                (other-window 1)
-                (expect (mapcar (lambda (x) (file-name-base (directory-file-name x)))  projectile-known-projects)
-                        ;; Sadly this behavior is contigent on the existance of
-                        ;; `buffer-list-update-hook' so it will behave
-                        ;; differently on older versions of Emacs that do not
-                        ;; have this variable.
-                        :to-equal (if (version<= "28.1" emacs-version)
-                                      '("project1" "project2")
-                                    '("project2" "project1")))))))
-
 (describe "projectile--impl-name-for-test-name"
   :var ((mock-projectile-project-types
          '((foo test-suffix "Test")


### PR DESCRIPTION
Responding to https://github.com/bbatsov/projectile/issues/1908

This reverts commit 3c92d28c056c3553f83a513a35502b4547d29319.

Addresses an apparent performance regression

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [-] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)