### PR TITLE
Fix dotnet sln project type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## master (unreleased)
 
 * [#1910](https://github.com/bbatsov/projectile/pull/1910): Reverts [#1895](https://github.com/bbatsov/projectile/pull/1895) as those changes appear to cause a significant performance regression across a number of use-cases.
+* [#1915](https://github.com/bbatsov/projectile/pull/1915): Fix
+  dotnet-sln project-type recognition (check `*.sln` files instead of
+  `src/`)
 
 ### New features
 

--- a/projectile.el
+++ b/projectile.el
@@ -3058,6 +3058,12 @@ it acts on the current project."
   (or (projectile-verify-file-wildcard "?*.csproj" dir)
       (projectile-verify-file-wildcard "?*.fsproj" dir)))
 
+(defun projectile-dotnet-sln-project-p (&optional dir)
+  "Check if a project contains a .NET solution project marker.
+When DIR is specified it checks DIR's project, otherwise
+it acts on the current project."
+  (or (projectile-verify-file-wildcard "?*.sln" dir)))
+
 (defun projectile-go-project-p (&optional dir)
   "Check if a project contains Go source files.
 When DIR is specified it checks DIR's project, otherwise
@@ -3271,7 +3277,7 @@ a manual COMMAND-TYPE command is created with
                                   :compile "dotnet build"
                                   :run "dotnet run"
                                   :test "dotnet test")
-(projectile-register-project-type 'dotnet-sln '("src")
+(projectile-register-project-type 'dotnet-sln #'projectile-dotnet-sln-project-p
                                   :project-file "?*.sln"
                                   :compile "dotnet build"
                                   :run "dotnet run"

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1347,11 +1347,11 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
       (let ((projectile-indexing-method 'native))
         (spy-on 'projectile-project-root :and-return-value (file-truename (expand-file-name "project/")))
         (expect (projectile-detect-project-type) :to-equal 'emacs-eldev)))))
-  (it "detects project-type for projects with src dir and no other marker"
+  (it "detects project-type for dotnet sln projects"
     (projectile-test-with-sandbox
      (projectile-test-with-files
       ("project/"
-       "project/src/")
+       "project/Project.sln")
       (let ((projectile-indexing-method 'native))
         (spy-on 'projectile-project-root :and-return-value (file-truename (expand-file-name "project/")))
         (expect (projectile-detect-project-type) :to-equal 'dotnet-sln)))))


### PR DESCRIPTION
-------

The presence of an "src/" directory doesn't say anything about the
type of the project. This PR fixes the dotnet sln project type to rely
on the presence of an .sln file instead of the "src/" directory.


-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings **=> the code in master branch does**
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!