### PR TITLE
[Fix #1909] Pass the project root to predicate marker-files functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### Bugs fixed
 
+* [#1909](https://github.com/bbatsov/projectile/issues/1909): A project type registered with a predicate `marker-files` function now receives the project root as its argument when detecting the current project's type. Previously it was passed `nil`, so such a function could never match the current project.
 * [#1829](https://github.com/bbatsov/projectile/issues/1829): `projectile-project-root` no longer errors with `(wrong-type-argument stringp nil)` when `default-directory` is nil (which can happen in some non-file buffers); it returns nil instead.
 * [#1946](https://github.com/bbatsov/projectile/issues/1946): `projectile-ripgrep` now builds its ignore exclusions as `--glob=!PATTERN` instead of `--glob '!PATTERN'`. The surrounding single quotes were only stripped by POSIX shells, so on Windows `cmd` they became part of the pattern and the exclusions silently failed.
 * [#2008](https://github.com/bbatsov/projectile/issues/2008): A project type with an empty `marker-files` list no longer matches every project. `projectile-verify-files` is vacuously true for an empty list, so a type whose markers were cleared (e.g. via `projectile-update-project-type ... :marker-files nil`) would be detected everywhere instead of nowhere. `projectile-detect-project-type` now treats an empty marker set as a non-match.

--- a/projectile.el
+++ b/projectile.el
@@ -3624,7 +3624,14 @@ ones and overrule settings in the other lists."
   "Return a project type plist with the provided arguments.
 
 A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
-and optional keyword arguments:
+and optional keyword arguments.
+
+MARKER-FILES is either a list of files that must all be present in the
+project root, or a predicate function.  The predicate is called with the
+project root as its single argument and should return non-nil when the
+project is of this type.
+
+The optional keyword arguments are:
 PROJECT-FILE the main project file in the root project directory.  It may be a
              single file or a list of possible files.  When omitted it
              defaults to the first marker file.  Pass the symbol `none'
@@ -3694,7 +3701,14 @@ files such as test/impl/other files as below:
   "Register a project type with projectile.
 
 A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
-and optional keyword arguments:
+and optional keyword arguments.
+
+MARKER-FILES is either a list of files that must all be present in the
+project root, or a predicate function.  The predicate is called with the
+project root as its single argument and should return non-nil when the
+project is of this type.
+
+The optional keyword arguments are:
 PROJECT-FILE the main project file in the root project directory.  It may be a
              single file or a list of possible files.  When omitted it
              defaults to the first marker file.  Pass the symbol `none'
@@ -3768,7 +3782,14 @@ types by default.  Otherwise, the arguments to this function are as for
 `projectile-register-project-type':
 
 A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
-and optional keyword arguments:
+and optional keyword arguments.
+
+MARKER-FILES is either a list of files that must all be present in the
+project root, or a predicate function.  The predicate is called with the
+project root as its single argument and should return non-nil when the
+project is of this type.
+
+The optional keyword arguments are:
 MARKER-FILES a set of indicator files for PROJECT-TYPE.
 PROJECT-FILE the main project file in the root project directory.
 COMPILATION-DIR the directory to run the tests- and compilations in,
@@ -4432,23 +4453,26 @@ on the current project.  PROJECT-ROOT, if provided, is used for caching
 instead of re-resolving via `projectile-project-root'.
 
 Fallback to a generic project type when the type can't be determined."
-  (let ((project-type
-         (or (car (seq-find
-                   (lambda (project-type-record)
-                     (let ((project-type (car project-type-record))
-                           (marker (plist-get (cdr project-type-record) 'marker-files)))
-                       (if (functionp marker)
-                           (and (funcall marker dir) project-type)
-                         ;; An empty marker set is vacuously satisfied by
-                         ;; `projectile-verify-files' (`seq-every-p' over nil
-                         ;; is t), which would make the type match every
-                         ;; project.  Guard against it so clearing a type's
-                         ;; markers disables detection instead of inverting it.
-                         (and marker (projectile-verify-files marker dir) project-type))))
-                   projectile-project-types))
-             'generic)))
-    (puthash (or project-root (projectile-project-root dir))
-             project-type projectile-project-type-cache)
+  ;; Resolve the root up front so function markers receive it (they used to
+  ;; get DIR, which is nil when detecting the current project's type - see
+  ;; #1909) and so the cache key below reuses the same value.
+  (let* ((project-root (or project-root (projectile-project-root dir)))
+         (project-type
+          (or (car (seq-find
+                    (lambda (project-type-record)
+                      (let ((project-type (car project-type-record))
+                            (marker (plist-get (cdr project-type-record) 'marker-files)))
+                        (if (functionp marker)
+                            (and (funcall marker project-root) project-type)
+                          ;; An empty marker set is vacuously satisfied by
+                          ;; `projectile-verify-files' (`seq-every-p' over nil
+                          ;; is t), which would make the type match every
+                          ;; project.  Guard against it so clearing a type's
+                          ;; markers disables detection instead of inverting it.
+                          (and marker (projectile-verify-files marker dir) project-type))))
+                    projectile-project-types))
+              'generic)))
+    (puthash project-root project-type projectile-project-type-cache)
     project-type))
 
 (defun projectile-project-type (&optional dir)

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -2752,7 +2752,21 @@ by `projectile-files-via-ext-command')."
       (let ((projectile-project-types '((empty marker-files nil)))
             (projectile-project-type-cache (make-hash-table :test 'equal)))
         (spy-on 'projectile-project-root :and-return-value (file-truename (expand-file-name "project/")))
-        (expect (projectile-detect-project-type) :to-equal 'generic))))))
+        (expect (projectile-detect-project-type) :to-equal 'generic)))))
+  (it "passes the project root to a function marker (#1909)"
+    (let ((projectile-project-types
+           (list (list 'custom 'marker-files
+                       (lambda (root) (and root (string-match-p "subproject/src/foo/?\\'" root))))))
+          (projectile-project-type-cache (make-hash-table :test 'equal)))
+      (spy-on 'projectile-project-root :and-return-value "/repo/subproject/src/foo/")
+      (expect (projectile-detect-project-type) :to-equal 'custom)))
+  (it "does not match a function marker when the root doesn't satisfy it (#1909)"
+    (let ((projectile-project-types
+           (list (list 'custom 'marker-files
+                       (lambda (root) (and root (string-match-p "subproject/src/foo/?\\'" root))))))
+          (projectile-project-type-cache (make-hash-table :test 'equal)))
+      (spy-on 'projectile-project-root :and-return-value "/repo/elsewhere/")
+      (expect (projectile-detect-project-type) :to-equal 'generic))))
 
 (describe "projectile-dirname-matching-count"
   (it "counts matching dirnames ascending file paths"


### PR DESCRIPTION
When a project type's `marker-files` is a predicate function, `projectile-detect-project-type` called it with `dir`, which is nil when detecting the current project's type. So a predicate marker could never match the current project (it always got nil). Now the root is resolved up front and passed to the predicate (and reused for the type-cache key). The predicate contract is also documented in `projectile-register-project-type`.

Fixes #1909.