### PR TITLE
Filter projectile-replace results through project ignore rules

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -4970,8 +4970,13 @@ on which to run the replacement."
          (new-text (read-string
                     (projectile-prepend-project-name
                      (format "Replace %s with: " old-text))))
-         (files (projectile-files-with-string old-text directory file-ext)))
-    (fileloop-initialize-replace (regexp-quote old-text) new-text files 'default)
+         (files (projectile-files-with-string old-text directory file-ext))
+         ;; Filter results through the project's file list so that files
+         ;; ignored via .projectile or other ignore rules are excluded.
+         (project-files (mapcar (lambda (file) (expand-file-name file directory))
+                                (projectile-dir-files directory)))
+         (filtered-files (seq-filter (lambda (f) (member f project-files)) files)))
+    (fileloop-initialize-replace (regexp-quote old-text) new-text filtered-files 'default)
     (fileloop-continue)))
 
 ;;;###autoload


### PR DESCRIPTION
- `projectile-replace` now filters the files found by external search tools (rg/ag/grep) through the project's file list (`projectile-dir-files`), ensuring that files ignored via `.projectile` or other ignore rules are excluded from replacement
- Previously, external tools searched the filesystem directly, which could include backup files (`*~`), build artifacts, and other entries that `.projectile` is configured to exclude
- This matches how `projectile-replace-regexp` already works (it uses `projectile-dir-files` as its file source)

Closes #1227