### PR TITLE
add variable to ignore specific projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#number](link): Add variable `projectile-non-project-roots`
 * [#1910](https://github.com/bbatsov/projectile/pull/1910): Reverts [#1895](https://github.com/bbatsov/projectile/pull/1895) as those changes appear to cause a significant performance regression across a number of use-cases.
 
 ### New features

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -515,3 +515,14 @@ NOTE: The project name & type will not appear when editing remote files
 Projectile supports https://cmake.org/cmake/help/git-stage/manual/cmake-presets.7.html[CMake presets]. Preset support is disabled by default, but can be enabled by setting `projectile-enable-cmake-presets` to non-nil. With preset-support enabled Projectile will parse the preset files and present the command-specific presets when executing a lifecycle command. In addition a `*no preset*` option is included for entering the command manually.
 
 NOTE: Preset support requires a CMake version that supports preset and for `json-parse-buffer` to be available.
+
+== Miscellaneous Configuration
+
+=== Marking dirs as not project roots
+
+TODO: explain
+
+[source,elisp]
+----
+(setq projectile-non-project-roots '(~))
+----

--- a/projectile.el
+++ b/projectile.el
@@ -908,6 +908,9 @@ Should be set via .dir-locals.el.")
 It takes precedence over the test-dir for the project type when set.
 Should be set via .dir-locals.el.")
 
+(defvar projectile-non-project-roots nil
+  "TODO: dox")
+
 
 ;;; Version information
 
@@ -1234,7 +1237,12 @@ which we're looking."
       (setq try (if (stringp name)
                     (projectile-file-exists-p (projectile-expand-file-name-wildcard name file))
                   (funcall name file)))
-      (cond (try (setq root file))
+      (cond ((and try
+                  (cl-notany (lambda (d) (string=
+                                          (expand-file-name (file-name-as-directory d))
+                                          (expand-file-name (file-name-as-directory file))))
+                             projectile-non-project-roots))
+             (setq root file))
             ((equal file (setq file (file-name-directory
                                      (directory-file-name file))))
              (setq file nil))))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -76,6 +76,7 @@ You'd normally combine this with `projectile-test-with-sandbox'."
      ,@body))
 
 (defmacro projectile-test-with-empty-cache (&rest body)
+  "TODO: dox"
   `(let ((projectile-indexing-method 'native)
          (projectile-projects-cache (make-hash-table :test 'equal))
          (projectile-projects-cache-time (make-hash-table :test 'equal))


### PR DESCRIPTION
I want to add a git repo to my home directory in order to track dotfiles (I'm aware there are other approaches that don't involve creating `~/.git/`, but for reasons beyond the scope of this PR, I want to do it this way). When I do this, in doom-emacs `doom doctor` complains

```
    ! Your $HOME is recognized as a project root
      Emacs will assume $HOME is the root of any project living under $HOME. If this
      isn't desired, you will need to remove ".git" from
      `projectile-project-root-files-bottom-up' (a variable), e.g.
      
        (after! projectile (setq projectile-project-root-files-bottom-up (remove ".git"
          projectile-project-root-files-bottom-up)))
```

Maybe I'm misunderstanding something, but it seems like the resolution here isn't something I want to do. I still want projectile to recognize dirs with `.git` as project roots, I just want it to not consider `$HOME` to be the universal project root, as threatened by `doom doctor`. Therefore, I need it to say that one or more named directories are not project roots, regardless of what the root-determination machinery would say otherwise.

So I add a variable to hold a list of such directories, and consult it inside `projectile-locate-dominating-file`.

NOTE: the PR is intentionally missing some required cleanup (like comments) in case there is something fundamentally wrong with my whole approach (I suck at elisp). That's why it's marked as a draft. AFAIK, the code itself does what it should, but I could be wrong.


-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
