### PR TITLE
Expands table of files for project markers

### DIFF
--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -40,109 +40,233 @@ Projectile considers many files to denote the root of a project. Usually those f
 are the configuration files of various build tools. Out of the box the following are supported:
 
 |===
-| File | Project Type
+| Language/Family | File | Project Type
 
-| `.ensime`
-| Ensime configuration file
+| Universal
+| `xmake.lua`
+| xmake project
 
-| `CMakeLists.txt`
-| CMake
-
-| `Cargo.toml`
-| Cargo project file
-
-| `DESCRIPTION`
-| R package description file
-
-| `GTAGS`
-| GNU Global tags
-
-| `Gemfile`
-| Bundler file
-
-| `Makefile`
-| Make
-
+| Universal
 | `SConstruct`
 | Scons project file
 
-| `TAGS`
-| etags/ctags are usually in the root of project
+| Universal
+| `meson.build`
+|  project file
 
-| `WORKSPACE`
-| Bazel workspace file
-
-| `build.boot`
-| Boot-clj project file
-
-| `build.gradle`
-| Gradle project file
-
-| `build.sbt`
-| SBT project file
-
-| `build.sc`
-| Mill project file
-
-| `composer.json`
-| Composer project file
-
-| `configure.ac`
-| autoconf new style
-
-| `configure.in`
-| autoconf old style
-
-| `cscope.out`
-| cscope
-
-| `debian/control`
-| Debian package dpkg control file
-
+| Universal
 | `default.nix`
 | Nix project file
 
-| `deps.edn`
-| Clojure CLI project file
-
-| `dune-project`
-| OCaml Dune project file
-
+| Universal
 | `flake.nix`
 | Nix flake project file
 
-| `gradlew`
-| Gradle wrapper script
+| Universal
+| `WORKSPACE`
+| Bazel workspace file
 
-| `info.rkt`
-| Racket package description file
+| Universal
+| `debian/control`
+| Debian package dpkg control file
 
-| `mix.exs`
-| Elixir mix project file
+| Make & CMake
+| `Makefile`
+| Make
 
-| `pom.xml`
-| Maven project file
+| Make & CMake
+| `GNUMakefile`
+| GNU Make
 
-| `project.clj`
-| Leiningen project file
+| Make & CMake
+| `CMakeLists.txt`
+| CMake
 
+| Go-task/Task
+| `Taskfile.yaml`
+| Go-task/Task project file
+
+| PHP
+| `composer.json`
+| PHP project file
+
+| Erlang & Elixir
 | `rebar.config`
 | Rebar project file
 
-| `requirements.txt`
-| Python Pip file
+| Erlang & Elixir
+| `mix.exs`
+| Elixir mix project file
 
+| JavaScript
+| `Gruntfile.js`
+| Grunt project file
+
+| Angular
+| `angular.json`
+| Angular project file
+
+| JavaScript
+| `gulpfile.js`
+| Javascript Gulp file
+
+| JavaScript
+| `package.json`
+| npm, pnpm and yarn project file
+
+
+| Python
+| `manage.py`
+| Django project file
+
+| Python
+| `requirements.txt`
+| Python requirements file
+
+| Python
 | `setup.py`
 | Setuptools file
 
+| Python
+| `tox.ini`
+| Python Tox file
+
+| Python
+| `Pipfile`
+| Python Pip file
+
+| Python
+| `poetry.lock`
+| Python Poetry project file
+
+| Python
+| `pyproject.toml`
+| Python project file
+
+| Java & friends
+| `pom.xml`
+| Maven project file
+
+| Java & friends
+| `application.yml`
+| Gradle project file
+
+| Java & friends
+| `build.gradle`
+| Gradle project file
+
+| Java & friends
+| `gradlew`
+| Gradle wrapper script
+
+| Java & friends
+| `application.yaml`
+| Gradle wrapper script
+
+| Scala
+| `build.sbt`
+| SBT project file
+
+| Scala
+| `build.sc`
+| Mill project file
+
+| Ensime
+| `.ensime`
+| Ensime configuration file
+
+| Clojure
+| `project.clj`
+| Leiningen project file
+
+| Clojure
+| `build.boot`
+| Boot-clj project file
+
+| Clojure
+| `deps.edn`
+| Clojure CLI project file
+
+| Clojure
+| `.bloop`
+| Clojure CLI project file
+
+| Ruby
+| `Gemfile`
+| Bundler file
+
+| Crystal
+| `shard.yml`
+| Crystal project file
+
+| Emacs
+| `Cask`
+| Emacs cask file
+
+| Emacs
+| `Eask`
+| Emacs cask file
+
+| Emacs
+| `Eldev`
+| Emacs LISP project file
+
+| R
+| `DESCRIPTION`
+| R package description file
+
+| Haskell
 | `stack.yaml`
 | Haskell's stack tool based project
 
-| `tox.ini`
-| Tox file
+| Rust
+| `Cargo.toml`
+| Cargo project file
 
-| `xmake.lua`
-| xmake project
+| Racket
+| `info.rkt`
+| Racket package description file
+
+| Dart
+| `pubspec.yaml`
+| Dart project file
+
+| Elm
+| `elm.json`
+| Elm project file
+
+| Julia
+| `Project.toml`
+| Julia project file
+
+| OCaml
+| `dune-project`
+| OCaml Dune project file
+
+| Universal
+| `GTAGS`
+| GNU Global tags
+
+| Universal
+| `TAGS`
+| etags/ctags are usually in the root of project
+
+| Universla
+| `configure.ac`
+| autoconf new style
+
+| Universal
+| `configure.in`
+| autoconf old style
+
+| C
+| `cscope.out`
+| cscope
+
+| Composer
+| `composer.json`
+| Composer project file
+
 |===
 
 There's also Projectile's own `.projectile` which serves both as a project marker


### PR DESCRIPTION
First attempt at expanding the table of file markers for projects based on code at [master/projectile.el#L3441](https://github.com/bbatsov/projectile/blob/master/projectile.el?rgh-link-date=2024-10-22T08%3A55%3A41Z#L3441)

I've followed the order of the languages/files in `projectile.el` (I hope!).

Not sure descriptions under `Project Type` are 100% correct so happy to revise anything that needs changing.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)

Thanks!
