### PR TITLE
Add projectile-forget-projects-under and a zombie-cleanup alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 * Warn when a `+' keep entry in `.projectile' contains glob metacharacters. The `+' prefix is for subdirectory paths only and globs are silently coerced into a non-matching directory name; the warning surfaces the misuse rather than letting it fail silently.
 * [#1964](https://github.com/bbatsov/projectile/issues/1964): Implement `project-name` and `project-buffers` methods for the `project.el` integration, so that code using `project.el` APIs returns correct results for Projectile-managed projects.
 * Implement the `project-ignores` method for the `project.el` integration, translating Projectile's global ignores, ignored file suffixes, and dirconfig (`.projectile`) ignore entries into the glob format `project.el` expects. This makes Projectile a more complete `project.el` backend for tools that rely on the protocol (e.g. `project-find-regexp`).
+* Add `projectile-forget-projects-under` to drop all known projects located under a directory (with a prefix argument it recurses into nested projects). Mirrors `project.el`'s `project-forget-projects-under`.
+* Add `projectile-forget-zombie-projects` as an alias for `projectile-cleanup-known-projects`, for discoverability and parity with `project.el`'s `project-forget-zombie-projects`.
 * [#1837](https://github.com/bbatsov/projectile/issues/1837): Add `eat` project terminal commands with keybindings `x x` and `x 4 x`.
 * Add keybinding `A` (in the projectile command map) and a menu entry for `projectile-add-known-project`.
 

--- a/doc/modules/ROOT/pages/projectile_vs_project.adoc
+++ b/doc/modules/ROOT/pages/projectile_vs_project.adoc
@@ -358,6 +358,10 @@ Side-by-side mapping of the most common entry points. Useful both when picking b
 | `projectile-remove-current-project-from-known-projects`
 | —
 
+| Forget projects under dir
+| `projectile-forget-projects-under`
+| `project-forget-projects-under`
+
 | Remember project
 | `projectile-add-known-project`
 | `project-remember-project`
@@ -367,7 +371,7 @@ Side-by-side mapping of the most common entry points. Useful both when picking b
 | —
 
 | Clean up zombies (manual)
-| `projectile-cleanup-known-projects`
+| `projectile-cleanup-known-projects` (aliased as `projectile-forget-zombie-projects`)
 | `project-forget-zombie-projects`
 
 | Auto-clean zombies

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -93,6 +93,14 @@ around. (e.g. they were removed or renamed) You can either trigger the command
 TIP: If you're a heavy TRAMP user it's probably not a good idea to auto-discover
 and cleanup projects, as the file operations are slower there.
 
+`projectile-cleanup-known-projects` is also available under the alias
+`projectile-forget-zombie-projects`, if you're used to that name from `project.el`.
+
+To drop a whole group of known projects at once (e.g. after deleting a directory
+that held several checkouts) use `projectile-forget-projects-under`. It prompts
+for a directory and removes the known projects that live directly under it; with
+a prefix argument it also removes projects nested deeper in the tree.
+
 === Minibuffer Completion
 
 While Projectile works fine with Emacs's default minibuffer completion system you're highly encouraged to use some

--- a/projectile.el
+++ b/projectile.el
@@ -6522,6 +6522,50 @@ Return a list of projects removed."
     (message "No projects needed to be removed.")))
 
 ;;;###autoload
+(defalias 'projectile-forget-zombie-projects #'projectile-cleanup-known-projects
+  "Forget known projects that don't exist any more.
+An alias for `projectile-cleanup-known-projects', provided for
+discoverability and parity with project.el's
+`project-forget-zombie-projects'.")
+
+;;;###autoload
+(defun projectile-forget-projects-under (directory &optional recursive)
+  "Remove known projects located under DIRECTORY.
+
+Interactively, prompt for DIRECTORY.  With optional argument
+RECURSIVE non-nil (interactively, the prefix argument), remove
+projects nested at any depth under DIRECTORY; otherwise only remove
+projects that are immediate children of DIRECTORY.
+
+Matching is lexical (after `file-truename' expansion for local paths,
+which is skipped for remote ones to avoid a round-trip), so projects
+are removed even when DIRECTORY has already been deleted.  Mirrors
+project.el's `project-forget-projects-under'.  Return the number of
+projects removed."
+  (interactive "DForget projects under directory: \nP")
+  (let* ((expand (lambda (path)
+                   (file-name-as-directory
+                    (if (file-remote-p path) path (file-truename path)))))
+         (directory (funcall expand directory))
+         (projects-removed
+          (seq-filter
+           (lambda (project)
+             (let ((project (funcall expand project)))
+               (if recursive
+                   (string-prefix-p directory project)
+                 (string= (file-name-directory (directory-file-name project))
+                          directory))))
+           projectile-known-projects)))
+    (setq projectile-known-projects
+          (seq-difference projectile-known-projects projects-removed))
+    (projectile-merge-known-projects)
+    (if projects-removed
+        (message "Projects removed: %s"
+                 (mapconcat #'identity projects-removed ", "))
+      (message "No projects found under %s." (abbreviate-file-name directory)))
+    (length projects-removed)))
+
+;;;###autoload
 (defun projectile-clear-known-projects ()
   "Clear both `projectile-known-projects' and `projectile-known-projects-file'."
   (interactive)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1565,6 +1565,81 @@ by `projectile-files-via-ext-command')."
         (mapc (lambda (d) (ignore-errors (delete-directory d))) directories)
         (delete-file projectile-known-projects-file nil)))))
 
+(describe "projectile-forget-zombie-projects"
+  (it "is an alias for projectile-cleanup-known-projects"
+    (expect (symbol-function 'projectile-forget-zombie-projects)
+            :to-be 'projectile-cleanup-known-projects)))
+
+(describe "projectile-forget-projects-under"
+  (it "removes only immediate child projects by default"
+    (let* ((projectile-known-projects-file (projectile-test-tmp-file-path))
+           (projectile-known-projects-on-file nil)
+           (parent (file-name-as-directory (make-temp-file "projectile-forget" t)))
+           (child-a (file-name-as-directory (concat parent "a")))
+           (child-b (file-name-as-directory (concat parent "b")))
+           (nested (file-name-as-directory (concat child-a "nested")))
+           (outside (file-name-as-directory (make-temp-file "projectile-forget-out" t)))
+           (projectile-known-projects (list child-a child-b nested outside)))
+      (unwind-protect
+          (progn
+            (mkdir child-a t) (mkdir child-b t) (mkdir nested t)
+            (let ((removed (projectile-forget-projects-under parent)))
+              (expect removed :to-equal 2)
+              (expect projectile-known-projects :to-equal (list nested outside))))
+        (ignore-errors (delete-directory parent t))
+        (ignore-errors (delete-directory outside t))
+        (delete-file projectile-known-projects-file nil))))
+
+  (it "removes nested projects too when recursive"
+    (let* ((projectile-known-projects-file (projectile-test-tmp-file-path))
+           (projectile-known-projects-on-file nil)
+           (parent (file-name-as-directory (make-temp-file "projectile-forget" t)))
+           (child-a (file-name-as-directory (concat parent "a")))
+           (nested (file-name-as-directory (concat child-a "nested")))
+           (outside (file-name-as-directory (make-temp-file "projectile-forget-out" t)))
+           (projectile-known-projects (list child-a nested outside)))
+      (unwind-protect
+          (progn
+            (mkdir child-a t) (mkdir nested t)
+            (let ((removed (projectile-forget-projects-under parent t)))
+              (expect removed :to-equal 2)
+              (expect projectile-known-projects :to-equal (list outside))))
+        (ignore-errors (delete-directory parent t))
+        (ignore-errors (delete-directory outside t))
+        (delete-file projectile-known-projects-file nil))))
+
+  (it "removes projects even when the directory has been deleted"
+    (let* ((projectile-known-projects-file (projectile-test-tmp-file-path))
+           (projectile-known-projects-on-file nil)
+           (parent (file-name-as-directory (make-temp-file "projectile-forget" t)))
+           (child-a (file-name-as-directory (concat parent "a")))
+           (nested (file-name-as-directory (concat child-a "nested")))
+           (outside (file-name-as-directory (make-temp-file "projectile-forget-out" t)))
+           (projectile-known-projects (list child-a nested outside)))
+      (unwind-protect
+          (progn
+            (mkdir child-a t) (mkdir nested t)
+            (delete-directory parent t)
+            (let ((removed (projectile-forget-projects-under parent t)))
+              (expect removed :to-equal 2)
+              (expect projectile-known-projects :to-equal (list outside))))
+        (ignore-errors (delete-directory parent t))
+        (ignore-errors (delete-directory outside t))
+        (delete-file projectile-known-projects-file nil))))
+
+  (it "returns 0 and keeps the list when nothing matches"
+    (let* ((projectile-known-projects-file (projectile-test-tmp-file-path))
+           (projectile-known-projects-on-file nil)
+           (parent (file-name-as-directory (make-temp-file "projectile-forget" t)))
+           (outside (file-name-as-directory (make-temp-file "projectile-forget-out" t)))
+           (projectile-known-projects (list outside)))
+      (unwind-protect
+          (expect (projectile-forget-projects-under parent) :to-equal 0)
+        (expect projectile-known-projects :to-equal (list outside))
+        (ignore-errors (delete-directory parent t))
+        (ignore-errors (delete-directory outside t))
+        (delete-file projectile-known-projects-file nil)))))
+
 (describe "projectile-project-root"
   (it "returns the absolute root directory of a project"
     (let* ((root-directory (make-temp-file "projectile-absolute" t))


### PR DESCRIPTION
Borrows project.el's granular known-project cleanup. `projectile-forget-projects-under` forgets every known project under a directory - immediate children by default, the whole subtree with a prefix arg. Matching is lexical (after `file-truename` for local paths), so it works even when the directory is already gone, which is usually why you'd want to forget a batch of projects.

Also adds `projectile-forget-zombie-projects` as an alias for `projectile-cleanup-known-projects`, so folks migrating from project.el find it under the expected name.