### PR TITLE
Add projectile-add-known-project kbd

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -6176,6 +6176,7 @@ thing shown in the mode line otherwise."
     (define-key map (kbd "&") #'projectile-run-async-shell-command-in-root)
     (define-key map (kbd "?") #'projectile-find-references)
     (define-key map (kbd "a") #'projectile-find-other-file)
+    (define-key map (kbd "A") #'projectile-add-known-project)
     (define-key map (kbd "b") #'projectile-switch-to-buffer)
     (define-key map (kbd "d") #'projectile-find-dir)
     (define-key map (kbd "D") #'projectile-dired)
@@ -6260,6 +6261,8 @@ thing shown in the mode line otherwise."
          ["Previous buffer" projectile-previous-project-buffer]
          ["Next buffer" projectile-next-project-buffer])
         ("Projects"
+         ["Add known project" projectile-add-known-project]
+         "--"
          ["Switch to project" projectile-switch-project]
          ["Switch to open project" projectile-switch-open-project]
          "--"


### PR DESCRIPTION
The method `projectile-add-known-project` does not have a kbd, nor it shows in the menu

Add kbd for projectile-add-known-project
Add menu entry for projectile-add-known-project

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)

Thanks!
