### PR TITLE
pages/usage.doc: fix ELisp for "Removal of missing projects"; Fixes #1954

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 ### Changes
+* [#1954](https://github.com/bbatsov/projectile/issues/1954): update ELisp for usage.html / "Removal of missing projects"
 * [#1947](https://github.com/bbatsov/projectile/issues/1947): `projectile-project-name` should be marked as safe
 * Set `projectile-auto-discover` to `nil` by default.
 * [#1943](https://github.com/bbatsov/projectile/pull/1943): Consider `projectile-indexing-method` to be safe as a dir-local variable if it is one of the preset values.

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -87,7 +87,7 @@ around. (e.g. they were removed or renamed) You can either trigger the command
 
 [source,elisp]
 ----
-(setq projectile-cleanup-known-projects nil)
+(customize-set-variable 'projectile-auto-cleanup-known-projects t)
 ----
 
 TIP: If you're a heavy TRAMP user it's probably not a good idea to auto-discover


### PR DESCRIPTION
(see title / #1954; should be self-explanatory)

Couple of notes:
- I went ahead to s/setq/customize-set-variable/; figured that was the better way based on what I read online (`projectile-auto-cleanup-known-projects` is a variable that can be customized)
- added a separate commit after seeing CHANGELOG.md mentioned in the PR template. But on second thought.. I'm not sure if this would be a candidate (I'm not really `adding/changing user-visible functionality`?)