### PR TITLE
[#1638] Document SVN credential caching requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* [#1638](https://github.com/bbatsov/projectile/issues/1638): Document in `projectile-svn-command` that it runs non-interactively and therefore needs SVN credentials to be cached up front for authenticated remotes.
 * Keep a separate command history per lifecycle command type (configure, compile, test, install, package, run), so the prompt's `M-p` history no longer mixes, say, test commands with compile commands. `projectile-repeat-last-command` still uses the combined per-project history and is unaffected.
 * Remove the unused private `projectile--init-known-projects` alias (a leftover compatibility shim for the old known-projects API; nothing in the codebase referenced it).
 * `projectile-get-immediate-sub-projects` skips the `git submodule foreach` shell-out for git projects with no `.gitmodules` file anywhere up the parent chain. Hot path for monorepos that index the project root often.

--- a/projectile.el
+++ b/projectile.el
@@ -938,7 +938,14 @@ Set to nil to disable listing submodules contents."
    :type 'string)
 
 (defcustom projectile-svn-command "svn list -R . | grep -v '$/' | tr '\\n' '\\0'"
-  "Command used by projectile to get the files in a svn project."
+  "Command used by projectile to get the files in a svn project.
+
+The command runs non-interactively (its output is piped), so `svn'
+can't prompt for credentials.  For projects on an authenticated remote
+you need to have your credentials cached first (e.g. by running `svn'
+once interactively and letting it store them), otherwise the command
+fails with an authentication error.  See URL
+`https://github.com/bbatsov/projectile/issues/1638'."
   :group 'projectile
   :type 'string)
 


### PR DESCRIPTION
`projectile-svn-command` runs non-interactively (its output is piped), so `svn` can't prompt for credentials - which is what caused the "no more credentials" error in the issue. As you suggested in the thread, this just documents in the docstring that credentials need to be cached up front for authenticated remotes.

Closes #1638.