### PR TITLE
Add projectile-run-ghostel project terminal commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Add `projectile-forget-zombie-projects` as an alias for `projectile-cleanup-known-projects`, for discoverability and parity with `project.el`'s `project-forget-zombie-projects`.
 * `projectile-kill-buffers-filter` now also accepts a composable list of conditions (buffer-name regexps, predicates, and `major-mode`/`derived-mode`/`not`/`and`/`or` forms), modeled on `project.el`'s `project-kill-buffer-conditions`. The existing `kill-all`, `kill-only-files`, and predicate-function values keep working unchanged.
 * [#1837](https://github.com/bbatsov/projectile/issues/1837): Add `eat` project terminal commands with keybindings `x x` and `x 4 x`.
+* Add `ghostel` project terminal commands with keybindings `x G` and `x 4 G`.
 * Add keybinding `A` (in the projectile command map) and a menu entry for `projectile-add-known-project`.
 
 ### Bugs fixed

--- a/doc/modules/ROOT/pages/projectile_vs_project.adoc
+++ b/doc/modules/ROOT/pages/projectile_vs_project.adoc
@@ -328,6 +328,10 @@ Side-by-side mapping of the most common entry points. Useful both when picking b
 | `projectile-run-eat`
 | —
 
+| Ghostel
+| `projectile-run-ghostel`
+| —
+
 | IELM
 | `projectile-run-ielm`
 | —

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -365,6 +365,9 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p x x]
 | Start or visit an `eat` terminal for the project.
 
+| kbd:[s-p x G]
+| Start or visit a `ghostel` terminal for the project.
+
 | kbd:[s-p ESC]
 | Switch to the most recently selected Projectile buffer.
 |===

--- a/projectile.el
+++ b/projectile.el
@@ -64,6 +64,7 @@
 (defvar grep-find-ignored-directories)
 (defvar grep-find-ignored-files)
 (defvar eat-buffer-name)
+(defvar ghostel-buffer-name)
 
 (declare-function tags-completion-table "etags")
 (declare-function make-term "term")
@@ -88,6 +89,7 @@
 (declare-function vterm-send-string "ext:vterm")
 (declare-function eat "ext:eat")
 (declare-function eat-other-window "ext:eat")
+(declare-function ghostel "ext:ghostel")
 
 
 ;;; Customization
@@ -5477,6 +5479,24 @@ Switch to the project specific eat buffer if it already exists."
           (eat-other-window nil new-process)
         (eat nil new-process)))))
 
+(defun projectile--ghostel (&optional new-process other-window)
+  "Invoke `ghostel' in the project's root.
+
+Use argument NEW-PROCESS to indicate creation of a new process instead.
+Use argument OTHER-WINDOW to indicate whether the buffer should
+be displayed in a different window.
+
+Switch to the project specific ghostel buffer if it already exists."
+  (unless (require 'ghostel nil 'noerror)
+    (error "Package 'ghostel' is not available"))
+  (let* ((project (projectile-acquire-root))
+         (ghostel-buffer-name
+          (projectile-generate-process-name "ghostel" new-process project))
+         (display-buffer-overriding-action
+          (and other-window '((display-buffer-pop-up-window)))))
+    (projectile-with-default-dir project
+      (ghostel))))
+
 ;;;###autoload
 (defun projectile-run-vterm (&optional arg)
   "Invoke `vterm' in the project's root.
@@ -5516,6 +5536,26 @@ Switch to the project specific eat buffer if it already exists.
 Use a prefix argument ARG to indicate creation of a new process instead."
   (interactive "P")
   (projectile--eat arg 'other-window))
+
+;;;###autoload
+(defun projectile-run-ghostel (&optional arg)
+  "Invoke `ghostel' in the project's root.
+
+Switch to the project specific ghostel buffer if it already exists.
+
+Use a prefix argument ARG to indicate creation of a new process instead."
+  (interactive "P")
+  (projectile--ghostel arg))
+
+;;;###autoload
+(defun projectile-run-ghostel-other-window (&optional arg)
+  "Invoke `ghostel' in the project's root.
+
+Switch to the project specific ghostel buffer if it already exists.
+
+Use a prefix argument ARG to indicate creation of a new process instead."
+  (interactive "P")
+  (projectile--ghostel arg 'other-window))
 
 (defun projectile-files-from-cmd (cmd directory)
   "Use a grep-like CMD to search for files within DIRECTORY.
@@ -7262,6 +7302,8 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "x 4 v") #'projectile-run-vterm-other-window)
     (define-key map (kbd "x x") #'projectile-run-eat)
     (define-key map (kbd "x 4 x") #'projectile-run-eat-other-window)
+    (define-key map (kbd "x G") #'projectile-run-ghostel)
+    (define-key map (kbd "x 4 G") #'projectile-run-ghostel-other-window)
     ;; misc
     (define-key map (kbd "z") #'projectile-cache-current-file)
     (define-key map (kbd "<left>") #'projectile-previous-project-buffer)
@@ -7330,6 +7372,7 @@ Magit that don't trigger `find-file-hook'."
       ("xg" "gdb" projectile-run-gdb)
       ("xv" "vterm" projectile-run-vterm)
       ("xx" "eat" projectile-run-eat)
+      ("xG" "ghostel" projectile-run-ghostel)
       ("!" "shell command" projectile-run-shell-command-in-root)
       ("&" "async shell command" projectile-run-async-shell-command-in-root)]
      ["Cache"
@@ -7414,6 +7457,7 @@ Magit that don't trigger `find-file-hook'."
          ["Run term" projectile-run-term]
          ["Run vterm" projectile-run-vterm]
          ["Run eat" projectile-run-eat]
+         ["Run ghostel" projectile-run-ghostel]
          "--"
          ["Run GDB" projectile-run-gdb])
         ("Build"


### PR DESCRIPTION
## Summary

Wire the [ghostel](https://github.com/dakra/ghostel) terminal emulator (libghostty-powered, a faster mouse-capable alternative to vterm/eat) into the `C-c p x` prefix, mirroring the existing vterm/eat integration:

- `projectile-run-ghostel` (`x G`) and `projectile-run-ghostel-other-window` (`x 4 G`), backed by a shared `projectile--ghostel` helper.
- ghostel is loaded lazily via `require ... noerror`, so it stays an optional dependency just like vterm and eat (no change to `Package-Requires`).
- Added to the `transient` dispatch menu and the `Run...` easy-menu.
- Documented in `usage.adoc`, `projectile_vs_project.adoc`, and the changelog.

## Implementation notes

`ghostel`'s entry point `(ghostel &optional arg)` creates its buffer from the dynamic value of `ghostel-buffer-name` and reuses buffers by a stored *identity* rather than the live buffer name — so reuse keeps working even after ghostel asynchronously retitles the visible buffer (OSC 2 / OSC 7). The helper therefore just `let`-binds `ghostel-buffer-name` to a project-scoped name (via `projectile-generate-process-name`) inside `projectile-with-default-dir`, the same shape as `projectile--eat`.

`ghostel-buffer-name` is declared special with a valueless `defvar` (next to the existing `eat-buffer-name`/`eshell-buffer-name` declarations) so the `let`-binding is dynamic under lexical-binding.

## Testing

- `emacs -Q --batch -L . -f batch-byte-compile projectile.el` — clean, no warnings.
- Verified the keybindings resolve (`x G` → `projectile-run-ghostel`, `x 4 G` → `projectile-run-ghostel-other-window`) and that invoking the command without ghostel installed errors with `Package 'ghostel' is not available`.
- The live terminal behaviour (opening/reusing a buffer, the other-window placement, `C-u` for an extra process) requires ghostel's native module and was not exercised in CI/batch.