### PR TITLE
Identification of caller for ivy-read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 ### Changes
+* (TODO link): Add :caller information to calls to `ivy-read` (used by packages like `ivy-rich`)
 * [#1954](https://github.com/bbatsov/projectile/issues/1954): update ELisp for usage.html / "Removal of missing projects"
 * [#1947](https://github.com/bbatsov/projectile/issues/1947): `projectile-project-name` should be marked as safe
 * Set `projectile-auto-discover` to `nil` by default.

--- a/projectile.el
+++ b/projectile.el
@@ -1147,7 +1147,8 @@ The cache is created both in memory and on the hard drive."
   (interactive
    (list (projectile-completing-read
           "Remove file from cache: "
-          (projectile-current-project-files))))
+          (projectile-current-project-files)
+          :caller 'projectile-read-file)))
   (let* ((project-root (projectile-project-root))
          (project-cache (gethash project-root projectile-projects-cache)))
     (if (projectile-file-cached-p file project-root)
@@ -1165,7 +1166,8 @@ The cache is created both in memory and on the hard drive."
   (interactive
    (list (projectile-completing-read
           "Remove directory from cache: "
-          (projectile-current-project-dirs))))
+          (projectile-current-project-dirs)
+          :caller 'projectile-read-directory)))
   (let* ((project-root (projectile-project-root))
          (project-cache (gethash project-root projectile-projects-cache)))
     (puthash project-root
@@ -1413,7 +1415,8 @@ See also `projectile-acquire-root'."
       dir
     (cond
      ((eq projectile-require-project-root 'prompt) (projectile-completing-read
-                                                    "Switch to project: " projectile-known-projects))
+                                                    "Switch to project: " projectile-known-projects
+                                                    :caller 'projectile-read-project))
      (projectile-require-project-root (error "Projectile cannot find a project definition in %s" default-directory))
      (t default-directory))))
 
@@ -1826,7 +1829,8 @@ choices."
   (projectile-completing-read
    prompt
    (delete (buffer-name (current-buffer))
-           (projectile-project-buffer-names))))
+           (projectile-project-buffer-names))
+   :caller 'projectile-read-buffer))
 
 ;;;###autoload
 (defun projectile-switch-to-buffer ()
@@ -1856,7 +1860,8 @@ choices."
   (display-buffer
    (projectile-completing-read
     "Display buffer: "
-    (projectile-project-buffer-names))))
+    (projectile-project-buffer-names)
+    :caller 'projectile-read-buffer)))
 
 ;;;###autoload
 (defun projectile-project-buffers-other-buffer ()
@@ -2123,9 +2128,10 @@ Never use on many files since it's going to recalculate the
 project-root for every file."
   (expand-file-name name (projectile-project-root dir)))
 
-(cl-defun projectile-completing-read (prompt choices &key initial-input action)
+(cl-defun projectile-completing-read (prompt choices &key initial-input action caller)
   "Present a project tailored PROMPT with CHOICES."
   (let ((prompt (projectile-prepend-project-name prompt))
+        (caller (or caller 'projectile-completing-read))
         res)
     (setq res
           (pcase (if (eq projectile-completion-system 'auto)
@@ -2167,7 +2173,7 @@ project-root for every file."
                            :initial-input initial-input
                            :action (prog1 action
                                      (setq action nil))
-                           :caller 'projectile-completing-read)
+                           :caller caller)
                (user-error "Please install ivy")))
             (_ (funcall projectile-completion-system prompt choices))))
     (if action
@@ -2276,7 +2282,7 @@ instead of `find-file'.   A typical example of such a defun would be
   (let ((ff (or ff-variant #'find-file))
         (other-files (projectile-get-other-files (buffer-file-name) flex-matching)))
     (if other-files
-        (let ((file-name (projectile--choose-from-candidates other-files)))
+        (let ((file-name (projectile--choose-from-candidates other-files :caller 'projectile-read-file)))
           (funcall ff (expand-file-name file-name
                                         (projectile-project-root))))
       (error "No other file found"))))
@@ -2425,9 +2431,11 @@ Subroutine for `projectile-find-file-dwim' and
          (file (cond ((= (length files) 1)
                       (car files))
                      ((> (length files) 1)
-                      (projectile-completing-read "Switch to: " files))
+                      (projectile-completing-read "Switch to: " files
+                                                  :caller 'projectile-read-file))
                      (t
-                      (projectile-completing-read "Switch to: " project-files))))
+                      (projectile-completing-read "Switch to: " project-files
+                                                  :caller 'projectile-read-file))))
          (ff (or ff-variant #'find-file)))
     (funcall ff (expand-file-name file project-root))
     (run-hooks 'projectile-find-file-hook)))
@@ -2530,7 +2538,8 @@ would be `find-file-other-window' or `find-file-other-frame'"
   (projectile-maybe-invalidate-cache invalidate-cache)
   (let* ((project-root (projectile-acquire-root))
          (file (projectile-completing-read "Find file: "
-                                           (projectile-project-files project-root)))
+                                           (projectile-project-files project-root)
+                                           :caller 'projectile-read-file))
          (ff (or ff-variant #'find-file)))
     (when file
       (funcall ff (expand-file-name file project-root))
@@ -2686,7 +2695,8 @@ With a prefix arg INVALIDATE-CACHE invalidates the cache first."
      "Find dir: "
      (if projectile-find-dir-includes-top-level
          (append '("./") project-dirs)
-       project-dirs))))
+       project-dirs)
+     :caller 'projectile-read-directory)))
 
 ;;;###autoload
 (defun projectile-find-test-file (&optional invalidate-cache)
@@ -2696,7 +2706,8 @@ With a prefix arg INVALIDATE-CACHE invalidates the cache first."
   (interactive "P")
   (projectile-maybe-invalidate-cache invalidate-cache)
   (let ((file (projectile-completing-read "Find test file: "
-                                          (projectile-current-project-test-files))))
+                                          (projectile-current-project-test-files)
+                                          :caller 'projectile-read-file)))
     (find-file (expand-file-name file (projectile-project-root)))))
 
 (defun projectile-test-files (files)
@@ -2783,11 +2794,12 @@ If KIND is not provided, a list of possible kinds can be chosen."
     (if-let* ((available-kinds (projectile--related-files-kinds file)))
         (setq kind (if (= (length available-kinds) 1)
                        (car available-kinds)
-                     (intern (projectile-completing-read "Kind :" available-kinds))))
+                     (intern (projectile-completing-read "Kind :" available-kinds
+                                                         :caller 'projectile-read-file))))
       (error "No related files found")))
 
-  (if-let* ((candidates (projectile--related-files file kind)))
-      (projectile-expand-root (projectile--choose-from-candidates candidates))
+  (if-let ((candidates (projectile--related-files file kind)))
+      (projectile-expand-root (projectile--choose-from-candidates candidates :caller 'projectile-read-file))
     (error
      "No matching related file as `%s' found for project type `%s'"
      kind (projectile-project-type))))
@@ -3270,7 +3282,8 @@ select a name of a command preset, or opt a manual command by selecting
            (preset-names (projectile--cmake-command-preset-names command-type)))
       (projectile-completing-read
        "Use preset: "
-       (append preset-names `(,projectile--cmake-no-preset)))
+       (append preset-names `(,projectile--cmake-no-preset))
+       :caller nil)
     projectile--cmake-no-preset))
 
 (defconst projectile--cmake-manual-command-alist
@@ -4212,21 +4225,21 @@ The precedence for determining implementation files to return is:
                 (projectile-current-project-files))) it)
    ((projectile--test-to-impl-dir-fallback test-file) (list it))))
 
-(defun projectile--choose-from-candidates (candidates)
+(defun projectile--choose-from-candidates (candidates &key caller)
   "Choose one item from CANDIDATES."
   (if (= (length candidates) 1)
       (car candidates)
-    (projectile-completing-read "Switch to: " candidates)))
+    (projectile-completing-read "Switch to: " candidates :caller caller)))
 
 (defun projectile-find-matching-test (impl-file)
   "Compute the name of the test matching IMPL-FILE."
-  (when-let* ((candidates (projectile--find-matching-test impl-file)))
-    (projectile--choose-from-candidates candidates)))
+  (when-let ((candidates (projectile--find-matching-test impl-file)))
+    (projectile--choose-from-candidates candidates :caller 'projectile-read-file)))
 
 (defun projectile-find-matching-file (test-file)
   "Compute the name of a file matching TEST-FILE."
-  (when-let* ((candidates (projectile--find-matching-file test-file)))
-    (projectile--choose-from-candidates candidates)))
+  (when-let ((candidates (projectile--find-matching-file test-file)))
+    (projectile--choose-from-candidates candidates :caller 'projectile-read-file)))
 
 (defun projectile-grep-default-files ()
   "Try to find a default pattern for `projectile-grep'.
@@ -5011,7 +5024,8 @@ directory to open."
                     (list
                      (projectile-completing-read
                       "Open project VC in: "
-                      projectile-known-projects))))
+                      projectile-known-projects
+                      :caller 'projectile-read-project))))
   (unless project-root
     (setq project-root (projectile-acquire-root)))
   (let ((vcs (projectile-project-vcs project-root)))
@@ -5037,7 +5051,8 @@ directory to open."
       (find-file (projectile-expand-root
                   (projectile-completing-read
                    "Recently visited files: "
-                   (projectile-recentf-files))))
+                   (projectile-recentf-files)
+                   :caller 'projectile-read-file)))
     (message "recentf is not enabled")))
 
 (defun projectile-recentf-files ()
@@ -5635,7 +5650,8 @@ With a prefix ARG invokes `projectile-commander' instead of
         (projectile-completing-read
          "Switch to project: " projects
          :action (lambda (project)
-                   (projectile-switch-project-by-name project arg)))
+                   (projectile-switch-project-by-name project arg))
+         :caller 'projectile-read-project)
       (user-error "There are no known projects"))))
 
 ;;;###autoload
@@ -5650,7 +5666,8 @@ With a prefix ARG invokes `projectile-commander' instead of
         (projectile-completing-read
          "Switch to open project: " projects
          :action (lambda (project)
-                   (projectile-switch-project-by-name project arg)))
+                   (projectile-switch-project-by-name project arg))
+         :caller 'projectile-read-project)
       (user-error "There are no open projects"))))
 
 (defun projectile-switch-project-by-name (project-to-switch &optional arg)
@@ -5702,7 +5719,8 @@ This command will first prompt for the directory the file is in."
     (if (projectile-project-p)
         ;; target directory is in a project
         (let ((file (projectile-completing-read "Find file: "
-                                                (projectile-dir-files directory))))
+                                                (projectile-dir-files directory)
+                                                :caller 'projectile-read-file)))
           (find-file (expand-file-name file directory))
           (run-hooks 'projectile-find-file-hook))
       ;; target directory is not in a project
@@ -5722,7 +5740,8 @@ This command will first prompt for the directory the file is in."
 (defun projectile-find-file-in-known-projects ()
   "Jump to a file in any of the known projects."
   (interactive)
-  (find-file (projectile-completing-read "Find file in projects: " (projectile-all-project-files))))
+  (find-file (projectile-completing-read "Find file in projects: " (projectile-all-project-files)
+                                         :caller 'projectile-read-file)))
 
 (defun projectile-keep-project-p (project)
   "Determine whether we should cleanup (remove) PROJECT or not.
@@ -5773,7 +5792,8 @@ Return a list of projects removed."
   "Remove PROJECT from the list of known projects."
   (interactive (list (projectile-completing-read
                       "Remove from known projects: " projectile-known-projects
-                      :action 'projectile-remove-known-project)))
+                      :action 'projectile-remove-known-project
+                      :caller 'projectile-read-project)))
   (unless (called-interactively-p 'any)
     (setq projectile-known-projects
           (cl-remove-if
@@ -5871,7 +5891,8 @@ Let user choose another project when PROMPT-FOR-PROJECT is supplied."
   (let ((project-root (if prompt-for-project
                           (projectile-completing-read
                            "Project name: "
-                           (projectile-relevant-known-projects))
+                           (projectile-relevant-known-projects)
+                           :caller 'projectile-read-project)
                         (projectile-acquire-root))))
     (projectile-ibuffer-by-project project-root)))
 
@@ -6054,7 +6075,8 @@ dirty project list."
     (while (not (= (length status) 0))
       (setq mod-proj (cons (car (pop status)) mod-proj)))
     (projectile-completing-read "Select project: " mod-proj
-                                :action 'projectile-vc)))
+                                :action 'projectile-vc
+                                :caller 'projectile-read-project)))
 
 
 ;;; Find next/previous project buffer


### PR DESCRIPTION
Hi,

With `ivy`, projectile uses `ivy-read` for completion. This function takes a named parameter `:caller` that allows `ivy` to change its behavior (e.g. `ivy-rich` annotations, or `display-buffer` behavior). As it stands, projectile always sets this parameter to `projectile-completing-read`. 

This PR changes it to set a different caller according to what is being read: `projectile-read-project` for a project name, `projectile-read-buffer` for a buffer name, `projectile-read-file` for a file name, `projectile-read-directory` for a directory.

Based on the changelog, the purpose appears to be similar to https://github.com/bbatsov/projectile/pull/1892.

It is also similar to what [counsel-projectile](https://github.com/ericdanan/counsel-projectile) does, but that package is much larger in scope. This PR won't change user-facing behavior without additional configuration on their side.

One possible friction point is if a user has already configured `ivy-rich`, etc. to match on `projectile-completing-read`. Then they will need to adjust their configuration to the new identifiers. If that is a big problem, we can add a configuration variable to make the new behavior opt-in or opt-out.

Examples of what can be done:

Show the current branch of the projects (very useful when juggling between multiple worktrees):
<img width="936" height="157" alt="image" src="https://github.com/user-attachments/assets/c7c475e2-f39f-4e57-9780-a876f95259e8" />

Have the same information with `projectile-switch-buffer` and `switch-buffer`:
<img width="1402" height="124" alt="image" src="https://github.com/user-attachments/assets/71392cf4-a625-4145-94eb-d88fab5c7d2e" />

 -----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)

Thanks!
