### PR TITLE
Fix docs: .bloop for Scala, not clojure

### DIFF
--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -170,6 +170,10 @@ are the configuration files of various build tools. Out of the box the following
 | `build.sc`
 | Mill project file
 
+| Scala
+| `.bloop`
+| Bloop project file
+
 | Ensime
 | `.ensime`
 | Ensime configuration file
@@ -184,10 +188,6 @@ are the configuration files of various build tools. Out of the box the following
 
 | Clojure
 | `deps.edn`
-| Clojure CLI project file
-
-| Clojure
-| `.bloop`
 | Clojure CLI project file
 
 | Ruby


### PR DESCRIPTION
Bloop is a Scala build tool, not a Clojure tool: https://scalacenter.github.io/bloop/

-----------------


- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)

