### PR TITLE
[Fix #1962] Fix finding other file when candidate is a root file

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2384,7 +2384,8 @@ With FLEX-MATCHING, match any file that contains the base name of current file"
          (candidates
           (cl-sort (copy-sequence candidates)
                    (lambda (file _)
-                     (let ((candidate-dirname (file-name-nondirectory (directory-file-name (file-name-directory file)))))
+                     (let ((candidate-dirname (file-name-nondirectory (directory-file-name (if (file-name-directory file)
+                                                                                               (file-name-directory file) "./")))))
                        (unless (equal fulldirname (file-name-directory file))
                          (equal dirname candidate-dirname)))))))
     candidates))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1143,7 +1143,10 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
   (it "returns files with same names but different extensions"
     (projectile-test-with-sandbox
       (projectile-test-with-files-using-custom-project
-          ("src/test1.c"
+          ("root.c"
+           "root.h"
+           "src/root.h"
+           "src/test1.c"
            "src/test2.c"
            "src/test+copying.m"
            "src/test1.cpp"
@@ -1153,6 +1156,7 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
            "src/test.frag"
            "src/same_name.c"
            "src/some_module/same_name.c"
+           "include1/root.h"
            "include1/same_name.h"
            "include1/test1.h"
            "include1/test1.h~"
@@ -1196,6 +1200,7 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
                                              ;; handle files with nested extensions
                                              ("service.js" . ("service.spec.js"))
                                              ("js" . ("js")))))
+          (expect (projectile-get-other-files "root.c") :to-equal '("root.h" "include1/root.h" "src/root.h"))
           (expect (projectile-get-other-files "src/test1.c") :to-equal '("include1/test1.h" "include2/test1.h"))
           (expect (projectile-get-other-files "src/test1.cpp") :to-equal '("include1/test1.h" "include2/test1.h" "include1/test1.hpp"))
           (expect (projectile-get-other-files "test2.c") :to-equal '("include1/test2.h" "include2/test2.h"))


### PR DESCRIPTION
This is the PR for #1962. I have added a regression test for the edge case I ran into. All other tests still run through.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] You've added tests (if possible) to cover your change(s)
- [X] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)

Thanks!