### PR TITLE
Implement project-ignores for the project.el backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Warn once per session when `projectile-indexing-method' is `alien' but the project has a non-empty `.projectile' file, so users notice their dirconfig rules are being bypassed. Controlled by the new `projectile-warn-when-dirconfig-is-ignored' option.
 * Warn when a `+' keep entry in `.projectile' contains glob metacharacters. The `+' prefix is for subdirectory paths only and globs are silently coerced into a non-matching directory name; the warning surfaces the misuse rather than letting it fail silently.
 * [#1964](https://github.com/bbatsov/projectile/issues/1964): Implement `project-name` and `project-buffers` methods for the `project.el` integration, so that code using `project.el` APIs returns correct results for Projectile-managed projects.
+* Implement the `project-ignores` method for the `project.el` integration, translating Projectile's global ignores, ignored file suffixes, and dirconfig (`.projectile`) ignore entries into the glob format `project.el` expects. This makes Projectile a more complete `project.el` backend for tools that rely on the protocol (e.g. `project-find-regexp`).
 * [#1837](https://github.com/bbatsov/projectile/issues/1837): Add `eat` project terminal commands with keybindings `x x` and `x 4 x`.
 * Add keybinding `A` (in the projectile command map) and a menu entry for `projectile-add-known-project`.
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -504,6 +504,11 @@ is enabled. You can also enable the integration manually like this:
 (add-hook 'project-find-functions #'project-projectile)
 ----
 
+Beyond root and file lookup, Projectile implements several of `project.el`'s
+backend methods (`project-root`, `project-files`, `project-name`,
+`project-buffers`, and `project-ignores`), so commands built on the protocol
+(e.g. `project-find-regexp`) behave correctly for Projectile-managed projects.
+
 TIP: You can read more about the implementation details of the integration https://github.com/bbatsov/projectile/issues/1591[here].
 
 That's useful as some packages (e.g. `eglot`) support natively only

--- a/projectile.el
+++ b/projectile.el
@@ -7273,6 +7273,39 @@ when opening new files."
 (cl-defmethod project-buffers ((project (head projectile)))
   (projectile-project-buffers (cdr project)))
 
+(cl-defmethod project-ignores ((project (head projectile)) _dir)
+  "Return a list of glob patterns to ignore in PROJECT.
+
+The patterns are derived from Projectile's ignore configuration and
+returned in the format expected by project.el (see `project-ignores'):
+globally ignored directory names and file suffixes are matched at any
+depth, while the files and directories ignored via the project's
+dirconfig (`.projectile') are rooted at the project root with a
+leading `./'."
+  ;; NOTE: Use the project root (the cdr) directly rather than
+  ;; `project-root', which doesn't exist on Emacs 27 (project.el provided
+  ;; `project-roots' there instead).
+  (let ((default-directory (cdr project)))
+    (append
+     ;; globally ignored directory names, matched at any depth
+     (mapcar (lambda (name)
+               (concat (directory-file-name name) "/"))
+             (projectile-globally-ignored-directory-names))
+     ;; globally ignored files, matched at any depth
+     (copy-sequence projectile-globally-ignored-files)
+     ;; globally ignored file suffixes as globs, e.g. "*.elc"
+     (projectile--globally-ignored-file-suffixes-glob)
+     ;; dirconfig patterns, matched by base name at any depth
+     (projectile-patterns-to-ignore)
+     ;; dirconfig ignored directories, rooted at the project root
+     (mapcar (lambda (dir)
+               (concat "./" (file-relative-name (directory-file-name dir)) "/"))
+             (projectile-project-ignored-directories))
+     ;; dirconfig ignored files, rooted at the project root
+     (mapcar (lambda (file)
+               (concat "./" (file-relative-name file)))
+             (projectile-project-ignored-files)))))
+
 ;;;###autoload
 (defun project-projectile (dir)
   "Return Projectile project of form ('projectile . root-dir) for DIR."

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -3219,6 +3219,35 @@ projectile-process-current-project-buffers-current to have similar behaviour"
                 (with-current-buffer (find-file-noselect "foo" t))
                 (expect (length (projectile-project-buffers)) :to-equal 1)))))
 
+(describe "project-ignores"
+  (it "returns ignore globs in the format expected by project.el"
+    (let ((root (file-truename (expand-file-name "/my/root/")))
+          (projectile-globally-ignored-files '("TAGS" ".#foo"))
+          (projectile-globally-ignored-file-suffixes '(".elc" ".o")))
+      (spy-on 'projectile-globally-ignored-directory-names
+              :and-return-value '(".git" ".svn/"))
+      (spy-on 'projectile-patterns-to-ignore :and-return-value '("*.log"))
+      (spy-on 'projectile-project-ignored-directories
+              :and-return-value (list (concat root "build/")
+                                      (concat root "dist/")))
+      (spy-on 'projectile-project-ignored-files
+              :and-return-value (list (concat root "TODO")))
+      (let ((ignores (project-ignores (cons 'projectile root) root)))
+        ;; globally ignored directory names match at any depth
+        (expect (member ".git/" ignores) :to-be-truthy)
+        (expect (member ".svn/" ignores) :to-be-truthy)
+        ;; globally ignored files match at any depth
+        (expect (member "TAGS" ignores) :to-be-truthy)
+        ;; suffixes become globs
+        (expect (member "*.elc" ignores) :to-be-truthy)
+        ;; dirconfig patterns are passed through
+        (expect (member "*.log" ignores) :to-be-truthy)
+        ;; dirconfig ignored directories are rooted and end with a slash
+        (expect (member "./build/" ignores) :to-be-truthy)
+        (expect (member "./dist/" ignores) :to-be-truthy)
+        ;; dirconfig ignored files are rooted
+        (expect (member "./TODO" ignores) :to-be-truthy)))))
+
 (describe "projectile--impl-name-for-test-name"
   :var ((mock-projectile-project-types
          '((foo test-suffix "Test")


### PR DESCRIPTION
Projectile already implements `project-root`, `project-files`, `project-name` and `project-buffers`, but project.el's protocol also expects `project-ignores`. Without it, tools that consult the backend for ignore globs (like `project-find-regexp`) fell back to project.el's generic defaults and never saw Projectile's own ignore configuration.

This adds the method, translating Projectile's global ignores, ignored file suffixes, and dirconfig (`.projectile`) ignore entries into the glob format project.el documents (global names match at any depth, dirconfig paths rooted with a leading `./`). That's the last real gap in the backend protocol - `project-roots` is obsolete and `project-external-roots` has no Projectile equivalent.