### PR TITLE
Make CMake version parsing more robust.

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -3156,7 +3156,7 @@ it acts on the current project."
 (defun projectile--cmake-version ()
   "Compute CMake version."
   (let* ((string (shell-command-to-string "cmake --version"))
-         (match (string-match "^cmake version \\(.*\\)$" string)))
+         (match (string-match "^cmake version \\([0-9]+\\.[0-9]+\\.[0-9]+\\).*$" string)))
     (when match
       (version-to-list (match-string 1 string)))))
 


### PR DESCRIPTION
More robust cmake-version matching to account for "-dirty" version on arch linux. Closes #1951.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)

Thanks!
