### PR TITLE
Set condition for considering `projectile-indexing-method` to be safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * Set `projectile-auto-discover` to `nil` by default.
+* [#1943](https://github.com/bbatsov/projectile/pull/1943): Consider `projectile-indexing-method` to be safe as a dir-local variable if it is one of the preset values
 
 ## 2.9.1 (2025-02-13)
 

--- a/projectile.el
+++ b/projectile.el
@@ -126,6 +126,7 @@ Projectile might also provide.
 The disadvantage of the hybrid and alien methods is that they are not well
 supported on Windows systems.  That's why by default alien indexing is the
 default on all operating systems, except Windows."
+  :safe (lambda (x) (memq x '(native hybrid alien)))
   :group 'projectile
   :type '(radio
           (const :tag "Native" native)


### PR DESCRIPTION
Set condition under which `projectile-indexing-method` should be considered "safe" as a dir-local variable: namely that it is one of the symbols `native`, `hybrid`, or `alien`.

Per #1940 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)

Thanks!
