### PR TITLE
Add subproject compile and test commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1964](https://github.com/bbatsov/projectile/issues/1964): Implement `project-name` and `project-buffers` methods for the `project.el` integration, so that code using `project.el` APIs returns correct results for Projectile-managed projects.
 * [#1837](https://github.com/bbatsov/projectile/issues/1837): Add `eat` project terminal commands with keybindings `x x` and `x 4 x`.
 * Add keybinding `A` (in the projectile command map) and a menu entry for `projectile-add-known-project`.
+* [#1653](https://github.com/bbatsov/projectile/issues/1653): Add `projectile-compile-subproject` and `projectile-test-subproject` commands for building/testing individual modules in multi-module projects (e.g. Maven, Gradle). Bound to `c m c` and `c m t`.
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 * [#1837](https://github.com/bbatsov/projectile/issues/1837): Add `eat` project terminal commands with keybindings `x x` and `x 4 x`.
 * Add `ghostel` project terminal commands with keybindings `x G` and `x 4 G`.
 * Add keybinding `A` (in the projectile command map) and a menu entry for `projectile-add-known-project`.
+* [#1653](https://github.com/bbatsov/projectile/issues/1653): Add `projectile-compile-subproject` and `projectile-test-subproject` commands for building/testing individual modules in multi-module projects (e.g. Maven, Gradle). Bound to `c m c` and `c m t`.
 
 ### Bugs fixed
 

--- a/projectile.el
+++ b/projectile.el
@@ -6784,6 +6784,33 @@ COMMAND-TYPE, when non-nil, selects the per-type command history
                             '(compile-history . 1)
                           'compile-history))))
 
+(defun projectile-subproject-root ()
+  "Find the root of the nearest subproject containing the current file.
+Walk up from `default-directory' looking for the project type's
+`:project-file' marker, stopping at the project root.  Returns the
+directory containing the nearest marker, or signals an error if no
+subproject is found between the current directory and the project root."
+  (let* ((project-root (projectile-acquire-root))
+         (type (projectile-project-type project-root))
+         (project-file (projectile-project-type-attribute type 'project-file))
+         (markers (if (listp project-file) project-file (list project-file)))
+         (dir (file-name-directory (or (buffer-file-name) default-directory)))
+         (result nil))
+    (unless markers
+      (user-error "Project type `%s' has no project-file defined" type))
+    ;; Walk up from current directory, stop at (but include) project root.
+    (while (and (not result)
+                dir
+                (string-prefix-p project-root dir))
+      (when (seq-some (lambda (m)
+                        (file-exists-p (expand-file-name m dir)))
+                      markers)
+        (setq result dir))
+      (let ((parent (file-name-directory (directory-file-name dir))))
+        (setq dir (unless (string= parent dir) parent))))
+    (or result
+        (user-error "No subproject found between current directory and project root"))))
+
 (defun projectile-compilation-dir ()
   "Retrieve the compilation directory for this project."
   (let* ((project-root (projectile-acquire-root))
@@ -6986,6 +7013,54 @@ with a prefix ARG."
                                  :command-type 'test
                                  :show-prompt arg
                                  :prompt-prefix "Test command: "
+                                 :save-buffers t
+                                 :use-comint-mode projectile-test-use-comint-mode)))
+
+;;;###autoload
+(defun projectile-compile-subproject (arg)
+  "Run compilation in the nearest subproject.
+Find the closest build file (e.g. pom.xml, build.gradle) between the
+current directory and the project root, then run the project's compile
+command there.  This is useful for multi-module projects where building
+a single module is faster than building the entire project.
+
+Normally you'll be prompted for a compilation command, unless
+variable `compilation-read-command'.  You can force the prompt
+with a prefix ARG."
+  (interactive "P")
+  (let* ((subproject-root (projectile-subproject-root))
+         (project-root (projectile-acquire-root))
+         (projectile-project-compilation-dir
+          (file-relative-name subproject-root project-root))
+         (command (projectile-compilation-command (projectile-compilation-dir)))
+         (command-map (if (projectile--cache-project-commands-p) projectile-compilation-cmd-map)))
+    (projectile--run-project-cmd command command-map
+                                 :show-prompt arg
+                                 :prompt-prefix "Compile subproject command: "
+                                 :save-buffers t
+                                 :use-comint-mode projectile-compile-use-comint-mode)))
+
+;;;###autoload
+(defun projectile-test-subproject (arg)
+  "Run tests in the nearest subproject.
+Find the closest build file (e.g. pom.xml, build.gradle) between the
+current directory and the project root, then run the project's test
+command there.  This is useful for multi-module projects where testing
+a single module is faster than testing the entire project.
+
+Normally you'll be prompted for a compilation command, unless
+variable `compilation-read-command'.  You can force the prompt
+with a prefix ARG."
+  (interactive "P")
+  (let* ((subproject-root (projectile-subproject-root))
+         (project-root (projectile-acquire-root))
+         (projectile-project-compilation-dir
+          (file-relative-name subproject-root project-root))
+         (command (projectile-test-command (projectile-compilation-dir)))
+         (command-map (if (projectile--cache-project-commands-p) projectile-test-cmd-map)))
+    (projectile--run-project-cmd command command-map
+                                 :show-prompt arg
+                                 :prompt-prefix "Test subproject command: "
                                  :save-buffers t
                                  :use-comint-mode projectile-test-use-comint-mode)))
 
@@ -7793,6 +7868,8 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "c i") #'projectile-install-project)
     (define-key map (kbd "c t") #'projectile-test-project)
     (define-key map (kbd "c r") #'projectile-run-project)
+    (define-key map (kbd "c m c") #'projectile-compile-subproject)
+    (define-key map (kbd "c m t") #'projectile-test-subproject)
     ;; integration with utilities
     (define-key map (kbd "x r") #'projectile-run)
     (define-key map (kbd "x e") #'projectile-run-eshell)

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -306,4 +306,64 @@
     (expect 'projectile-run-compilation
             :to-have-been-called-with "make build" nil)))
 
+(describe "projectile-subproject-root"
+  (it "returns the nearest ancestor directory that holds a project-file marker"
+    (let* ((root (file-name-as-directory (make-temp-file "projectile-sub" t)))
+           (sub (file-name-as-directory (expand-file-name "mod" root)))
+           (deep (file-name-as-directory (expand-file-name "src" sub))))
+      (unwind-protect
+          (progn
+            (make-directory deep t)
+            (write-region "" nil (expand-file-name "pom.xml" root))
+            (write-region "" nil (expand-file-name "pom.xml" sub))
+            (spy-on 'projectile-acquire-root :and-return-value root)
+            (spy-on 'projectile-project-type :and-return-value 'maven)
+            (spy-on 'projectile-project-type-attribute :and-return-value "pom.xml")
+            (let ((default-directory deep))
+              (expect (projectile-subproject-root) :to-equal sub)))
+        (delete-directory root t))))
+
+  (it "falls back to the project root when only the root holds a marker"
+    (let* ((root (file-name-as-directory (make-temp-file "projectile-sub" t)))
+           (sub (file-name-as-directory (expand-file-name "mod" root)))
+           (deep (file-name-as-directory (expand-file-name "src" sub))))
+      (unwind-protect
+          (progn
+            (make-directory deep t)
+            (write-region "" nil (expand-file-name "pom.xml" root))
+            (spy-on 'projectile-acquire-root :and-return-value root)
+            (spy-on 'projectile-project-type :and-return-value 'maven)
+            (spy-on 'projectile-project-type-attribute :and-return-value "pom.xml")
+            (let ((default-directory deep))
+              (expect (projectile-subproject-root) :to-equal root)))
+        (delete-directory root t))))
+
+  (it "errors when there is no marker up to the project root"
+    (let* ((root (file-name-as-directory (make-temp-file "projectile-sub" t)))
+           (deep (file-name-as-directory (expand-file-name "mod/src" root))))
+      (unwind-protect
+          (progn
+            (make-directory deep t)
+            (spy-on 'projectile-acquire-root :and-return-value root)
+            (spy-on 'projectile-project-type :and-return-value 'maven)
+            (spy-on 'projectile-project-type-attribute :and-return-value "pom.xml")
+            (let ((default-directory deep))
+              (expect (projectile-subproject-root) :to-throw 'user-error)))
+        (delete-directory root t)))))
+
+(describe "projectile-compile-subproject"
+  (it "compiles with the subproject as the relative compilation dir"
+    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    (spy-on 'projectile-subproject-root :and-return-value "/proj/mod/")
+    (spy-on 'projectile-compilation-dir :and-return-value "/proj/mod/")
+    (spy-on 'projectile-compilation-command :and-return-value "make")
+    (spy-on 'projectile--cache-project-commands-p :and-return-value nil)
+    (let (seen-dir)
+      (spy-on 'projectile--run-project-cmd :and-call-fake
+              (lambda (&rest _) (setq seen-dir projectile-project-compilation-dir)))
+      (projectile-compile-subproject nil)
+      (expect 'projectile--run-project-cmd :to-have-been-called)
+      ;; the subproject dir is passed relative to the project root
+      (expect seen-dir :to-equal "mod/"))))
+
 ;;; projectile-commands-test.el ends here


### PR DESCRIPTION
Closes #1653.

- Add `projectile-subproject-root` helper that walks up from the current directory to find the nearest build file (`:project-file` marker), stopping at the project root
- Add `projectile-compile-subproject` — runs the project's compile command in the nearest subproject directory
- Add `projectile-test-subproject` — runs the project's test command in the nearest subproject directory
- Keybindings: `c m c` (compile subproject), `c m t` (test subproject)

This works for any project type that defines `:project-file` — Maven (`pom.xml`), Gradle (`build.gradle`), Leiningen (`project.clj`), etc. The implementation let-binds `projectile-project-compilation-dir` so the existing `projectile--run-project-cmd` infrastructure handles everything else (command caching, buffer naming, prompting, etc.).

### Example: Maven multi-module project

```
myproject/
  pom.xml          <- project root
  module-foo/
    pom.xml        <- subproject root (found when editing Foo.java)
    src/main/java/
      Foo.java
  module-bar/
    pom.xml
    src/main/java/
      Bar.java
```

With cursor in `Foo.java`, `C-c p c m c` runs `mvn -B clean install` in `module-foo/` instead of the project root.