### PR TITLE
Batch directory listings in project detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* `projectile-root-bottom-up` now probes each directory level with a single `directory-files` listing instead of one `file-exists-p` per marker (9 stats per level with the default VCS list). Over TRAMP a cache-miss walk up a deep tree drops from `depth * markers` round-trips to `depth`. Markers containing a path separator fall back to `file-exists-p`.
 * `projectile-get-immediate-sub-projects` skips the `git submodule foreach` shell-out for git projects with no `.gitmodules` file anywhere up the parent chain. Hot path for monorepos that index the project root often.
 * `projectile-discover-projects-in-directory` now uses `directory-files-no-dot-files-regexp` to skip `.` and `..` at the C level instead of doing the post-filter in Elisp - matches the indexing walker.
 * Document the anchored vs `*`-prefixed semantics of `projectile-globally-ignored-directories`, the `find` fallback's lack of common directory exclusions when `fd` isn't available, and how `fd`/`git ls-files` handle deleted-but-unstaged files differently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * `projectile-root-bottom-up` now probes each directory level with a single `directory-files` listing instead of one `file-exists-p` per marker (9 stats per level with the default VCS list). Over TRAMP a cache-miss walk up a deep tree drops from `depth * markers` round-trips to `depth`. Markers containing a path separator fall back to `file-exists-p`.
+* `projectile-detect-project-type` lists the project root once and answers plain-name markers from that listing rather than stat'ing each marker of every registered project type. On the first detection of a remote project this collapses dozens of round-trips into one. `projectile-verify-file`/`projectile-verify-files` gained an optional `entry-set` argument to support this; existing callers are unaffected.
 * `projectile-get-immediate-sub-projects` skips the `git submodule foreach` shell-out for git projects with no `.gitmodules` file anywhere up the parent chain. Hot path for monorepos that index the project root often.
 * `projectile-discover-projects-in-directory` now uses `directory-files-no-dot-files-regexp` to skip `.` and `..` at the C level instead of doing the post-filter in Elisp - matches the indexing walker.
 * Document the anchored vs `*`-prefixed semantics of `projectile-globally-ignored-directories`, the `find` fallback's lack of common directory exclusions when `fd` isn't available, and how `fd`/`git ls-files` handle deleted-but-unstaged files differently.

--- a/projectile.el
+++ b/projectile.el
@@ -1465,6 +1465,17 @@ Invoked automatically when `projectile-mode' is enabled."
 PATH may be a file or directory and directory paths may end with a slash."
   (directory-file-name (file-name-directory (directory-file-name (expand-file-name path)))))
 
+(defun projectile--directory-entry-set (directory)
+  "Return a hash set of the immediate entry names of DIRECTORY, or nil.
+A single `directory-files' call replaces one `file-exists-p' per
+candidate name - over TRAMP that turns N sequential remote round-trips
+into one.  Returns nil when DIRECTORY can't be listed (missing or
+permission denied)."
+  (when-let* ((entries (ignore-errors (directory-files directory nil nil t))))
+    (let ((set (make-hash-table :test 'equal :size (length entries))))
+      (dolist (entry entries) (puthash entry t set))
+      set)))
+
 (defun projectile--locate-dominating-file (file name first-match-only)
   "Walk up from FILE looking for NAME and return the matching directory.
 NAME is either a filename (matched via `projectile-file-exists-p' in
@@ -1538,12 +1549,28 @@ Return the first (topmost) matched directory or nil if not found."
   "Identify a project root in DIR by bottom-up search for files in LIST.
 If LIST is nil, use `projectile-project-root-files-bottom-up' instead.
 Return the first (bottommost) matched directory or nil if not found."
-  (projectile-locate-dominating-file
-   dir
-   (lambda (directory)
-     (let ((files (mapcar (lambda (file) (expand-file-name file directory))
-                          (or list projectile-project-root-files-bottom-up))))
-       (seq-some (lambda (file) (and file (file-exists-p file))) files)))))
+  (let ((markers (or list projectile-project-root-files-bottom-up)))
+    (projectile-locate-dominating-file
+     dir
+     (lambda (directory)
+       ;; Probe each level with a single `directory-files' listing rather
+       ;; than one `file-exists-p' per marker.  The default markers are all
+       ;; plain names sitting directly in the directory, so membership in
+       ;; the listing is equivalent; markers carrying a path separator
+       ;; (a user customization) can't be answered from the basename listing
+       ;; and fall back to `file-exists-p'.
+       (let ((entries nil) (listed nil))
+         (seq-some
+          (lambda (marker)
+            (cond
+             ((not marker) nil)
+             ((string-match-p "/" marker)
+              (file-exists-p (expand-file-name marker directory)))
+             (t (unless listed
+                  (setq entries (projectile--directory-entry-set directory)
+                        listed t))
+                (and entries (gethash marker entries)))))
+          markers))))))
 
 (defun projectile-root-top-down-recurring (dir &optional list)
   "Identify a project root in DIR by recurring top-down search for files in LIST.
@@ -4461,13 +4488,10 @@ wins, so changes here are visible to all VCS detection.")
 Issues a single `directory-files' call rather than one
 `file-exists-p' per marker - over TRAMP that turns 10 sequential
 remote round-trips into one."
-  (when-let* ((entries (ignore-errors
-                         (directory-files directory nil nil t))))
-    (let ((entry-set (make-hash-table :test 'equal :size (length entries))))
-      (dolist (e entries) (puthash e t entry-set))
-      (cl-some (lambda (cell)
-                 (and (gethash (car cell) entry-set) (cdr cell)))
-               projectile--vcs-markers))))
+  (when-let* ((entry-set (projectile--directory-entry-set directory)))
+    (cl-some (lambda (cell)
+               (and (gethash (car cell) entry-set) (cdr cell)))
+             projectile--vcs-markers)))
 
 (defun projectile-project-vcs (&optional project-root)
   "Determine the VCS used by the project if any.

--- a/projectile.el
+++ b/projectile.el
@@ -4410,23 +4410,29 @@ on the current project.  PROJECT-ROOT, if provided, is used for caching
 instead of re-resolving via `projectile-project-root'.
 
 Fallback to a generic project type when the type can't be determined."
-  (let ((project-type
-         (or (car (seq-find
-                   (lambda (project-type-record)
-                     (let ((project-type (car project-type-record))
-                           (marker (plist-get (cdr project-type-record) 'marker-files)))
-                       (if (functionp marker)
-                           (and (funcall marker dir) project-type)
-                         ;; An empty marker set is vacuously satisfied by
-                         ;; `projectile-verify-files' (`seq-every-p' over nil
-                         ;; is t), which would make the type match every
-                         ;; project.  Guard against it so clearing a type's
-                         ;; markers disables detection instead of inverting it.
-                         (and marker (projectile-verify-files marker dir) project-type))))
-                   projectile-project-types))
-             'generic)))
-    (puthash (or project-root (projectile-project-root dir))
-             project-type projectile-project-type-cache)
+  (let* ((root (or project-root (projectile-project-root dir)))
+         ;; List the root once and answer plain-name markers from the
+         ;; listing.  Detection walks every registered type (50+), and the
+         ;; vast majority use plain-name markers in the root, so this turns
+         ;; "one stat per marker per type" into a single `directory-files'
+         ;; call - a big win on the first detection of a remote project.
+         (entry-set (and root (projectile--directory-entry-set root)))
+         (project-type
+          (or (car (seq-find
+                    (lambda (project-type-record)
+                      (let ((project-type (car project-type-record))
+                            (marker (plist-get (cdr project-type-record) 'marker-files)))
+                        (if (functionp marker)
+                            (and (funcall marker dir) project-type)
+                          ;; An empty marker set is vacuously satisfied by
+                          ;; `projectile-verify-files' (`seq-every-p' over nil
+                          ;; is t), which would make the type match every
+                          ;; project.  Guard against it so clearing a type's
+                          ;; markers disables detection instead of inverting it.
+                          (and marker (projectile-verify-files marker dir entry-set) project-type))))
+                    projectile-project-types))
+              'generic)))
+    (puthash root project-type projectile-project-type-cache)
     project-type))
 
 (defun projectile-project-type (&optional dir)
@@ -4449,17 +4455,27 @@ The project type is cached for improved performance."
            (projectile-project-vcs)
            (projectile-project-type)))
 
-(defun projectile-verify-files (files &optional dir)
+(defun projectile-verify-files (files &optional dir entry-set)
   "Check whether all FILES exist in the project.
 When DIR is specified it checks DIR's project, otherwise
-it acts on the current project."
-  (seq-every-p #'(lambda (file) (projectile-verify-file file dir)) files))
+it acts on the current project.  ENTRY-SET, when non-nil, is a hash set
+of the project root's immediate entries (see
+`projectile--directory-entry-set') used to answer plain-name FILES
+without a `file-exists-p' round-trip each."
+  (seq-every-p (lambda (file) (projectile-verify-file file dir entry-set)) files))
 
-(defun projectile-verify-file (file &optional dir)
+(defun projectile-verify-file (file &optional dir entry-set)
   "Check whether FILE exists in the current project.
 When DIR is specified it checks DIR's project, otherwise
-it acts on the current project."
-  (file-exists-p (projectile-expand-root file dir)))
+it acts on the current project.
+
+ENTRY-SET, when non-nil, is a hash set of the project root's immediate
+entries.  A plain-name FILE (one sitting directly in the root) is then
+answered by membership in ENTRY-SET instead of a filesystem stat; a FILE
+carrying a path separator can't be and falls back to `file-exists-p'."
+  (if (and entry-set (not (string-match-p "/" file)))
+      (and (gethash file entry-set) t)
+    (file-exists-p (projectile-expand-root file dir))))
 
 (defun projectile-verify-file-wildcard (file &optional dir)
   "Check whether FILE exists in the current project.

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1685,6 +1685,17 @@ by `projectile-files-via-ext-command')."
       (expect (projectile-root-bottom-up "worktree/src/" '(".git"))
               :to-equal
               (expand-file-name "worktree/")))))
+  (it "matches a marker containing a path separator via fallback"
+    ;; Plain markers are answered from a single directory listing per
+    ;; level; a marker carrying a `/' can't be, so it falls back to
+    ;; `file-exists-p' on the expanded path.
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("repo/build/marker"
+       "repo/sub/file.txt")
+      (expect (projectile-root-bottom-up "repo/sub/" '("build/marker"))
+              :to-equal
+              (expand-file-name "repo/")))))
   (it "lets an outer VC root win over a nearer manifest by default"
     ;; The default bottom-up list is VCS markers only, so in a monorepo
     ;; layout (`.git' at the top, a language manifest deeper down) the

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -2620,7 +2620,36 @@ by `projectile-files-via-ext-command')."
       (let ((projectile-project-types '((empty marker-files nil)))
             (projectile-project-type-cache (make-hash-table :test 'equal)))
         (spy-on 'projectile-project-root :and-return-value (file-truename (expand-file-name "project/")))
-        (expect (projectile-detect-project-type) :to-equal 'generic))))))
+        (expect (projectile-detect-project-type) :to-equal 'generic)))))
+  (it "detects a marker that sits in a subdirectory of the root"
+    ;; `debian/control' carries a path separator, so it can't be answered
+    ;; from the root's directory listing and exercises the file-exists-p
+    ;; fallback inside detection.
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/"
+       "project/debian/"
+       "project/debian/control")
+      (let ((projectile-indexing-method 'native)
+            (projectile-project-type-cache (make-hash-table :test 'equal)))
+        (spy-on 'projectile-project-root :and-return-value (file-truename (expand-file-name "project/")))
+        (expect (projectile-detect-project-type) :to-equal 'debian))))))
+
+(describe "projectile-verify-file"
+  (it "answers a plain-name file from the entry set without touching disk"
+    (let ((entry-set (make-hash-table :test 'equal)))
+      (puthash "Gemfile" t entry-set)
+      (spy-on 'file-exists-p :and-return-value nil)
+      (expect (projectile-verify-file "Gemfile" "/whatever/" entry-set) :to-be-truthy)
+      (expect (projectile-verify-file "absent" "/whatever/" entry-set) :not :to-be-truthy)
+      (expect 'file-exists-p :not :to-have-been-called)))
+  (it "falls back to file-exists-p for a marker with a path separator"
+    (let ((entry-set (make-hash-table :test 'equal)))
+      (puthash "debian" t entry-set)
+      (spy-on 'projectile-project-root :and-return-value "/root/")
+      (spy-on 'file-exists-p :and-return-value t)
+      (expect (projectile-verify-file "debian/control" nil entry-set) :to-be-truthy)
+      (expect 'file-exists-p :to-have-been-called-with "/root/debian/control"))))
 
 (describe "projectile-dirname-matching-count"
   (it "counts matching dirnames ascending file paths"


### PR DESCRIPTION
Follow-up to #2009 with the TRAMP perf work from that review. Two cache-miss hot paths in project detection were doing one `file-exists-p` per candidate; both now issue a single `directory-files` listing per directory, the same trick `projectile--vcs-from-directory-listing` already uses.

- `projectile-root-bottom-up`: `depth * markers` round-trips up a deep tree become `depth`.
- `projectile-detect-project-type`: dozens of stats across all registered types on first detection of a remote project become one.

Markers with a path separator fall back to `file-exists-p`, so nothing changes for `debian/control` and friends.