### PR TITLE
Refactor dirconfig parser: struct, pure classifier, deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Changes
 
-* `projectile-parse-dirconfig-file' now returns a `projectile-dirconfig' struct (with `keep', `ignore', and `ensure' slots) instead of a positional 3-tuple. External callers should use the accessors (`projectile-dirconfig-keep' etc.) rather than `car'/`cadr'/`caddr'.
+* `projectile-parse-dirconfig-file' now returns a `projectile-dirconfig' struct (with `keep', `ignore', `ensure', and `prefixless-ignore' slots) instead of a positional 3-tuple. External callers should use the accessors (`projectile-dirconfig-keep' etc.) rather than `car'/`cadr'/`caddr'.
+* Soft-deprecate prefix-less ignore entries in `.projectile'. Lines without a `+'/`-'/`!' prefix are still treated as ignore patterns for backward compatibility, but a one-time warning is now shown for each project that uses them. Set `projectile-warn-on-prefixless-dirconfig-lines' to nil to silence.
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* `projectile-parse-dirconfig-file' now returns a `projectile-dirconfig' struct (with `keep', `ignore', and `ensure' slots) instead of a positional 3-tuple. External callers should use the accessors (`projectile-dirconfig-keep' etc.) rather than `car'/`cadr'/`caddr'.
+
 ### New features
 
 * Warn once per session when `projectile-indexing-method' is `alien' but the project has a non-empty `.projectile' file, so users notice their dirconfig rules are being bypassed. Controlled by the new `projectile-warn-when-dirconfig-is-ignored' option.

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -813,8 +813,13 @@ If you'd like to instruct Projectile to ignore certain files in a
 project, when indexing it you can do so in the `.projectile` file by
 adding each path to ignore, where the paths all are relative to the
 root directory and start with a slash. Everything ignored should be
-preceded with a `-` sign. Alternatively, not having any prefix at all
-also means to ignore the directory or file pattern that follows.
+preceded with a `-` sign.
+
+NOTE: Lines without any prefix at all are still accepted and treated
+as ignore patterns for backward compatibility, but the implicit form
+is being phased out and Projectile now warns about it once per
+project.  Prefer the explicit `-` prefix in new dirconfigs.
+
 Here's an example for a typical Rails application:
 
 ----

--- a/projectile.el
+++ b/projectile.el
@@ -2209,38 +2209,50 @@ or move the pattern to a `-'/`!' rule."
            dirconfig entry)
    :warning))
 
+(defun projectile--dirconfig-classify-line (line)
+  "Classify LINE from a dirconfig file.
+Return a cons (BUCKET . VALUE) where BUCKET is one of `:keep',
+`:ignore', `:ensure', or `:comment'.  Return nil for a blank line.
+Leading whitespace is skipped before dispatch so an accidental space
+or tab before the prefix does not change classification."
+  (let* ((trimmed (string-trim-left line))
+         (first-char (and (> (length trimmed) 0) (aref trimmed 0))))
+    (cond
+     ((null first-char) nil)
+     ((and projectile-dirconfig-comment-prefix
+           (eql first-char projectile-dirconfig-comment-prefix))
+      (cons :comment nil))
+     ((eql first-char ?+) (cons :keep   (string-trim (substring trimmed 1))))
+     ((eql first-char ?-) (cons :ignore (string-trim (substring trimmed 1))))
+     ((eql first-char ?!) (cons :ensure (string-trim (substring trimmed 1))))
+     (t                   (cons :ignore (string-trim trimmed))))))
+
+(defun projectile--parse-dirconfig-string (text)
+  "Parse TEXT (a dirconfig file's contents) into a `projectile-dirconfig'."
+  (let (keep ignore ensure)
+    (dolist (line (split-string text "\n"))
+      (pcase (projectile--dirconfig-classify-line line)
+        (`(:keep   . ,v) (unless (string-empty-p v) (push v keep)))
+        (`(:ignore . ,v) (unless (string-empty-p v) (push v ignore)))
+        (`(:ensure . ,v) (unless (string-empty-p v) (push v ensure)))))
+    (make-projectile-dirconfig
+     :keep   (mapcar #'file-name-as-directory (nreverse keep))
+     :ignore (nreverse ignore)
+     :ensure (nreverse ensure))))
+
 (defun projectile--parse-dirconfig-file-uncached ()
   "Parse the dirconfig file without caching.
 Return a `projectile-dirconfig' or nil if the file doesn't exist."
-  (let (keep ignore ensure (dirconfig (projectile-dirconfig-file)))
+  (let ((dirconfig (projectile-dirconfig-file)))
     (when (projectile-file-exists-p dirconfig)
-      (with-temp-buffer
-        (insert-file-contents dirconfig)
-        (while (not (eobp))
-          ;; Skip leading whitespace so prefix dispatch isn't defeated by
-          ;; an accidental space or tab before the +/-/! marker or the
-          ;; configured comment character.
-          (skip-chars-forward " \t")
-          (pcase (char-after)
-            ;; ignore comment lines if prefix char has been set
-            ((pred (lambda (leading-char)
-                     (and projectile-dirconfig-comment-prefix
-                          (eql leading-char
-                               projectile-dirconfig-comment-prefix))))
-             nil)
-            (?+ (push (buffer-substring (1+ (point)) (line-end-position)) keep))
-            (?- (push (buffer-substring (1+ (point)) (line-end-position)) ignore))
-            (?! (push (buffer-substring (1+ (point)) (line-end-position)) ensure))
-            (_ (push (buffer-substring (point) (line-end-position)) ignore)))
-          (forward-line)))
-      (let ((trimmed-keep (mapcar #'string-trim (delete "" (reverse keep)))))
-        (dolist (entry trimmed-keep)
+      (let ((cfg (projectile--parse-dirconfig-string
+                  (with-temp-buffer
+                    (insert-file-contents dirconfig)
+                    (buffer-string)))))
+        (dolist (entry (projectile-dirconfig-keep cfg))
           (when (string-match-p "[*?[]" entry)
             (projectile--warn-glob-in-keep-entry entry dirconfig)))
-        (make-projectile-dirconfig
-         :keep (mapcar #'file-name-as-directory trimmed-keep)
-         :ignore (mapcar #'string-trim (delete "" (reverse ignore)))
-         :ensure (mapcar #'string-trim (delete "" (reverse ensure))))))))
+        cfg))))
 
 (defun projectile-parse-dirconfig-file ()
   "Parse project ignore file and return its rules.

--- a/projectile.el
+++ b/projectile.el
@@ -1516,8 +1516,10 @@ If PROJECT is not specified acts on the current project."
 ;;; Project indexing
 (defun projectile-get-project-directories (project-dir)
   "Get the list of PROJECT-DIR directories that are of interest to the user."
-  (mapcar (lambda (subdir) (concat project-dir subdir))
-          (or (car (projectile-parse-dirconfig-file)) '(""))))
+  (let* ((cfg (projectile-parse-dirconfig-file))
+         (keep (and cfg (projectile-dirconfig-keep cfg))))
+    (mapcar (lambda (subdir) (concat project-dir subdir))
+            (or keep '("")))))
 
 (defun projectile--directory-p (directory)
   "Checks if DIRECTORY is a string designating a valid directory."
@@ -2101,13 +2103,23 @@ Unignored files are not included."
 Unignored directories are not included."
   (seq-filter 'file-directory-p (projectile-project-ignored)))
 
+(defun projectile--dirconfig-ignore ()
+  "Return the IGNORE entries from the project's dirconfig, or nil."
+  (when-let* ((cfg (projectile-parse-dirconfig-file)))
+    (projectile-dirconfig-ignore cfg)))
+
+(defun projectile--dirconfig-ensure ()
+  "Return the ENSURE entries from the project's dirconfig, or nil."
+  (when-let* ((cfg (projectile-parse-dirconfig-file)))
+    (projectile-dirconfig-ensure cfg)))
+
 (defun projectile-paths-to-ignore ()
   "Return a list of ignored project paths."
-  (projectile-normalise-paths (cadr (projectile-parse-dirconfig-file))))
+  (projectile-normalise-paths (projectile--dirconfig-ignore)))
 
 (defun projectile-patterns-to-ignore ()
   "Return a list of relative file patterns."
-  (projectile-normalise-patterns (cadr (projectile-parse-dirconfig-file))))
+  (projectile-normalise-patterns (projectile--dirconfig-ignore)))
 
 (defun projectile-project-ignored ()
   "Return list of project ignored files/directories.
@@ -2151,7 +2163,7 @@ Unignored files/directories are not included."
 
 (defun projectile-paths-to-ensure ()
   "Return a list of unignored project paths."
-  (projectile-normalise-paths (caddr (projectile-parse-dirconfig-file))))
+  (projectile-normalise-paths (projectile--dirconfig-ensure)))
 
 (defun projectile-files-to-ensure ()
   (let ((default-directory (projectile-project-root)))
@@ -2160,7 +2172,7 @@ Unignored files/directories are not included."
 
 (defun projectile-patterns-to-ensure ()
   "Return a list of relative file patterns."
-  (projectile-normalise-patterns (caddr (projectile-parse-dirconfig-file))))
+  (projectile-normalise-patterns (projectile--dirconfig-ensure)))
 
 (defun projectile-filtering-patterns ()
   (cons (projectile-patterns-to-ignore)
@@ -2176,6 +2188,15 @@ Unignored files/directories are not included."
   "Return the absolute path to the project's dirconfig file."
   (expand-file-name projectile-dirconfig-file (projectile-project-root)))
 
+(cl-defstruct projectile-dirconfig
+  "Parsed contents of a project's dirconfig file.
+KEEP is the list of subdirectories to restrict the project to (as
+returned with a trailing slash).  IGNORE and ENSURE are the lists
+of files or directories to ignore and to forcibly include,
+respectively.  All slots default to nil, which represents \"no
+file present or no entries of this kind\"."
+  (keep nil) (ignore nil) (ensure nil))
+
 (defun projectile--warn-glob-in-keep-entry (entry dirconfig)
   "Warn that ENTRY in DIRCONFIG looks like a glob pattern after a `+'.
 The `+' prefix is for subdirectories only; the parser silently coerces
@@ -2190,7 +2211,7 @@ or move the pattern to a `-'/`!' rule."
 
 (defun projectile--parse-dirconfig-file-uncached ()
   "Parse the dirconfig file without caching.
-Returns a list of (KEEP IGNORE ENSURE) or nil if the file doesn't exist."
+Return a `projectile-dirconfig' or nil if the file doesn't exist."
   (let (keep ignore ensure (dirconfig (projectile-dirconfig-file)))
     (when (projectile-file-exists-p dirconfig)
       (with-temp-buffer
@@ -2216,20 +2237,19 @@ Returns a list of (KEEP IGNORE ENSURE) or nil if the file doesn't exist."
         (dolist (entry trimmed-keep)
           (when (string-match-p "[*?[]" entry)
             (projectile--warn-glob-in-keep-entry entry dirconfig)))
-        (list (mapcar #'file-name-as-directory trimmed-keep)
-              (mapcar #'string-trim
-                      (delete "" (reverse ignore)))
-              (mapcar #'string-trim
-                      (delete "" (reverse ensure))))))))
+        (make-projectile-dirconfig
+         :keep (mapcar #'file-name-as-directory trimmed-keep)
+         :ignore (mapcar #'string-trim (delete "" (reverse ignore)))
+         :ensure (mapcar #'string-trim (delete "" (reverse ensure))))))))
 
 (defun projectile-parse-dirconfig-file ()
-  "Parse project ignore file and return directories to ignore and keep.
+  "Parse project ignore file and return its rules.
 
-The return value is a list of three elements: the car is the list
-of directories to keep, the cadr is the list of files or
-directories to ignore, and the caddr is the list of files or
-directories to ensure (i.e. forcibly include even when otherwise
-ignored).
+The return value is a `projectile-dirconfig' struct with three
+slots: KEEP (subdirectories to restrict the project to), IGNORE
+(files or directories to skip), and ENSURE (files or directories
+to forcibly include even when otherwise ignored).  When the file
+does not exist, the return value is nil.
 
 Lines are dispatched on their first non-whitespace character:
 

--- a/projectile.el
+++ b/projectile.el
@@ -415,6 +415,17 @@ silent bypass is a frequent source of confusion."
   :type 'boolean
   :package-version '(projectile . "2.10.0"))
 
+(defcustom projectile-warn-on-prefixless-dirconfig-lines t
+  "Whether to warn about deprecated prefix-less ignore entries.
+Lines in `.projectile' that start with no `+'/`-'/`!' prefix are
+still accepted as ignore patterns for backward compatibility, but
+the implicit form is being phased out.  When this option is
+non-nil, a one-time warning is shown per project that uses any
+such line, listing the offending entries."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "2.10.0"))
+
 (defcustom projectile-globally-ignored-files
   (list projectile-tags-file-name projectile-cache-file)
   "A list of files globally ignored by projectile.
@@ -666,6 +677,9 @@ Each value is a cons of (MTIME . PARSED-RESULT).")
 
 (defvar projectile--alien-dirconfig-warned-projects (make-hash-table :test 'equal)
   "Set of project roots already warned about alien indexing skipping the dirconfig.")
+
+(defvar projectile--prefixless-dirconfig-warned-projects (make-hash-table :test 'equal)
+  "Set of project roots already warned about prefix-less dirconfig entries.")
 
 (defvar projectile-known-projects nil
   "List of locations where we have previously seen projects.
@@ -2193,9 +2207,11 @@ Unignored files/directories are not included."
 KEEP is the list of subdirectories to restrict the project to (as
 returned with a trailing slash).  IGNORE and ENSURE are the lists
 of files or directories to ignore and to forcibly include,
-respectively.  All slots default to nil, which represents \"no
-file present or no entries of this kind\"."
-  (keep nil) (ignore nil) (ensure nil))
+respectively.  PREFIXLESS-IGNORE is the subset of IGNORE entries
+that arrived without a leading `+'/`-'/`!'/comment marker; they
+are accepted for backward compatibility but recorded separately so
+callers can flag the deprecated syntax.  All slots default to nil."
+  (keep nil) (ignore nil) (ensure nil) (prefixless-ignore nil))
 
 (defun projectile--warn-glob-in-keep-entry (entry dirconfig)
   "Warn that ENTRY in DIRCONFIG looks like a glob pattern after a `+'.
@@ -2212,9 +2228,12 @@ or move the pattern to a `-'/`!' rule."
 (defun projectile--dirconfig-classify-line (line)
   "Classify LINE from a dirconfig file.
 Return a cons (BUCKET . VALUE) where BUCKET is one of `:keep',
-`:ignore', `:ensure', or `:comment'.  Return nil for a blank line.
-Leading whitespace is skipped before dispatch so an accidental space
-or tab before the prefix does not change classification."
+`:ignore', `:ensure', `:legacy-ignore', or `:comment'.  Return nil
+for a blank line.  Leading whitespace is skipped before dispatch
+so an accidental space or tab before the prefix does not change
+classification.  `:legacy-ignore' is reserved for prefix-less
+lines, which are still treated as ignore patterns for backward
+compatibility but are tracked separately so callers can warn."
   (let* ((trimmed (string-trim-left line))
          (first-char (and (> (length trimmed) 0) (aref trimmed 0))))
     (cond
@@ -2222,23 +2241,27 @@ or tab before the prefix does not change classification."
      ((and projectile-dirconfig-comment-prefix
            (eql first-char projectile-dirconfig-comment-prefix))
       (cons :comment nil))
-     ((eql first-char ?+) (cons :keep   (string-trim (substring trimmed 1))))
-     ((eql first-char ?-) (cons :ignore (string-trim (substring trimmed 1))))
-     ((eql first-char ?!) (cons :ensure (string-trim (substring trimmed 1))))
-     (t                   (cons :ignore (string-trim trimmed))))))
+     ((eql first-char ?+) (cons :keep          (string-trim (substring trimmed 1))))
+     ((eql first-char ?-) (cons :ignore        (string-trim (substring trimmed 1))))
+     ((eql first-char ?!) (cons :ensure        (string-trim (substring trimmed 1))))
+     (t                   (cons :legacy-ignore (string-trim trimmed))))))
 
 (defun projectile--parse-dirconfig-string (text)
   "Parse TEXT (a dirconfig file's contents) into a `projectile-dirconfig'."
-  (let (keep ignore ensure)
+  (let (keep ignore ensure prefixless)
     (dolist (line (split-string text "\n"))
       (pcase (projectile--dirconfig-classify-line line)
-        (`(:keep   . ,v) (unless (string-empty-p v) (push v keep)))
-        (`(:ignore . ,v) (unless (string-empty-p v) (push v ignore)))
-        (`(:ensure . ,v) (unless (string-empty-p v) (push v ensure)))))
+        (`(:keep . ,v)          (unless (string-empty-p v) (push v keep)))
+        (`(:ignore . ,v)        (unless (string-empty-p v) (push v ignore)))
+        (`(:ensure . ,v)        (unless (string-empty-p v) (push v ensure)))
+        (`(:legacy-ignore . ,v) (unless (string-empty-p v)
+                                  (push v ignore)
+                                  (push v prefixless)))))
     (make-projectile-dirconfig
-     :keep   (mapcar #'file-name-as-directory (nreverse keep))
-     :ignore (nreverse ignore)
-     :ensure (nreverse ensure))))
+     :keep              (mapcar #'file-name-as-directory (nreverse keep))
+     :ignore            (nreverse ignore)
+     :ensure            (nreverse ensure)
+     :prefixless-ignore (nreverse prefixless))))
 
 (defun projectile--parse-dirconfig-file-uncached ()
   "Parse the dirconfig file without caching.
@@ -2253,6 +2276,28 @@ Return a `projectile-dirconfig' or nil if the file doesn't exist."
           (when (string-match-p "[*?[]" entry)
             (projectile--warn-glob-in-keep-entry entry dirconfig)))
         cfg))))
+
+(defun projectile--maybe-warn-prefixless-entries (project-root cfg)
+  "Warn once per session about prefix-less ignore entries in CFG for PROJECT-ROOT.
+CFG is a `projectile-dirconfig' struct."
+  (when (and projectile-warn-on-prefixless-dirconfig-lines
+             cfg
+             (projectile-dirconfig-prefixless-ignore cfg)
+             (not (gethash project-root
+                           projectile--prefixless-dirconfig-warned-projects)))
+    (puthash project-root t projectile--prefixless-dirconfig-warned-projects)
+    (display-warning
+     'projectile
+     (format "%s contains entries without a `+'/`-'/`!' prefix: %s.  \
+The implicit form is treated as an ignore rule for backward \
+compatibility but is being phased out — please prefix the lines \
+explicitly.  Set `projectile-warn-on-prefixless-dirconfig-lines' \
+to nil to silence this warning."
+             (expand-file-name projectile-dirconfig-file project-root)
+             (mapconcat (lambda (s) (format "`%s'" s))
+                        (projectile-dirconfig-prefixless-ignore cfg)
+                        ", "))
+     :warning)))
 
 (defun projectile-parse-dirconfig-file ()
   "Parse project ignore file and return its rules.
@@ -2280,13 +2325,17 @@ dirconfig file's modification time changes."
          (project-root (projectile-project-root))
          (cached (gethash project-root projectile--dirconfig-cache))
          (attrs (file-attributes dirconfig))
-         (mtime (when attrs (file-attribute-modification-time attrs))))
-    (if (and cached mtime (equal (car cached) mtime))
-        (cdr cached)
-      (let ((result (projectile--parse-dirconfig-file-uncached)))
-        (when mtime
-          (puthash project-root (cons mtime result) projectile--dirconfig-cache))
-        result))))
+         (mtime (when attrs (file-attribute-modification-time attrs)))
+         (result (if (and cached mtime (equal (car cached) mtime))
+                     (cdr cached)
+                   (let ((parsed (projectile--parse-dirconfig-file-uncached)))
+                     (when mtime
+                       (puthash project-root
+                                (cons mtime parsed)
+                                projectile--dirconfig-cache))
+                     parsed))))
+    (projectile--maybe-warn-prefixless-entries project-root result)
+    result))
 
 (defun projectile-expand-root (name &optional dir)
   "Expand NAME to project root.

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -527,6 +527,37 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
         (let ((projectile-globally-unignored-files '("path/unignored-file")))
           (expect (projectile-add-unignored nil nil '("file")) :to-equal '("file" "path/unignored-file")))))))
 
+(describe "projectile--dirconfig-classify-line"
+  (it "returns nil for blank or whitespace-only lines"
+    (expect (projectile--dirconfig-classify-line "") :to-be nil)
+    (expect (projectile--dirconfig-classify-line "   ") :to-be nil)
+    (expect (projectile--dirconfig-classify-line "\t") :to-be nil))
+  (it "classifies prefix dispatches"
+    (expect (projectile--dirconfig-classify-line "+/src")
+            :to-equal '(:keep . "/src"))
+    (expect (projectile--dirconfig-classify-line "-/build")
+            :to-equal '(:ignore . "/build"))
+    (expect (projectile--dirconfig-classify-line "!/build/keepme")
+            :to-equal '(:ensure . "/build/keepme")))
+  (it "treats prefix-less lines as ignore for backward compatibility"
+    (expect (projectile--dirconfig-classify-line "stale-pattern")
+            :to-equal '(:ignore . "stale-pattern")))
+  (it "skips leading whitespace before dispatch"
+    (expect (projectile--dirconfig-classify-line "  -indented")
+            :to-equal '(:ignore . "indented"))
+    (expect (projectile--dirconfig-classify-line "\t+keep")
+            :to-equal '(:keep . "keep")))
+  (it "honors the comment prefix when configured"
+    (let ((projectile-dirconfig-comment-prefix ?#))
+      (expect (projectile--dirconfig-classify-line "# a comment")
+              :to-equal '(:comment))
+      (expect (projectile--dirconfig-classify-line "  # indented comment")
+              :to-equal '(:comment)))
+    ;; Without a comment prefix, # is just a regular character.
+    (let ((projectile-dirconfig-comment-prefix nil))
+      (expect (projectile--dirconfig-classify-line "#may-be-a-comment")
+              :to-equal '(:ignore . "#may-be-a-comment")))))
+
 (describe "projectile-parse-dirconfig-file"
   (it "parses dirconfig and returns directories to ignore and keep"
     (spy-on 'file-exists-p :and-return-value t)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -534,22 +534,23 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
     (spy-on 'insert-file-contents :and-call-fake
             (lambda (filename)
               (save-excursion (insert "\n-exclude\n+include\n#may-be-a-comment\nno-prefix\n left-wspace\nright-wspace\t\n"))))
-    (expect (projectile-parse-dirconfig-file) :to-equal '(("include/")
-                                                          ("exclude"
-							   "#may-be-a-comment"
-							   "no-prefix"
-							   "left-wspace"
-							   "right-wspace")
-                                                          nil))
+    (expect (projectile-parse-dirconfig-file)
+            :to-equal (make-projectile-dirconfig
+                       :keep '("include/")
+                       :ignore '("exclude"
+                                 "#may-be-a-comment"
+                                 "no-prefix"
+                                 "left-wspace"
+                                 "right-wspace")))
     ;; same test - but with comment lines enabled using prefix '#'
     (let ((projectile-dirconfig-comment-prefix ?#))
-      (expect (projectile-parse-dirconfig-file) :to-equal '(("include/")
-							    ("exclude"
-							     "no-prefix"
-							     "left-wspace"
-							     "right-wspace")
-							    nil)))
-    )
+      (expect (projectile-parse-dirconfig-file)
+              :to-equal (make-projectile-dirconfig
+                         :keep '("include/")
+                         :ignore '("exclude"
+                                   "no-prefix"
+                                   "left-wspace"
+                                   "right-wspace")))))
   (it "skips leading whitespace before dispatching on the prefix"
     (spy-on 'file-exists-p :and-return-value t)
     (spy-on 'insert-file-contents :and-call-fake
@@ -560,9 +561,10 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
                         " !indented-ensure\n"
                         "  no-prefix-indented\n"))))
     (expect (projectile-parse-dirconfig-file)
-            :to-equal '(("indented-include/")
-                        ("indented-exclude" "no-prefix-indented")
-                        ("indented-ensure"))))
+            :to-equal (make-projectile-dirconfig
+                       :keep '("indented-include/")
+                       :ignore '("indented-exclude" "no-prefix-indented")
+                       :ensure '("indented-ensure"))))
   (it "treats indented comment-prefix lines as comments"
     (spy-on 'file-exists-p :and-return-value t)
     (spy-on 'insert-file-contents :and-call-fake
@@ -572,7 +574,7 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
                         "-keep-this\n"))))
     (let ((projectile-dirconfig-comment-prefix ?#))
       (expect (projectile-parse-dirconfig-file)
-              :to-equal '(nil ("keep-this") nil))))
+              :to-equal (make-projectile-dirconfig :ignore '("keep-this")))))
   (it "warns when a + keep entry contains glob metacharacters"
     (spy-on 'file-exists-p :and-return-value t)
     (spy-on 'insert-file-contents :and-call-fake
@@ -613,9 +615,10 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
                   "stale-pattern\n"))
         (spy-on 'projectile-project-root :and-return-value root)
         (expect (projectile-parse-dirconfig-file)
-                :to-equal '(("/src/")
-                            ("/build" "stale-pattern")
-                            ("/build/keepme")))))))
+                :to-equal (make-projectile-dirconfig
+                           :keep '("/src/")
+                           :ignore '("/build" "stale-pattern")
+                           :ensure '("/build/keepme")))))))
   (it "round-trips non-ASCII paths through the parser"
     (projectile-test-with-sandbox
      (projectile-test-with-files
@@ -627,9 +630,9 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
                   "+/プロジェクト\n"))
         (spy-on 'projectile-project-root :and-return-value root)
         (expect (projectile-parse-dirconfig-file)
-                :to-equal '(("/プロジェクト/")
-                            ("héllo/wörld")
-                            nil))))))
+                :to-equal (make-projectile-dirconfig
+                           :keep '("/プロジェクト/")
+                           :ignore '("héllo/wörld")))))))
   (it "tolerates a trailing line without a final newline"
     (projectile-test-with-sandbox
      (projectile-test-with-files
@@ -638,7 +641,7 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
         (with-temp-file (expand-file-name ".projectile" root)
           (insert "-foo\n-bar"))
         (spy-on 'projectile-project-root :and-return-value root)
-        (expect (cadr (projectile-parse-dirconfig-file))
+        (expect (projectile-dirconfig-ignore (projectile-parse-dirconfig-file))
                 :to-equal '("foo" "bar")))))))
 
 (describe "dirconfig cache"
@@ -667,14 +670,14 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
              (dirconfig (expand-file-name ".projectile" root)))
         (with-temp-file dirconfig (insert "-foo\n"))
         (spy-on 'projectile-project-root :and-return-value root)
-        (expect (cadr (projectile-parse-dirconfig-file))
+        (expect (projectile-dirconfig-ignore (projectile-parse-dirconfig-file))
                 :to-equal '("foo"))
         ;; Force a distinct mtime — file-attribute-modification-time has
         ;; second-level resolution on some filesystems.
         (set-file-times dirconfig (time-add (current-time) 5))
         (with-temp-file dirconfig (insert "-bar\n"))
         (set-file-times dirconfig (time-add (current-time) 5))
-        (expect (cadr (projectile-parse-dirconfig-file))
+        (expect (projectile-dirconfig-ignore (projectile-parse-dirconfig-file))
                 :to-equal '("bar"))))))
   (it "returns nil and does not cache when the dirconfig file is absent"
     (projectile-test-with-sandbox
@@ -766,11 +769,12 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
 (describe "projectile-get-project-directories"
   (it "gets the list of project directories"
     (spy-on 'projectile-project-root :and-return-value "/my/root/")
-    (spy-on 'projectile-parse-dirconfig-file :and-return-value '(nil))
+    (spy-on 'projectile-parse-dirconfig-file :and-return-value nil)
     (expect (projectile-get-project-directories "/my/root") :to-equal '("/my/root")))
   (it "gets the list of project directories with dirs to keep"
     (spy-on 'projectile-project-root :and-return-value "/my/root/")
-    (spy-on 'projectile-parse-dirconfig-file :and-return-value '(("foo" "bar/baz")))
+    (spy-on 'projectile-parse-dirconfig-file
+            :and-return-value (make-projectile-dirconfig :keep '("foo" "bar/baz")))
     (expect (projectile-get-project-directories "/my/root/") :to-equal '("/my/root/foo" "/my/root/bar/baz"))))
 
 (describe "projectile-dir-files"

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -539,9 +539,9 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
             :to-equal '(:ignore . "/build"))
     (expect (projectile--dirconfig-classify-line "!/build/keepme")
             :to-equal '(:ensure . "/build/keepme")))
-  (it "treats prefix-less lines as ignore for backward compatibility"
+  (it "tags prefix-less lines as legacy-ignore for backward compatibility"
     (expect (projectile--dirconfig-classify-line "stale-pattern")
-            :to-equal '(:ignore . "stale-pattern")))
+            :to-equal '(:legacy-ignore . "stale-pattern")))
   (it "skips leading whitespace before dispatch"
     (expect (projectile--dirconfig-classify-line "  -indented")
             :to-equal '(:ignore . "indented"))
@@ -556,7 +556,7 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
     ;; Without a comment prefix, # is just a regular character.
     (let ((projectile-dirconfig-comment-prefix nil))
       (expect (projectile--dirconfig-classify-line "#may-be-a-comment")
-              :to-equal '(:ignore . "#may-be-a-comment")))))
+              :to-equal '(:legacy-ignore . "#may-be-a-comment")))))
 
 (describe "projectile-parse-dirconfig-file"
   (it "parses dirconfig and returns directories to ignore and keep"
@@ -572,7 +572,11 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
                                  "#may-be-a-comment"
                                  "no-prefix"
                                  "left-wspace"
-                                 "right-wspace")))
+                                 "right-wspace")
+                       :prefixless-ignore '("#may-be-a-comment"
+                                            "no-prefix"
+                                            "left-wspace"
+                                            "right-wspace")))
     ;; same test - but with comment lines enabled using prefix '#'
     (let ((projectile-dirconfig-comment-prefix ?#))
       (expect (projectile-parse-dirconfig-file)
@@ -581,7 +585,10 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
                          :ignore '("exclude"
                                    "no-prefix"
                                    "left-wspace"
-                                   "right-wspace")))))
+                                   "right-wspace")
+                         :prefixless-ignore '("no-prefix"
+                                              "left-wspace"
+                                              "right-wspace")))))
   (it "skips leading whitespace before dispatching on the prefix"
     (spy-on 'file-exists-p :and-return-value t)
     (spy-on 'insert-file-contents :and-call-fake
@@ -595,7 +602,8 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
             :to-equal (make-projectile-dirconfig
                        :keep '("indented-include/")
                        :ignore '("indented-exclude" "no-prefix-indented")
-                       :ensure '("indented-ensure"))))
+                       :ensure '("indented-ensure")
+                       :prefixless-ignore '("no-prefix-indented"))))
   (it "treats indented comment-prefix lines as comments"
     (spy-on 'file-exists-p :and-return-value t)
     (spy-on 'insert-file-contents :and-call-fake
@@ -649,7 +657,8 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
                 :to-equal (make-projectile-dirconfig
                            :keep '("/src/")
                            :ignore '("/build" "stale-pattern")
-                           :ensure '("/build/keepme")))))))
+                           :ensure '("/build/keepme")
+                           :prefixless-ignore '("stale-pattern")))))))
   (it "round-trips non-ASCII paths through the parser"
     (projectile-test-with-sandbox
      (projectile-test-with-files
@@ -733,6 +742,48 @@ Just delegates OPERATION and ARGS for all operations except for`shell-command`'.
         (expect (gethash root projectile--dirconfig-cache) :not :to-be nil)
         (projectile-invalidate-cache nil)
         (expect (gethash root projectile--dirconfig-cache) :to-be nil))))))
+
+(describe "prefix-less dirconfig warning"
+  (before-each
+    (clrhash projectile--dirconfig-cache)
+    (clrhash projectile--prefixless-dirconfig-warned-projects))
+  (it "warns once when a dirconfig contains prefix-less ignore lines"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/.projectile")
+      (let ((root (file-truename (expand-file-name "project/"))))
+        (with-temp-file (expand-file-name ".projectile" root)
+          (insert "-foo\nstale-pattern\n"))
+        (spy-on 'projectile-project-root :and-return-value root)
+        (spy-on 'display-warning)
+        (let ((projectile-warn-on-prefixless-dirconfig-lines t))
+          (projectile-parse-dirconfig-file)
+          (projectile-parse-dirconfig-file))
+        (expect 'display-warning :to-have-been-called-times 1)))))
+  (it "does not warn for a fully-prefixed dirconfig"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/.projectile")
+      (let ((root (file-truename (expand-file-name "project/"))))
+        (with-temp-file (expand-file-name ".projectile" root)
+          (insert "-foo\n+/src\n!/build/keep\n"))
+        (spy-on 'projectile-project-root :and-return-value root)
+        (spy-on 'display-warning)
+        (let ((projectile-warn-on-prefixless-dirconfig-lines t))
+          (projectile-parse-dirconfig-file))
+        (expect 'display-warning :not :to-have-been-called)))))
+  (it "does not warn when the option is disabled"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/.projectile")
+      (let ((root (file-truename (expand-file-name "project/"))))
+        (with-temp-file (expand-file-name ".projectile" root)
+          (insert "stale-pattern\n"))
+        (spy-on 'projectile-project-root :and-return-value root)
+        (spy-on 'display-warning)
+        (let ((projectile-warn-on-prefixless-dirconfig-lines nil))
+          (projectile-parse-dirconfig-file))
+        (expect 'display-warning :not :to-have-been-called))))))
 
 (describe "alien-mode dirconfig warning"
   (before-each


### PR DESCRIPTION
Three follow-ups from #1993, in order from least to most invasive:

* **Return a `projectile-dirconfig` struct from the parser.** Replaces
  the positional `(KEEP IGNORE ENSURE)` triple. Every internal call
  site used `car`/`cadr`/`caddr` to pull out a slot — now they use
  named accessors (`projectile-dirconfig-keep` etc.). The struct has
  room to grow without a coordinated rewrite.

* **Split the parser into a pure line classifier.** The old parser
  walked a temp buffer with `point` and `pcase`'d on `char-after`,
  mixing IO, prefix dispatch, and bookkeeping. New
  `projectile--dirconfig-classify-line` takes a string and returns
  `(BUCKET . VALUE)`, and `projectile--parse-dirconfig-string`
  consumes the whole text. Both are unit-testable without buffer
  plumbing. The IO wrapper shrinks to read-and-dispatch.

* **Soft-deprecate prefix-less ignore entries.** Lines like
  `stale-pattern` (no `+`/`-`/`!`) are still accepted as ignore
  patterns, but the parser now records them in a separate
  `prefixless-ignore` slot and emits a one-time warning per project.
  This is the lingering source of subtle parser surprises — it's why
  a single leading space silently changes a `+`-keep into a literal
  ignore pattern. Controlled by the new
  `projectile-warn-on-prefixless-dirconfig-lines` option.

Test suite: 260 specs, 0 failed.