### PR TITLE
Order file markers table by file name

### DIFF
--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -42,106 +42,106 @@ are the configuration files of various build tools. Out of the box the following
 |===
 | File | Project Type
 
-| rebar.config
-| Rebar project file
-
-| project.clj
-| Leiningen project file
-
-| build.boot
-| Boot-clj project file
-
-| deps.edn
-| Clojure CLI project file
-
-| SConstruct
-| Scons project file
-
-| default.nix
-| Nix project file
-
-| flake.nix
-| Nix flake project file
-
-| pom.xml
-| Maven project file
-
-| build.sbt
-| SBT project file
-
-| build.sc
-| Mill project file
-
-| gradlew
-| Gradle wrapper script
-
-| build.gradle
-| Gradle project file
-
-| .ensime
+| `.ensime`
 | Ensime configuration file
 
-| Gemfile
-| Bundler file
-
-| requirements.txt
-| Pip file
-
-| setup.py
-| Setuptools file
-
-| tox.ini
-| Tox file
-
-| composer.json
-| Composer project file
-
-| Cargo.toml
-| Cargo project file
-
-| mix.exs
-| Elixir mix project file
-
-| stack.yaml
-| Haskell's stack tool based project
-
-| dune-project
-| OCaml Dune project file
-
-| info.rkt
-| Racket package description file
-
-| DESCRIPTION
-| R package description file
-
-| TAGS
-| etags/ctags are usually in the root of project
-
-| GTAGS
-| GNU Global tags
-
-| configure.in
-| autoconf old style
-
-| configure.ac
-| autoconf new style
-
-| cscope.out
-| cscope
-
-| Makefile
-| Make
-
-| CMakeLists.txt
+| `CMakeLists.txt`
 | CMake
 
-| WORKSPACE
+| `Cargo.toml`
+| Cargo project file
+
+| `DESCRIPTION`
+| R package description file
+
+| `GTAGS`
+| GNU Global tags
+
+| `Gemfile`
+| Bundler file
+
+| `Makefile`
+| Make
+
+| `SConstruct`
+| Scons project file
+
+| `TAGS`
+| etags/ctags are usually in the root of project
+
+| `WORKSPACE`
 | Bazel workspace file
 
-| debian/control
+| `build.boot`
+| Boot-clj project file
+
+| `build.gradle`
+| Gradle project file
+
+| `build.sbt`
+| SBT project file
+
+| `build.sc`
+| Mill project file
+
+| `composer.json`
+| Composer project file
+
+| `configure.ac`
+| autoconf new style
+
+| `configure.in`
+| autoconf old style
+
+| `cscope.out`
+| cscope
+
+| `debian/control`
 | Debian package dpkg control file
 
-| xmake.lua
+| `default.nix`
+| Nix project file
+
+| `deps.edn`
+| Clojure CLI project file
+
+| `dune-project`
+| OCaml Dune project file
+
+| `flake.nix`
+| Nix flake project file
+
+| `gradlew`
+| Gradle wrapper script
+
+| `info.rkt`
+| Racket package description file
+
+| `mix.exs`
+| Elixir mix project file
+
+| `pom.xml`
+| Maven project file
+
+| `project.clj`
+| Leiningen project file
+
+| `rebar.config`
+| Rebar project file
+
+| `requirements.txt`
+| Python Pip file
+
+| `setup.py`
+| Setuptools file
+
+| `stack.yaml`
+| Haskell's stack tool based project
+
+| `tox.ini`
+| Tox file
+
+| `xmake.lua`
 | xmake project
 |===
 


### PR DESCRIPTION
Browsing the documentation I found it cumbersome to read this table as it wasn't in alphabetical order. This commit re-orders the table by `File` column.

Perhaps a different order might be to include a column for language and order by that with sub-ordering by supported files within that language.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
