### PR TITLE
Handle the projects cache better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Set `projectile-auto-discover` to `nil` by default.
 * [#1943](https://github.com/bbatsov/projectile/pull/1943): Consider `projectile-indexing-method` to be safe as a dir-local variable if it is one of the preset values.
+* [#1936](https://github.com/bbatsov/projectile/issues/1936): Do not require selecting a project when using `M-x projectile-invalidate-cache`, since there is a global cache that is also cleared by that command, even when not operating on any specific project.
 
 ## 2.9.1 (2025-02-13)
 

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -57,6 +57,19 @@ This will bring up a backtrace with the entire function stack, including
 function arguments. So you should be able to figure out what's going on (or at
 least what's being required).
 
+=== Projectile recognizes the wrong project
+
+If Projectile does not think you are in a project, check how you
+expect Projectile to recognize the project: it needs the presence of
+an indicator file like `.git` or similar at the project root. If the
+directory you want to be a project is not version-controlled, a file
+named `.projectile` will do.
+
+Note that Projectile caches the operation of checking which project
+(if any) a file belongs to. If you have already opened a file, then
+later added a marker file like `.projectile`, run `M-x
+projectile-invalidate-cache` to reset the cache.
+
 === I upgraded Projectile using `package.el` and nothing changed
 
 Emacs doesn't load the new files, it only installs them on disk.  To see the

--- a/projectile.el
+++ b/projectile.el
@@ -1089,15 +1089,21 @@ A wrapper around `file-exists-p' with additional caching support."
   "Remove the current project's files from `projectile-projects-cache'.
 
 With a prefix argument PROMPT prompts for the name of the project whose cache
-to invalidate."
+to invalidate.
+
+The global (project-independent) cache for checking which project a file
+belongs to, is also cleared. Therefore this function is still useful even
+when not operating on a specific project, and as such only the global cache
+is cleared when there is no current project (unless you give a prefix
+argument)."
   (interactive "P")
-  (let ((project-root
-         (if prompt
-             (completing-read "Remove cache for: "
-                              (hash-table-keys projectile-projects-cache))
-           (projectile-acquire-root))))
+  (setq projectile-project-root-cache (make-hash-table :test 'equal))
+  (when-let ((project-root
+              (if prompt
+                  (completing-read "Remove cache for: "
+                                   (hash-table-keys projectile-projects-cache))
+                (projectile-project-root))))
     ;; reset the in-memory cache
-    (setq projectile-project-root-cache (make-hash-table :test 'equal))
     (remhash project-root projectile-project-type-cache)
     (remhash project-root projectile-projects-cache)
     (remhash project-root projectile-projects-cache-time)


### PR DESCRIPTION
Handle part of https://github.com/bbatsov/projectile/issues/1936 by allowing for `M-x projectile-invalidate-cache` to still clear the global cache even if the user invokes it from outside of any project, and no longer force the user to select a project to invalidate the cache for in that case. Also, document how this command may be used for troubleshooting.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)
