### PR TITLE
Quote ignore globs in projectile-ripgrep

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -4475,7 +4475,7 @@ installed to work."
    (list (projectile--read-search-string-with-default
           (format "Ripgrep %ssearch for" (if current-prefix-arg "regexp " "")))
          current-prefix-arg))
-  (let ((args (mapcar (lambda (val) (concat "--glob !" val))
+  (let ((args (mapcar (lambda (val) (concat "--glob '!" val "'"))
                       (append projectile-globally-ignored-files
                               projectile-globally-ignored-directories))))
     ;; we rely on the external packages ripgrep and rg for the actual search


### PR DESCRIPTION
Otherwise, the globs are interpreted by the shell which may lead to errors such as

    zsh:1: no matches found: !*.bundle.js

In this example the command was

    /usr/bin/rg [...] --glob !*.bundle.js [...]

and after this change will become

    /usr/bin/rg [...] --glob '!*.bundle.js' [...]

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)

Thanks!
