### PR TITLE
[Fix #1809] Track and revisit the most recent project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### New features
 
+* [#1809](https://github.com/bbatsov/projectile/issues/1809): Track the project switched away from in `projectile-most-recent-project` and add `projectile-switch-to-most-recent-project` to jump back to it (repeated calls toggle between the two). Only switches made through Projectile's switch-project commands are tracked.
 * Add `projectile-uniquify-dirname-transform`, a project-aware value for `uniquify-dirname-transform` that disambiguates same-named buffers using the project name. Mirrors `project.el`'s `project-uniquify-dirname-transform`.
 * Add `projectile-dispatch`, a `transient` menu mirroring `projectile-command-map` for more discoverable command access. `transient` is an optional dependency (it requires Emacs 28+); the menu is only available when it's installed and is not bound to a key by default.
 * [#2008](https://github.com/bbatsov/projectile/issues/2008): Add `projectile-remove-project-type` to unregister a project type. This is the supported way to stop Projectile auto-detecting a type; clearing its `marker-files` does not work (see the related bug fix below).

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -156,7 +156,7 @@ NOTE: The extent of the support for every VCS differs and Git is the best suppor
 You need to know only a handful of Projectile commands to start benefiting from it.
 
 * Find file in current project (kbd:[s-p f])
-* Switch project (kbd:[s-p p]) (you can also switch between open projects with kbd:[s-p q])
+* Switch project (kbd:[s-p p]) (you can also switch between open projects with kbd:[s-p q], or jump back to the previously active project with `projectile-switch-to-most-recent-project`)
 * Grep (search for text/regexp) in project (kbd:[s-p s g])
 * Replace in project (kbd:[s-p r])
 * Find references in project (kbd:[s-p ?] or kbd:[s-p s x])

--- a/projectile.el
+++ b/projectile.el
@@ -6495,6 +6495,14 @@ It factors the value of `projectile-current-project-on-switch'."
       ('move-to-end (projectile--move-current-project-to-end open-projects))
       ('keep open-projects))))
 
+(defvar projectile-most-recent-project nil
+  "Root of the project that was current before the most recent project switch.
+
+Updated by `projectile-switch-project-by-name', so it only tracks
+switches made through Projectile's switch-project commands (not project
+changes that happen merely by visiting a file or buffer in another
+project).  Use `projectile-switch-to-most-recent-project' to jump to it.")
+
 ;;;###autoload
 (defun projectile-switch-project (&optional arg)
   "Switch to a project we have visited before.
@@ -6527,6 +6535,18 @@ With a prefix ARG invokes `projectile-commander' instead of
          :caller 'projectile-read-project)
       (user-error "There are no open projects"))))
 
+;;;###autoload
+(defun projectile-switch-to-most-recent-project (&optional arg)
+  "Switch to the project recorded in `projectile-most-recent-project'.
+That's the project that was current before the most recent project
+switch, so calling this from a buffer in the switched-to project takes
+you back where you came from.  With a prefix ARG invokes
+`projectile-commander' instead of `projectile-switch-project-action'."
+  (interactive "P")
+  (if projectile-most-recent-project
+      (projectile-switch-project-by-name projectile-most-recent-project arg)
+    (user-error "No most recent project recorded yet")))
+
 (defun projectile-switch-project-by-name (project-to-switch &optional arg)
   "Switch to project by project name PROJECT-TO-SWITCH.
 Invokes the command referenced by `projectile-switch-project-action' on switch.
@@ -6537,7 +6557,11 @@ With a prefix ARG invokes `projectile-commander' instead of
   (unless (or (file-remote-p project-to-switch) (projectile-project-p project-to-switch))
     (projectile-remove-known-project project-to-switch)
     (error "Directory %s is not a project" project-to-switch))
-  (let ((switch-project-action (if arg
+  ;; Record the project we're leaving so `projectile-most-recent-project'
+  ;; points at it after the switch (captured before `default-directory' is
+  ;; rebound below).
+  (let ((previous-project (projectile-project-root))
+        (switch-project-action (if arg
                                    'projectile-commander
                                  projectile-switch-project-action)))
     (run-hooks 'projectile-before-switch-project-hook)
@@ -6562,6 +6586,19 @@ With a prefix ARG invokes `projectile-commander' instead of
       ;; have lost that change, so switch back to the correct buffer.
       (when (buffer-live-p switched-buffer)
         (switch-to-buffer switched-buffer)))
+    ;; Don't record the project we just came from if it's the same one we
+    ;; switched to.  Compare with `file-equal-p' for local paths (handles
+    ;; symlinks/abbreviation), but fall back to a plain string compare when
+    ;; either side is remote, so we don't trigger a TRAMP round-trip (and
+    ;; possible hang) for an unconnected remote project - the very thing the
+    ;; remote skip above guards against.
+    (when (and previous-project
+               (not (if (or (file-remote-p previous-project)
+                            (file-remote-p project-to-switch))
+                        (string-equal (file-name-as-directory previous-project)
+                                      (file-name-as-directory project-to-switch))
+                      (file-equal-p previous-project project-to-switch))))
+      (setq projectile-most-recent-project previous-project))
     (run-hooks 'projectile-after-switch-project-hook)))
 
 ;;;###autoload

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -2385,6 +2385,46 @@ by `projectile-files-via-ext-command')."
                 (let ((default-directory "/"))
                   (expect (projectile-delete-dir-local-variable nil 'fooo 1) :to-throw 'error)) )))
 
+(describe "projectile-most-recent-project"
+  (it "records the project switched away from"
+    (let ((projectile-most-recent-project nil)
+          (projectile-switch-project-action #'ignore))
+      (projectile-test-with-sandbox
+        (projectile-test-with-files
+            ("project-a/" "project-a/.projectile"
+             "project-b/" "project-b/.projectile")
+          (let ((a (file-name-as-directory (expand-file-name "project-a")))
+                (b (file-name-as-directory (expand-file-name "project-b"))))
+            (projectile-add-known-project a)
+            (projectile-add-known-project b)
+            (let ((default-directory a))
+              (projectile-switch-project-by-name b))
+            (expect (file-equal-p projectile-most-recent-project a) :to-be-truthy))))))
+
+  (it "does not clobber the recent project when re-switching to the same one"
+    (let ((projectile-most-recent-project "/sentinel/")
+          (projectile-switch-project-action #'ignore))
+      (projectile-test-with-sandbox
+        (projectile-test-with-files
+            ("project-a/" "project-a/.projectile")
+          (let ((a (file-name-as-directory (expand-file-name "project-a"))))
+            (projectile-add-known-project a)
+            (let ((default-directory a))
+              (projectile-switch-project-by-name a))
+            (expect projectile-most-recent-project :to-equal "/sentinel/")))))))
+
+(describe "projectile-switch-to-most-recent-project"
+  (it "errors when no recent project is recorded"
+    (let ((projectile-most-recent-project nil))
+      (expect (projectile-switch-to-most-recent-project) :to-throw 'user-error)))
+
+  (it "switches to the recorded project"
+    (let ((projectile-most-recent-project "/proj/a/"))
+      (spy-on 'projectile-switch-project-by-name)
+      (projectile-switch-to-most-recent-project)
+      (expect 'projectile-switch-project-by-name
+              :to-have-been-called-with "/proj/a/" nil))))
+
 (describe "projectile-switch-project-by-name"
   (it "calls the switch project action with project-to-switch's dir-locals loaded"
     (defvar switch-project-foo)


### PR DESCRIPTION
Adds `projectile-most-recent-project`, which `projectile-switch-project-by-name` updates to point at the project you switched away from, and `projectile-switch-to-most-recent-project` to jump back to it. As discussed in the issue, only Projectile's switch-project commands update it - tracking project changes that happen by merely visiting a file or buffer can't be done reliably.

The same-project guard uses `file-equal-p` for local paths but a string compare when either side is remote, so it won't trigger a TRAMP round-trip for an unconnected remote project.

Fixes #1809.