### PR TITLE
Check globally-ignored-file-suffixes in native indexing

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1986,7 +1986,11 @@ A pre-computed list of IGNORED-FILES may optionally be provided."
    (seq-some
     (lambda (name)
       (string-match-p name file))
-    projectile-global-ignore-file-patterns)))
+    projectile-global-ignore-file-patterns)
+   (seq-some
+    (lambda (suffix)
+      (string-suffix-p suffix file t))
+    projectile-globally-ignored-file-suffixes)))
 
 (defun projectile-check-pattern-p (file pattern)
   "Check if FILE matches globbing PATTERN."


### PR DESCRIPTION
- `projectile-ignored-file-p` now checks `projectile-globally-ignored-file-suffixes` in addition to `projectile-globally-ignored-files` and file patterns
- Previously the suffix check only happened in `projectile-remove-ignored`, which is called by hybrid indexing but not native indexing
- This is a one-line addition to the `or` chain in `projectile-ignored-file-p`

Fixes #1959