### PR TITLE
Use template for jujutsu file listing

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -757,7 +757,7 @@ Set to nil to disable listing submodules contents."
   :group 'projectile
   :type 'string)
 
-(defcustom projectile-jj-command "jj file list --no-pager . | tr '\\n' '\\0'"
+(defcustom projectile-jj-command "jj file list -T 'path ++ \"\\0\"' --no-pager ."
   "Command used by projectile to get the files in a Jujutsu project."
   :group 'projectile
   :type 'string


### PR DESCRIPTION
In jujutsu users can configure the default behaviour of `jj file list` so that it no longer puts out file names separated by newlines (which is the default behaviour). This means the output of `jj file list` can't be trusted to be stable. On the other hand the same mechanism allows you to output the files separated with a null byte without invoking `tr`, this has the additional benefit that filenames with newlines in them are now working.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)

Thanks!
