### PR TITLE
Avoid obsolete macros (fixes "snapshot" tests)

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1101,7 +1101,7 @@ is cleared when there is no current project (unless you give a prefix
 argument)."
   (interactive "P")
   (setq projectile-project-root-cache (make-hash-table :test 'equal))
-  (when-let ((project-root
+  (when-let* ((project-root
               (if prompt
                   (completing-read "Remove cache for: "
                                    (hash-table-keys projectile-projects-cache))
@@ -4147,7 +4147,7 @@ anaphora.el."
   (if (null clauses)
       nil
     (let ((cl1 (car clauses))
-          (sym (cl-gensym)))
+          (sym (gensym)))
       `(let ((,sym ,(car cl1)))
          (if ,sym
              (if (null ',(cdr cl1))


### PR DESCRIPTION
Emacs 31.1 treats when-let and cl-gensym as obsolete errors during byte-compilation, so switch to when-let* and gensym to keep snapshot CI green.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)

Thanks!
