### PR TITLE
Fix searching ignored directories for ripgrep

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -4388,9 +4388,12 @@ installed to work."
    (list (projectile--read-search-string-with-default
           (format "Ripgrep %ssearch for" (if current-prefix-arg "regexp " "")))
          current-prefix-arg))
-  (let ((args (mapcar (lambda (val) (concat "--glob !" val))
+  (let ((args (mapcar (lambda (val) (concat "--glob '!" val "'"))
                       (append projectile-globally-ignored-files
-                              projectile-globally-ignored-directories))))
+                              ;; remove "^\" and "$"
+                              (mapcar (lambda (dir)
+                                        (replace-regexp-in-string "\\^\\\\\\|\\$" "" dir))
+                                      projectile-globally-ignored-directories)))))
     ;; we rely on the external packages ripgrep and rg for the actual search
     ;;
     ;; first we check if we can load ripgrep


### PR DESCRIPTION
Currently `projectile-ripgrep` does not properly hide directories of `projectile-globally-ignored-directories` as mentioned in issue #1811 . `projectile-ripgrep` produces following arguments for searching.

```bash
rg  --fixed-strings --hidden --glob !TAGS --glob !^\.idea$ --glob !^\.vscode$ ...
```

I found that there are two problems:
- Both ignored file and directory name is not quoted with `'`
- Directory name includes regexp which I believe `--glob` option does not support
  - Looking at [ripgrep's `-g` flag docstring](https://github.com/BurntSushi/ripgrep/blob/79cbe89deb1151e703f4d91b19af9cdcc128b765/crates/core/flags/defs.rs#L2482), it says that it uses gitignore rules

In this PR, I made both globally ignored file and directory names to be quoted with `'` and remove unnecessary regexp (`^\` and `$`) from `projectile-globally-ignored-directories`. This results in making arguments such as...

```bash
rg  --fixed-strings --hidden --glob '!TAGS' --glob '!.idea' --glob '!.vscode' ...
```

resulting with ripgrep properly ignoring contents of `projectile-globally-ignored-directories`.

By the way I am new to emacs lisp, so feel free to edit my changes.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
