### PR TITLE
feat: add support for swift projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#1899](https://github.com/bbatsov/projectile/pull/1899): Add support for xmake build utility.
 * [#1895](https://github.com/bbatsov/projectile/pull/1895): Modify projectile-mode to add a hook to `buffer-list-update-hook` such that any change in the buffer list will update the selected project.
 * [#1918](https://github.com/bbatsov/projectile/pull/1895): Add Zig project discovery.
+* Add support for Swift project discovery.
 
 ### Bugs fixed
 

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -269,6 +269,10 @@ are the configuration files of various build tools. Out of the box the following
 | Zig
 | `build.zig.zon`
 | Zig project file
+
+| Swift
+| `Package.swift`
+| Swift package file
 |===
 
 There's also Projectile's own `.projectile` which serves both as a project marker

--- a/projectile.el
+++ b/projectile.el
@@ -3633,6 +3633,13 @@ a manual COMMAND-TYPE command is created with
                                   :test "zig build test"
                                   :run "zig build run")
 
+;; Swift
+(projectile-register-project-type 'swift-spm '("Package.swift")
+                                  :project-file "Package.swift"
+                                  :compile "swift build"
+                                  :test "swift test"
+                                  :run "swift run")
+
 (defvar-local projectile-project-type nil
   "Buffer local var for overriding the auto-detected project type.
 Normally you'd set this from .dir-locals.el.")


### PR DESCRIPTION
Add support for swift projects using swift package manager (SPM).

The 'swift-spm symbol is qualified to leave room for other flavors of swift project that are more Xcode oriented or use cocoapods.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)

Thanks!
