### PR TITLE
[Fix #1935] Add a test command to the emacs-eask project type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* [#1935](https://github.com/bbatsov/projectile/issues/1935): The `emacs-eask` project type now has a `test` command (`eask test`), so `projectile-test-project` works out of the box for Eask projects. Eask auto-detects the test framework (buttercup, ERT, ...), so no framework-specific type is needed.
 * [#1638](https://github.com/bbatsov/projectile/issues/1638): Document in `projectile-svn-command` that it runs non-interactively and therefore needs SVN credentials to be cached up front for authenticated remotes.
 * Keep a separate command history per lifecycle command type (configure, compile, test, install, package, run), so the prompt's `M-p` history no longer mixes, say, test commands with compile commands. `projectile-repeat-last-command` still uses the combined per-project history and is unaffected.
 * Remove the unused private `projectile--init-known-projects` alias (a leftover compatibility shim for the old known-projects API; nothing in the codebase referenced it).

--- a/projectile.el
+++ b/projectile.el
@@ -4382,6 +4382,7 @@ a manual COMMAND-TYPE command is created with
 
 (projectile-register-project-type 'emacs-eask '("Eask")
                                   :compile "eask install"
+                                  :test "eask test"
                                   :test-prefix "test-"
                                   :test-suffix "-test")
 

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -408,6 +408,10 @@ by `projectile-files-via-ext-command')."
     (let ((projectile-project-types '((foo marker-files ("foo")))))
       (expect (projectile-remove-project-type 'bar) :to-throw))))
 
+(describe "emacs-eask project type"
+  (it "uses `eask test' as its test command (#1935)"
+    (expect (projectile-default-test-command 'emacs-eask) :to-equal "eask test")))
+
 (describe "projectile-project-type"
   :var ((dir default-directory))
   (it "detects the type of Projectile's project"


### PR DESCRIPTION
Adds `:test "eask test"` to the `emacs-eask` project type so `projectile-test-project` works out of the box for Eask projects. As you noted in the issue, Eask auto-detects the test framework (buttercup, ERT, ...), so a framework-specific type isn't needed - the generic `eask test` covers it, mirroring how `emacs-eldev` has `eldev test`.

Fixes #1935.