### PR TITLE
[Fix #1872] Clarify that marker-files lists are AND-ed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* [#1872](https://github.com/bbatsov/projectile/issues/1872): Clarify in the `projectile-register-project-type` docstring and the manual that a list of `marker-files` must *all* be present for a type to match (logical AND), and that a predicate function should be used to match when any one of several files is present.
 * [#1935](https://github.com/bbatsov/projectile/issues/1935): The `emacs-eask` project type now has a `test` command (`eask test`), so `projectile-test-project` works out of the box for Eask projects. Eask auto-detects the test framework (buttercup, ERT, ...), so no framework-specific type is needed.
 * [#1638](https://github.com/bbatsov/projectile/issues/1638): Document in `projectile-svn-command` that it runs non-interactively and therefore needs SVN credentials to be cached up front for authenticated remotes.
 * Keep a separate command history per lifecycle command type (configure, compile, test, install, package, run), so the prompt's `M-p` history no longer mixes, say, test commands with compile commands. `projectile-repeat-last-command` still uses the combined per-project history and is unaffected.

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -297,7 +297,7 @@ initialization code
 What this does is:
 
 . add your own type of project, in this case `npm` package.
-. add a list of files and/or folders in a root of the project that helps to identify the type, in this case it is only `package.json`. This can also be a function which takes a project root as argument and verifies whether that directory has the correct project structure for the type.
+. add a list of files and/or folders in a root of the project that helps to identify the type, in this case it is only `package.json`. When you list several markers, *all* of them must be present for the type to match (logical AND). This can also be a function which takes a project root as argument and returns non-nil when that directory has the correct project structure for the type - use that if you instead want to match when *any* one of several files is present.
 . add _project-file_, which is typically the primary project configuration file. In this case that's `package.json`. When omitted it defaults to the first marker file (so the explicit `:project-file` above is optional here); supply it explicitly when the marker is a function or when the primary file differs from the first marker. The value can contain wildcards and/or be a list containing multiple project files to look for. Pass the symbol `none` for a type that should be detected but never anchor a project root (e.g. its marker also shows up outside real projects).
 . add _compile-command_, in this case it is `npm install`.
 . add _test-command_, in this case it is `npm test`.

--- a/projectile.el
+++ b/projectile.el
@@ -3635,10 +3635,13 @@ ones and overrule settings in the other lists."
 A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
 and optional keyword arguments.
 
-MARKER-FILES is either a list of files that must all be present in the
-project root, or a predicate function.  The predicate is called with the
-project root as its single argument and should return non-nil when the
-project is of this type.
+MARKER-FILES is either a list of files or a predicate function.  When it
+is a list, ALL of the listed files must be present in the project root for
+the type to match (logical AND) - so a single-file marker like `(\"Foo\")'
+is the common case.  To match when ANY one of several files is present,
+don't pass a list; use a predicate function instead.  The predicate is
+called with the project root as its single argument and should return
+non-nil when the project is of this type.
 
 The optional keyword arguments are:
 PROJECT-FILE the main project file in the root project directory.  It may be a
@@ -3712,10 +3715,13 @@ files such as test/impl/other files as below:
 A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
 and optional keyword arguments.
 
-MARKER-FILES is either a list of files that must all be present in the
-project root, or a predicate function.  The predicate is called with the
-project root as its single argument and should return non-nil when the
-project is of this type.
+MARKER-FILES is either a list of files or a predicate function.  When it
+is a list, ALL of the listed files must be present in the project root for
+the type to match (logical AND) - so a single-file marker like `(\"Foo\")'
+is the common case.  To match when ANY one of several files is present,
+don't pass a list; use a predicate function instead.  The predicate is
+called with the project root as its single argument and should return
+non-nil when the project is of this type.
 
 The optional keyword arguments are:
 PROJECT-FILE the main project file in the root project directory.  It may be a
@@ -3793,10 +3799,13 @@ types by default.  Otherwise, the arguments to this function are as for
 A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
 and optional keyword arguments.
 
-MARKER-FILES is either a list of files that must all be present in the
-project root, or a predicate function.  The predicate is called with the
-project root as its single argument and should return non-nil when the
-project is of this type.
+MARKER-FILES is either a list of files or a predicate function.  When it
+is a list, ALL of the listed files must be present in the project root for
+the type to match (logical AND) - so a single-file marker like `(\"Foo\")'
+is the common case.  To match when ANY one of several files is present,
+don't pass a list; use a predicate function instead.  The predicate is
+called with the project root as its single argument and should return
+non-nil when the project is of this type.
 
 The optional keyword arguments are:
 MARKER-FILES a set of indicator files for PROJECT-TYPE.


### PR DESCRIPTION
A user registered a type with two marker files expecting it to match when *either* was present, but a marker-files list requires *all* of them (logical AND). This documents that semantics in the `projectile-register-project-type` docstring and the manual, and points to predicate markers for any-of matching.

Fixes #1872.