### PR TITLE
Normalize file path returned by projectile-files-from-cmd

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -5463,9 +5463,7 @@ CMD should include the necessary search params and should output
 equivalently to grep -HlI (only unique matching filenames).
 Returns a list of expanded filenames."
   (let ((default-directory directory))
-    (mapcar (lambda (str)
-              (concat directory
-                      (string-remove-prefix "./" str)))
+    (mapcar #'expand-file-name
             (split-string
              (string-trim (shell-command-to-string cmd))
              "\n+"


### PR DESCRIPTION
# Summary

On Windows, in the function `projectile-files-from-cmd`, the file path harvested in the standard output of running `cmd` may use backslash as folder separator.

Since the result of `projectile-files-from-cmd` are to be compared with the files from the current project in `projectile-replace`, both file path must be constructed/normalized in the same way for the comparison to be meaningful.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings

Thanks!
