### PR TITLE
[Fix #1861] Add projectile-discard-command-cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### New features
 
 * [#1809](https://github.com/bbatsov/projectile/issues/1809): Track the project switched away from in `projectile-most-recent-project` and add `projectile-switch-to-most-recent-project` to jump back to it (repeated calls toggle between the two). Only switches made through Projectile's switch-project commands are tracked.
+* [#1861](https://github.com/bbatsov/projectile/issues/1861): Add `projectile-discard-command-cache` to drop the cached configure/compile/test/install/package/run commands for the current project, so a freshly edited `.dir-locals.el` (or project-type default) is picked up on the next run. Can be called manually or added to `after-save-hook`.
 * Add `projectile-uniquify-dirname-transform`, a project-aware value for `uniquify-dirname-transform` that disambiguates same-named buffers using the project name. Mirrors `project.el`'s `project-uniquify-dirname-transform`.
 * Add `projectile-dispatch`, a `transient` menu mirroring `projectile-command-map` for more discoverable command access. `transient` is an optional dependency (it requires Emacs 28+); the menu is only available when it's installed and is not bound to a key by default.
 * [#2008](https://github.com/bbatsov/projectile/issues/2008): Add `projectile-remove-project-type` to unregister a project type. This is the supported way to stop Projectile auto-detecting a type; clearing its `marker-files` does not work (see the related bug fix below).

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -1261,6 +1261,13 @@ In addition caching of commands can be disabled by setting the variable
 `projectile-project-enable-cmd-caching` to `nil`. This is useful for
 preset-based CMake projects.
 
+Because the cached command takes precedence over the value from
+`.dir-locals.el` (and the project type default), editing those won't take
+effect until the cache is refreshed. Run `projectile-discard-command-cache`
+to drop the cached commands for the current project so they're re-read on the
+next run. You can also wire it into an `after-save-hook` for `.dir-locals.el`
+buffers if you edit them often.
+
 By default, Projectile will not add consecutive duplicate commands to its
 command history.  To alter this behaviour you can use `projectile-cmd-hist-ignoredups`.
   The default value of `t` means consecutive duplicates are ignored, a value

--- a/projectile.el
+++ b/projectile.el
@@ -5894,6 +5894,34 @@ Acts on the current project if not specified explicitly."
   (make-hash-table :test 'equal)
   "A mapping between projects and the last run command used on them.")
 
+;;;###autoload
+(defun projectile-discard-command-cache ()
+  "Discard the cached lifecycle commands for the current project.
+
+Projectile caches the last command used for each of the configure,
+compile, test, install, package, and run actions and prefers it over the
+value from `.dir-locals.el' or the project type's default.  After
+editing those, run this command so the next invocation re-reads them.
+Handy on `after-save-hook' for `.dir-locals.el' buffers.
+
+This only clears the cached commands, not the command history offered at
+the prompt.  See also `projectile-discard-root-cache'."
+  (interactive)
+  (let ((root (projectile-acquire-root)))
+    (dolist (command-map (list projectile-configure-cmd-map
+                               projectile-compilation-cmd-map
+                               projectile-install-cmd-map
+                               projectile-package-cmd-map
+                               projectile-test-cmd-map
+                               projectile-run-cmd-map))
+      (dolist (dir (hash-table-keys command-map))
+        (when (string-prefix-p root dir)
+          (remhash dir command-map))))
+    ;; Give feedback when invoked interactively; stay quiet when used
+    ;; programmatically (e.g. from `after-save-hook') unless verbose.
+    (when (or projectile-verbose (called-interactively-p 'interactive))
+      (message "Discarded Projectile command cache for %s" root))))
+
 (defvar projectile-project-enable-cmd-caching t
   "Enables command caching for the project.  Set to nil to disable.
 Should be set via .dir-locals.el.")

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -3645,6 +3645,36 @@ projectile-process-current-project-buffers-current to have similar behaviour"
       (funcall-interactively 'projectile-run-async-shell-command-in-root "cmd")
       (expect 'async-shell-command :to-have-been-called-with "cmd" nil nil))))
 
+(describe "projectile-discard-command-cache"
+  (it "removes cached commands for the current project across all maps"
+    (let ((projectile-configure-cmd-map (make-hash-table :test 'equal))
+          (projectile-compilation-cmd-map (make-hash-table :test 'equal))
+          (projectile-install-cmd-map (make-hash-table :test 'equal))
+          (projectile-package-cmd-map (make-hash-table :test 'equal))
+          (projectile-test-cmd-map (make-hash-table :test 'equal))
+          (projectile-run-cmd-map (make-hash-table :test 'equal)))
+      (spy-on 'projectile-acquire-root :and-return-value "/proj/a/")
+      ;; one entry per map, plus a subdir compile dir
+      (puthash "/proj/a/" "configure" projectile-configure-cmd-map)
+      (puthash "/proj/a/build/" "make" projectile-compilation-cmd-map)
+      (puthash "/proj/a/" "make install" projectile-install-cmd-map)
+      (puthash "/proj/a/" "make package" projectile-package-cmd-map)
+      (puthash "/proj/a/" "make test" projectile-test-cmd-map)
+      (puthash "/proj/a/" "./run" projectile-run-cmd-map)
+      ;; a different project and a prefix-sharing sibling must survive
+      (puthash "/proj/b/" "other" projectile-compilation-cmd-map)
+      (puthash "/proj/a-extra/" "sibling" projectile-compilation-cmd-map)
+      (projectile-discard-command-cache)
+      (expect (gethash "/proj/a/" projectile-configure-cmd-map) :to-be nil)
+      (expect (gethash "/proj/a/build/" projectile-compilation-cmd-map) :to-be nil)
+      (expect (gethash "/proj/a/" projectile-install-cmd-map) :to-be nil)
+      (expect (gethash "/proj/a/" projectile-package-cmd-map) :to-be nil)
+      (expect (gethash "/proj/a/" projectile-test-cmd-map) :to-be nil)
+      (expect (gethash "/proj/a/" projectile-run-cmd-map) :to-be nil)
+      ;; unrelated project and prefix-sharing sibling are left untouched
+      (expect (gethash "/proj/b/" projectile-compilation-cmd-map) :to-equal "other")
+      (expect (gethash "/proj/a-extra/" projectile-compilation-cmd-map) :to-equal "sibling"))))
+
 (describe "projectile--run-project-cmd"
 
   (before-each


### PR DESCRIPTION
The cached lifecycle commands take precedence over `.dir-locals.el` and the project-type defaults, so editing those didn't take effect until the cache was cleared. This adds an interactive `projectile-discard-command-cache` that drops the cached configure/compile/test/install/package/run commands for the current project, so they're re-read next run. Call it manually or wire it into an `after-save-hook` for `.dir-locals.el` buffers (as discussed in the issue).

Fixes #1861.