### PR TITLE
Add concordance table and 'Migrating from project.el' page

### DIFF
--- a/doc/modules/ROOT/nav.adoc
+++ b/doc/modules/ROOT/nav.adoc
@@ -5,6 +5,7 @@
 * xref:configuration.adoc[Configuration]
 * xref:extensions.adoc[Extensions]
 * xref:projectile_vs_project.adoc[Projectile vs project.el]
+* xref:migrating_from_project_el.adoc[Migrating from project.el]
 * xref:faq.adoc[FAQ]
 * xref:troubleshooting.adoc[Troubleshooting]
 * xref:contributing.adoc[Contributing]

--- a/doc/modules/ROOT/pages/migrating_from_project_el.adoc
+++ b/doc/modules/ROOT/pages/migrating_from_project_el.adoc
@@ -1,0 +1,73 @@
+= Migrating from project.el
+
+A short guide for people who've been using Emacs's built-in `project.el` and want to try Projectile. For the bigger picture (philosophical differences, feature gaps in either direction) see xref:projectile_vs_project.adoc[Projectile versus project.el]; for a side-by-side mapping of commands and config knobs see the "Concept and command concordance" section there.
+
+== Quick start
+
+Install Projectile from MELPA (or NonGNU ELPA), enable the global mode, and bind a prefix key:
+
+[source,emacs-lisp]
+----
+(require 'projectile)
+(projectile-mode +1)
+(define-key projectile-mode-map (kbd "C-c p") 'projectile-command-map)
+----
+
+`project.el`'s `C-x p` keymap continues to work; Projectile's keymap is independent. The prefix doesn't have to be `C-c p` — many people use `s-p` or whatever else fits their setup.
+
+That's enough to get going. Most of `project.el`'s commands have a direct Projectile counterpart (e.g. `C-x p f` becomes `C-c p f`, `C-x p p` becomes `C-c p p`).
+
+== Behavioral differences worth knowing
+
+A handful of places where Projectile doesn't behave like `project.el`:
+
+* **Switching projects.** `project-switch-project` opens a command menu; Projectile instead runs whatever's in `projectile-switch-project-action` after picking a project (find-file by default). If you miss the menu UX, set `projectile-switch-project-action` to `projectile-commander` — same idea, different implementation.
+* **Indexing strategies.** Projectile has three (`native`, `hybrid`, `alien`) controlled by `projectile-indexing-method`. The default is `alien` and behaves like `project.el`'s VC backend (delegates to `git ls-files`, `fd`, `find` etc.). Pick `native` if you need to work somewhere external tools aren't available.
+* **`.projectile`.** Projectile's native config file is consulted only under `native` or `hybrid` indexing. Under `alien` (the default) it's mostly ignored — the external tool's ignore rules (`.gitignore` etc.) take over. So in most modern setups, `.projectile` doesn't do much.
+* **Project types.** Projectile auto-detects ~60 project types (Cargo, Maven, Mix, npm, etc.) and pre-fills `projectile-compile-project`, `projectile-test-project`, `projectile-run-project`, `projectile-install-project`, `projectile-package-project`, and `projectile-configure-project` with sensible defaults for each. There's no equivalent in `project.el` — `project-compile` runs whatever `compile-command` happens to be.
+* **Buffer ownership.** Projectile and `project.el` use slightly different rules to decide which buffers belong to a project. Don't expect `projectile-kill-buffers` and `project-kill-buffers` to act on identical sets.
+* **Persistent caches.** Projectile maintains a project-file cache (controlled by `projectile-enable-caching`) and a known-projects file (`projectile-known-projects-file`). The latter is roughly analogous to `project-list-file`, but the format differs.
+
+== Configuration knob translation
+
+Most knob-for-knob mappings are in the concordance table in xref:projectile_vs_project.adoc[the comparison page]. A few common ones:
+
+|===
+| If you had | Use
+
+| `project-list-file`
+| `projectile-known-projects-file`
+
+| `project-vc-ignores`
+| `projectile-globally-ignored-files`, `projectile-globally-ignored-directories`, `projectile-globally-ignored-file-suffixes`, plus the project-local `.projectile`
+
+| `project-vc-extra-root-markers`
+| `projectile-project-root-files-bottom-up` (and its sibling defcustoms)
+
+| `project-prompter`
+| `projectile-completion-system` (an enum: `auto`, `default`, `ido`, `ivy`, `helm`, or a custom function)
+
+| `project-vc-name`
+| `projectile-project-name` set via `.dir-locals.el`
+
+| `project-list-exclude`
+| `projectile-ignored-projects` (list) or `projectile-ignored-project-function` (predicate)
+|===
+
+== Things that don't have a direct equivalent (yet)
+
+A few `project.el` features have no real Projectile counterpart at the time of writing:
+
+* `project-find-matching-buffer` (jump to the equivalent buffer in another project)
+* `project-file-history-behavior` `'relativize` (file-name history rewritten across projects)
+* `project-other-window-command` / `-other-frame-command` / `-other-tab-command` (prefix-style display redirection — we duplicate commands instead)
+* Sparse-index support for Git
+* `project-vc-merge-submodules` (explicit Git submodule strategy)
+
+See xref:projectile_vs_project.adoc[the comparison page] for the full list.
+
+== Coexisting with project.el
+
+You don't have to pick one. `project.el` ships with Emacs and won't go away, and several other packages (`xref`, `eglot`, modern compilation buffers) will reach for `project-current` regardless of whether Projectile is loaded.
+
+In practice this means: enabling `projectile-mode` doesn't disable `project.el`. Both keymaps coexist, both sets of commands are available via `M-x`. Just keep in mind that some features (e.g. modeline integration, idle file-existence caching) come from `projectile-mode` itself, so if you turn the mode off you lose them.

--- a/doc/modules/ROOT/pages/projectile_vs_project.adoc
+++ b/doc/modules/ROOT/pages/projectile_vs_project.adoc
@@ -133,6 +133,294 @@ We're at parity (or close) on a few others:
 * `project-vc-name` and `project-vc-extra-root-markers` are covered by `projectile-project-name` (via dir-locals) and the project-type system.
 * `project-list-exclude` is covered by `projectile-ignored-projects` and `projectile-ignored-project-function` (the latter even accepts a predicate, e.g. `file-remote-p`).
 
+== Concept and command concordance
+
+Side-by-side mapping of the most common entry points. Useful both when picking between the two and when switching from one to the other. Empty cells mean there's no direct equivalent (which doesn't necessarily mean the functionality can't be had — just that you'd need to wire something up yourself).
+
+=== Project root and detection
+
+|===
+| Concept | Projectile | project.el
+
+| Project root of `default-directory`
+| `projectile-project-root`
+| `project-root` (via `project-current`)
+
+| Project name
+| `projectile-project-name`
+| `project-name`
+
+| Detection hook
+| `projectile-project-root-functions`
+| `project-find-functions`
+
+| Extra project markers
+| `projectile-project-root-files-bottom-up` (and friends)
+| `project-vc-extra-root-markers`
+
+| Native config file
+| `.projectile`
+| —
+|===
+
+=== File and directory navigation
+
+|===
+| Concept | Projectile | project.el
+
+| Find file in project
+| `projectile-find-file`
+| `project-find-file`
+
+| Find file in known projects
+| `projectile-find-file-in-known-projects`
+| —
+
+| Find directory
+| `projectile-find-dir`
+| `project-find-dir`
+
+| Open dired in root
+| `projectile-dired`
+| `project-dired`
+
+| Toggle test ↔ implementation
+| `projectile-toggle-between-implementation-and-test`
+| —
+
+| Find related file
+| `projectile-find-other-file`, `projectile-find-related-file`
+| —
+
+| "Other window/frame" variants
+| `…-other-window` / `…-other-frame` per command
+| `project-other-window-command` / `-other-frame-command` / `-other-tab-command` (prefix style)
+|===
+
+=== Buffer management
+
+|===
+| Concept | Projectile | project.el
+
+| Switch to project buffer
+| `projectile-switch-to-buffer`
+| `project-switch-to-buffer`
+
+| List project buffers
+| `projectile-display-buffer` / `projectile-ibuffer`
+| `project-list-buffers` (via `project-buffers-viewer`)
+
+| Kill project buffers
+| `projectile-kill-buffers`
+| `project-kill-buffers`
+
+| Save project buffers
+| `projectile-save-project-buffers`
+| `project-save-some-buffers`
+
+| Find equivalent buffer in another project
+| —
+| `project-find-matching-buffer`
+|===
+
+=== Search and replace
+
+|===
+| Concept | Projectile | project.el
+
+| Grep
+| `projectile-grep`
+| —
+
+| Ripgrep
+| `projectile-ripgrep`
+| —
+
+| Ag
+| `projectile-ag`
+| —
+
+| Find regex via xref
+| —
+| `project-find-regexp`
+
+| Multi-occur
+| `projectile-multi-occur`
+| —
+
+| Query-replace
+| `projectile-replace`, `projectile-replace-regexp`
+| `project-query-replace-regexp`
+
+| Find references
+| `projectile-find-references`
+| (use `xref-find-references`)
+|===
+
+=== Build, test, run, VC
+
+|===
+| Concept | Projectile | project.el
+
+| Compile
+| `projectile-compile-project`
+| `project-compile`
+
+| Recompile
+| (re-runs last compile per project)
+| `project-recompile`
+
+| Test
+| `projectile-test-project`
+| —
+
+| Run
+| `projectile-run-project`
+| —
+
+| Configure
+| `projectile-configure-project`
+| —
+
+| Install
+| `projectile-install-project`
+| —
+
+| Package
+| `projectile-package-project`
+| —
+
+| VC dir
+| `projectile-vc`
+| `project-vc-dir`
+|===
+
+=== Shell, terminal, REPL
+
+|===
+| Concept | Projectile | project.el
+
+| Shell command in root
+| `projectile-run-shell-command-in-root`
+| `project-shell-command`
+
+| Async shell command in root
+| `projectile-run-async-shell-command-in-root`
+| `project-async-shell-command`
+
+| `M-x shell`
+| `projectile-run-shell`
+| `project-shell`
+
+| `M-x eshell`
+| `projectile-run-eshell`
+| `project-eshell`
+
+| `M-x term`
+| `projectile-run-term`
+| —
+
+| Vterm
+| `projectile-run-vterm`
+| —
+
+| Eat
+| `projectile-run-eat`
+| —
+
+| IELM
+| `projectile-run-ielm`
+| —
+
+| GDB
+| `projectile-run-gdb`
+| —
+|===
+
+=== Project switching and known projects
+
+|===
+| Concept | Projectile | project.el
+
+| Switch project
+| `projectile-switch-project`
+| `project-switch-project`
+
+| Switch to open project
+| `projectile-switch-open-project`
+| —
+
+| Forget project
+| `projectile-remove-known-project`
+| `project-forget-project`
+
+| Forget current
+| `projectile-remove-current-project-from-known-projects`
+| —
+
+| Remember project
+| `projectile-add-known-project`
+| `project-remember-project`
+
+| Discover projects in path
+| `projectile-discover-projects-in-search-path`
+| —
+
+| Clean up zombies (manual)
+| `projectile-cleanup-known-projects`
+| `project-forget-zombie-projects`
+
+| Auto-clean zombies
+| `projectile-auto-cleanup-known-projects` (boolean)
+| `project-prune-zombie-projects` (granular triggers)
+
+| Known-projects file
+| `projectile-known-projects-file`
+| `project-list-file`
+
+| Block from being remembered
+| `projectile-ignored-projects`, `projectile-ignored-project-function`
+| `project-list-exclude`
+|===
+
+=== Configuration and extension
+
+|===
+| Concept | Projectile | project.el
+
+| Custom completion UI
+| `projectile-completion-system` (enum)
+| `project-prompter` (function)
+
+| Custom file-name reader
+| —
+| `project-read-file-name-function`
+
+| Persistent file cache
+| `projectile-cache-file`
+| —
+
+| Ignore patterns
+| `projectile-globally-ignored-files`, `…-directories`, `…-file-suffixes`, `.projectile`
+| `project-vc-ignores`, plus `.gitignore`/`.hgignore`
+
+| Per-project name override
+| `projectile-project-name` (via dir-locals)
+| `project-vc-name` (via dir-locals)
+
+| Edit dir-locals
+| `projectile-edit-dir-locals`
+| `project-customize-dirlocals`
+
+| Backend extension
+| `projectile-register-project-type` (project types)
+| `cl-defmethod` on the project protocol
+
+| Switch-project hook
+| `projectile-before-switch-project-hook`, `projectile-after-switch-project-hook`
+| —
+|===
+
 == Projectile's Pros
 
 * Projectile targets Emacs 27.1, so you can get all the features even with older Emacs releases


### PR DESCRIPTION
Two related additions to the project.el comparison docs:

1. **Concept and command concordance table** in `projectile_vs_project.adoc` — a side-by-side mapping grouped into 8 sub-tables (project root and detection, file/dir navigation, buffer management, search and replace, build/test/run/VC, shells/REPLs, project switching and known projects, configuration and extension). Useful both when picking between the two and when switching from one to the other.

2. **New page `migrating_from_project_el.adoc`** — a focused guide for people coming from `project.el`. Covers a quick-start, behavioral differences worth knowing (switch-project UX, indexing strategies, `.projectile` semantics, project types, buffer ownership, caches), a short "if you had X, use Y" config translation table, things that don't have a direct equivalent yet, and how the two can coexist.

Wired the new page into `nav.adoc` next to the comparison.