### PR TITLE
Replace deprecated Jujutsu command

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -725,7 +725,7 @@ Set to nil to disable listing submodules contents."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-jj-command "jj files --no-pager . | tr '\\n' '\\0'"
+(defcustom projectile-jj-command "jj file list --no-pager . | tr '\\n' '\\0'"
   "Command used by projectile to get the files in a Jujutsu project."
   :group 'projectile
   :type 'string


### PR DESCRIPTION
The `jj files` command was deprecated and replaced with `jj file list` in Jujutsu 0.19 and is slated to be fully removed in the future

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)

Thanks!
