### PR TITLE
Composable condition DSL for projectile-kill-buffers-filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Implement the `project-ignores` method for the `project.el` integration, translating Projectile's global ignores, ignored file suffixes, and dirconfig (`.projectile`) ignore entries into the glob format `project.el` expects. This makes Projectile a more complete `project.el` backend for tools that rely on the protocol (e.g. `project-find-regexp`).
 * Add `projectile-forget-projects-under` to drop all known projects located under a directory (with a prefix argument it recurses into nested projects). Mirrors `project.el`'s `project-forget-projects-under`.
 * Add `projectile-forget-zombie-projects` as an alias for `projectile-cleanup-known-projects`, for discoverability and parity with `project.el`'s `project-forget-zombie-projects`.
+* `projectile-kill-buffers-filter` now also accepts a composable list of conditions (buffer-name regexps, predicates, and `major-mode`/`derived-mode`/`not`/`and`/`or` forms), modeled on `project.el`'s `project-kill-buffer-conditions`. The existing `kill-all`, `kill-only-files`, and predicate-function values keep working unchanged.
 * [#1837](https://github.com/bbatsov/projectile/issues/1837): Add `eat` project terminal commands with keybindings `x x` and `x 4 x`.
 * Add keybinding `A` (in the projectile command map) and a menu entry for `projectile-add-known-project`.
 

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -1200,6 +1200,22 @@ When you run `projectile-kill-buffers` (kbd:[s-p k]), the variable
 You can also set it to a custom predicate function that receives a buffer and
 returns non-nil if the buffer should be killed.
 
+For finer control there's a small composable condition DSL (modeled on
+`project.el`'s `project-kill-buffer-conditions`). Set the filter to a list of
+conditions and a buffer is killed when it matches any of them:
+
+[source,elisp]
+----
+;; Kill file-visiting buffers and dired buffers, but leave everything else alone
+(setq projectile-kill-buffers-filter
+      '(buffer-file-name (derived-mode . dired-mode)))
+----
+
+Each condition is a buffer-name regexp, a predicate function, or a cons cell:
+`(major-mode . MODE)`, `(derived-mode . MODE)`, `(not COND)`, `(and COND...)`,
+or `(or COND...)`. The last three nest, so you can build arbitrarily specific
+rules. See the docstring of `projectile-kill-buffers-filter` for the details.
+
 === Uniquifying buffer names by project
 
 When you open same-named files from different projects (say two `README.md`

--- a/projectile.el
+++ b/projectile.el
@@ -159,13 +159,40 @@ When the kill-all option is selected, kills each buffer.
 When the kill-only-files option is selected, kill only the buffer
 associated to a file.
 
+It can also be a list of conditions, in which case a buffer is killed
+when it satisfies any of them.  This is a composable DSL modeled on
+project.el's `project-kill-buffer-conditions'.  Each condition is either:
+- a regular expression, matched against the buffer name,
+- a predicate function that takes the buffer as its argument and returns
+  non-nil if it should be killed,
+- a cons cell whose car says how to interpret the cdr:
+  * `major-mode' - kill if the buffer's major mode is `eq' to the cdr,
+  * `derived-mode' - kill if the buffer's major mode is derived from it,
+  * `not' - the cdr is a single negated condition,
+  * `and' - the cdr is a list of conditions that must all match,
+  * `or' - the cdr is a list of conditions, any of which match.
+
+An empty list (or nil) matches no buffers, so nothing is killed.
+
+For example, to kill only file-visiting buffers and dired buffers:
+
+  (setq projectile-kill-buffers-filter
+        \\='(buffer-file-name (derived-mode . dired-mode)))
+
 Otherwise, it should be a predicate that takes one argument: the buffer to
 be killed."
   :group 'projectile
-  :type '(radio
+  :type '(choice
           (const :tag "All project buffers" kill-all)
           (const :tag "Project file buffers" kill-only-files)
-          (function :tag "Predicate")))
+          (function :tag "Predicate")
+          (repeat :tag "Conditions"
+                  (choice regexp function symbol
+                          (cons :tag "Major mode" (const major-mode) symbol)
+                          (cons :tag "Derived mode" (const derived-mode) symbol)
+                          (cons :tag "Negation" (const not) sexp)
+                          (cons :tag "Conjunction" (const and) sexp)
+                          (cons :tag "Disjunction" (const or) sexp)))))
 
 (defcustom projectile-file-exists-local-cache-expire nil
   "Number of seconds before the local file existence cache expires.
@@ -5655,6 +5682,48 @@ to run the replacement."
     (fileloop-initialize-replace old-text new-text files 'default)
     (fileloop-continue)))
 
+(defun projectile--buffer-matches-conditions (buffer conditions)
+  "Return non-nil if BUFFER satisfies any condition in CONDITIONS.
+
+CONDITIONS is a list using the DSL documented in
+`projectile-kill-buffers-filter'.  Modeled on project.el's
+`project--buffer-check'."
+  (catch 'match
+    (dolist (c conditions)
+      (when (cond
+             ((stringp c)
+              (string-match-p c (buffer-name buffer)))
+             ((functionp c)
+              (funcall c buffer))
+             ((eq (car-safe c) 'major-mode)
+              (eq (buffer-local-value 'major-mode buffer) (cdr c)))
+             ((eq (car-safe c) 'derived-mode)
+              (provided-mode-derived-p
+               (buffer-local-value 'major-mode buffer) (cdr c)))
+             ((eq (car-safe c) 'not)
+              (not (projectile--buffer-matches-conditions buffer (cdr c))))
+             ((eq (car-safe c) 'or)
+              (projectile--buffer-matches-conditions buffer (cdr c)))
+             ((eq (car-safe c) 'and)
+              (seq-every-p
+               (apply-partially #'projectile--buffer-matches-conditions buffer)
+               (mapcar #'list (cdr c)))))
+        (throw 'match t)))))
+
+(defun projectile-buffer-killed-p (buffer)
+  "Return non-nil if BUFFER should be killed by `projectile-kill-buffers'.
+The decision follows `projectile-kill-buffers-filter'."
+  (cond
+   ((functionp projectile-kill-buffers-filter)
+    (funcall projectile-kill-buffers-filter buffer))
+   ((eq projectile-kill-buffers-filter 'kill-all) t)
+   ((eq projectile-kill-buffers-filter 'kill-only-files)
+    (buffer-file-name buffer))
+   ((listp projectile-kill-buffers-filter)
+    (projectile--buffer-matches-conditions buffer projectile-kill-buffers-filter))
+   (t (user-error "Invalid projectile-kill-buffers-filter value: %S"
+                  projectile-kill-buffers-filter))))
+
 ;;;###autoload
 (defun projectile-kill-buffers ()
   "Kill project buffers.
@@ -5673,12 +5742,7 @@ The buffers are killed according to the value of
                ;; we take care not to kill indirect buffers directly
                ;; as we might encounter them after their base buffers are killed
                (not (buffer-base-buffer buffer))
-               (if (functionp projectile-kill-buffers-filter)
-                   (funcall projectile-kill-buffers-filter buffer)
-                 (pcase projectile-kill-buffers-filter
-                   ('kill-all t)
-                   ('kill-only-files (buffer-file-name buffer))
-                   (_ (user-error "Invalid projectile-kill-buffers-filter value: %S" projectile-kill-buffers-filter)))))
+               (projectile-buffer-killed-p buffer))
           (kill-buffer buffer))))))
 
 ;;;###autoload

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -3294,6 +3294,88 @@ projectile-process-current-project-buffers-current to have similar behaviour"
                 (with-current-buffer (find-file-noselect "foo" t))
                 (expect (length (projectile-project-buffers)) :to-equal 1)))))
 
+(describe "projectile-buffer-killed-p"
+  (it "kills every buffer with the kill-all filter"
+    (let ((projectile-kill-buffers-filter 'kill-all))
+      (with-temp-buffer
+        (expect (projectile-buffer-killed-p (current-buffer)) :to-be-truthy))))
+
+  (it "kills only file-visiting buffers with the kill-only-files filter"
+    (let ((projectile-kill-buffers-filter 'kill-only-files))
+      (with-temp-buffer
+        (expect (projectile-buffer-killed-p (current-buffer)) :not :to-be-truthy)
+        (setq buffer-file-name "/tmp/projectile-killtest")
+        (expect (projectile-buffer-killed-p (current-buffer)) :to-be-truthy))))
+
+  (it "honors a predicate function filter"
+    (let ((projectile-kill-buffers-filter
+           (lambda (buf) (string-match-p "keep" (buffer-name buf)))))
+      (with-current-buffer (get-buffer-create "keep-me")
+        (expect (projectile-buffer-killed-p (current-buffer)) :to-be-truthy))
+      (with-current-buffer (get-buffer-create "drop-me")
+        (expect (projectile-buffer-killed-p (current-buffer)) :not :to-be-truthy))
+      (kill-buffer "keep-me")
+      (kill-buffer "drop-me")))
+
+  (it "signals a user-error for an invalid filter value"
+    (let ((projectile-kill-buffers-filter 42))
+      (with-temp-buffer
+        (expect (projectile-buffer-killed-p (current-buffer)) :to-throw 'user-error)))))
+
+(describe "projectile--buffer-matches-conditions"
+  (it "matches a buffer-name regexp condition"
+    (with-current-buffer (get-buffer-create "*scratch-test*")
+      (expect (projectile--buffer-matches-conditions
+               (current-buffer) '("\\`\\*scratch-test\\*\\'"))
+              :to-be-truthy)
+      (kill-buffer)))
+
+  (it "matches a predicate-function condition"
+    (with-temp-buffer
+      (setq buffer-file-name "/tmp/projectile-cond")
+      (expect (projectile--buffer-matches-conditions
+               (current-buffer) '(buffer-file-name))
+              :to-be-truthy)))
+
+  (it "matches major-mode and derived-mode conditions"
+    (with-temp-buffer
+      (lisp-mode)
+      (expect (projectile--buffer-matches-conditions
+               (current-buffer) '((major-mode . lisp-mode)))
+              :to-be-truthy)
+      (expect (projectile--buffer-matches-conditions
+               (current-buffer) '((major-mode . text-mode)))
+              :not :to-be-truthy)
+      (expect (projectile--buffer-matches-conditions
+               (current-buffer) '((derived-mode . prog-mode)))
+              :to-be-truthy)))
+
+  (it "composes conditions with and/or/not"
+    (with-temp-buffer
+      (text-mode)
+      (setq buffer-file-name "/tmp/projectile-compose")
+      (expect (projectile--buffer-matches-conditions
+               (current-buffer) '((and buffer-file-name (derived-mode . text-mode))))
+              :to-be-truthy)
+      (expect (projectile--buffer-matches-conditions
+               (current-buffer) '((and buffer-file-name (derived-mode . prog-mode))))
+              :not :to-be-truthy)
+      (expect (projectile--buffer-matches-conditions
+               (current-buffer) '((or (derived-mode . prog-mode) (derived-mode . text-mode))))
+              :to-be-truthy)
+      (expect (projectile--buffer-matches-conditions
+               (current-buffer) '((not (derived-mode . prog-mode))))
+              :to-be-truthy)))
+
+  (it "returns nil when no condition matches and for an empty list"
+    (with-temp-buffer
+      (fundamental-mode)
+      (expect (projectile--buffer-matches-conditions
+               (current-buffer) '((derived-mode . prog-mode)))
+              :not :to-be-truthy)
+      (expect (projectile--buffer-matches-conditions (current-buffer) nil)
+              :not :to-be-truthy))))
+
 (describe "project-ignores"
   (it "returns ignore globs in the format expected by project.el"
     (let ((root (file-truename (expand-file-name "/my/root/")))


### PR DESCRIPTION
`projectile-kill-buffers-filter` was limited to `kill-all`, `kill-only-files`, or a bare predicate - coarse next to project.el's `project-kill-buffer-conditions`. This teaches the filter to also accept a list of composable conditions: buffer-name regexps, predicate functions, and `(major-mode . M)` / `(derived-mode . M)` / `(not ...)` / `(and ...)` / `(or ...)` forms. A buffer is killed when it matches any condition. The matcher mirrors project.el's `project--buffer-check`.

Fully backward compatible - the existing symbol and predicate values are untouched. The per-buffer decision now lives in a small `projectile-buffer-killed-p` predicate.