### PR TITLE
[Fix #1663] Exclude ignored projects from the known-projects list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### Bugs fixed
 
+* [#1663](https://github.com/bbatsov/projectile/issues/1663): Projects matched by `projectile-ignored-projects` (or `projectile-ignored-project-function`) are now excluded from `projectile-relevant-known-projects`, so they no longer show up in `projectile-switch-project` even when they were added to the known projects before being ignored. Previously the ignore list was only consulted when adding a project.
 * [#1909](https://github.com/bbatsov/projectile/issues/1909): A project type registered with a predicate `marker-files` function now receives the project root as its argument when detecting the current project's type. Previously it was passed `nil`, so such a function could never match the current project.
 * [#1829](https://github.com/bbatsov/projectile/issues/1829): `projectile-project-root` no longer errors with `(wrong-type-argument stringp nil)` when `default-directory` is nil (which can happen in some non-file buffers); it returns nil instead.
 * [#1946](https://github.com/bbatsov/projectile/issues/1946): `projectile-ripgrep` now builds its ignore exclusions as `--glob=!PATTERN` instead of `--glob '!PATTERN'`. The surrounding single quotes were only stripped by POSIX shells, so on Windows `cmd` they became part of the pattern and the exclusions silently failed.

--- a/projectile.el
+++ b/projectile.el
@@ -6572,8 +6572,16 @@ enabled."
 (defun projectile-relevant-known-projects ()
   "Return a list of known projects.
 
+Projects matched by `projectile-ignored-projects' or
+`projectile-ignored-project-function' are excluded, even if they were
+added to the known projects before being ignored (see #1663).
+
 It factors the value of `projectile-current-project-on-switch'."
   (let ((known-projects (projectile-known-projects)))
+    ;; Only filter when there's actually some ignore configuration, so the
+    ;; common case doesn't pay for a `file-truename' per known project.
+    (when (or projectile-ignored-projects projectile-ignored-project-function)
+      (setq known-projects (seq-remove #'projectile-ignored-project-p known-projects)))
     (pcase projectile-current-project-on-switch
       ('remove (projectile--remove-current-project known-projects))
       ('move-to-end (projectile--move-current-project-to-end known-projects))

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -1548,7 +1548,22 @@ by `projectile-files-via-ext-command')."
   (it "returns a list of known projects"
     (let ((projectile-known-projects '("/path/to/project1" "/path/to/project2")))
       (spy-on 'projectile-project-root :and-return-value "/path/to/project1")
-      (expect (projectile-relevant-known-projects) :to-equal '("/path/to/project2")))))
+      (expect (projectile-relevant-known-projects) :to-equal '("/path/to/project2"))))
+
+  (it "excludes projects matched by projectile-ignored-projects (#1663)"
+    (let ((projectile-known-projects '("/projects/a/" "/projects/b/"))
+          (projectile-ignored-projects '("/projects/b/"))
+          (projectile-current-project-on-switch 'keep))
+      (expect (projectile-relevant-known-projects) :to-equal '("/projects/a/"))))
+
+  (it "does not filter (or call the ignore check) without any ignore config (#1663)"
+    (let ((projectile-known-projects '("/projects/a/" "/projects/b/"))
+          (projectile-ignored-projects nil)
+          (projectile-ignored-project-function nil)
+          (projectile-current-project-on-switch 'keep))
+      (spy-on 'projectile-ignored-project-p)
+      (expect (projectile-relevant-known-projects) :to-equal '("/projects/a/" "/projects/b/"))
+      (expect 'projectile-ignored-project-p :not :to-have-been-called))))
 
 (describe "projectile--cleanup-known-projects"
   (it "removes known projects that don't exist anymore"


### PR DESCRIPTION
`projectile-ignored-projects` (and `projectile-ignored-project-function`) were only consulted when *adding* a project, so a project that was added to the known projects before being ignored still showed up in `projectile-switch-project`. This filters ignored projects out of `projectile-relevant-known-projects`, guarded so the common case (no ignore config) doesn't pay for a `file-truename` per known project.

Fixes #1663.