### PR TITLE
[Fix #1956] Add switch-project-other-window/-frame commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### New features
 
+* [#1956](https://github.com/bbatsov/projectile/issues/1956): Add `projectile-switch-project-other-window` and `projectile-switch-project-other-frame` (bound to `4 p` and `5 p`), which switch to a project and display it in another window/frame. The action they run is configurable via `projectile-switch-project-other-window-action` / `projectile-switch-project-other-frame-action` (find-file in the other window/frame by default).
 * [#1809](https://github.com/bbatsov/projectile/issues/1809): Track the project switched away from in `projectile-most-recent-project` and add `projectile-switch-to-most-recent-project` to jump back to it (repeated calls toggle between the two). Only switches made through Projectile's switch-project commands are tracked.
 * [#1861](https://github.com/bbatsov/projectile/issues/1861): Add `projectile-discard-command-cache` to drop the cached configure/compile/test/install/package/run commands for the current project, so a freshly edited `.dir-locals.el` (or project-type default) is picked up on the next run. Can be called manually or added to `after-save-hook`.
 * Add `projectile-uniquify-dirname-transform`, a project-aware value for `uniquify-dirname-transform` that disambiguates same-named buffers using the project name. Mirrors `project.el`'s `project-uniquify-dirname-transform`.

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -335,6 +335,12 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p p]
 | Display a list of known projects you can switch to.
 
+| kbd:[s-p 4 p]
+| Switch to a known project and show it in another window (runs `projectile-switch-project-other-window-action`, by default find-file in the other window).
+
+| kbd:[s-p 5 p]
+| Switch to a known project and show it in another frame (runs `projectile-switch-project-other-frame-action`).
+
 | kbd:[s-p q]
 | Display a list of open projects you can switch to.
 

--- a/projectile.el
+++ b/projectile.el
@@ -603,6 +603,24 @@ Any function that does not take arguments will do."
   :group 'projectile
   :type 'function)
 
+(defcustom projectile-switch-project-other-window-action 'projectile-find-file-other-window
+  "Action run by `projectile-switch-project-other-window' after switching.
+Like `projectile-switch-project-action', but for the other-window variant.
+
+Any function that does not take arguments will do."
+  :group 'projectile
+  :type 'function
+  :package-version '(projectile . "2.10.0"))
+
+(defcustom projectile-switch-project-other-frame-action 'projectile-find-file-other-frame
+  "Action run by `projectile-switch-project-other-frame' after switching.
+Like `projectile-switch-project-action', but for the other-frame variant.
+
+Any function that does not take arguments will do."
+  :group 'projectile
+  :type 'function
+  :package-version '(projectile . "2.10.0"))
+
 (defcustom projectile-find-dir-includes-top-level nil
   "If true, add top-level dir to options offered by `projectile-find-dir'."
   :group 'projectile
@@ -6652,6 +6670,37 @@ With a prefix ARG invokes `projectile-commander' instead of
          :caller 'projectile-read-project)
       (user-error "There are no open projects"))))
 
+;; The other-window/-frame switch commands reuse `projectile-switch-project'
+;; wholesale (so the dir-locals dance, prefix-arg commander, and most-recent
+;; tracking all stay in one place) and just rebind the post-switch action
+;; around it.  This relies on the completion framework invoking its action
+;; synchronously, which the supported ones (default, vertico, ivy, helm) do.
+;;;###autoload
+(defun projectile-switch-project-other-window (&optional arg)
+  "Switch to a project we have visited before and display it in another window.
+
+Like `projectile-switch-project', but runs
+`projectile-switch-project-other-window-action' (by default
+`projectile-find-file-other-window') after switching, so the project is
+shown in another window.  With a prefix ARG invokes `projectile-commander'
+instead."
+  (interactive "P")
+  (let ((projectile-switch-project-action projectile-switch-project-other-window-action))
+    (projectile-switch-project arg)))
+
+;;;###autoload
+(defun projectile-switch-project-other-frame (&optional arg)
+  "Switch to a project we have visited before and display it in another frame.
+
+Like `projectile-switch-project', but runs
+`projectile-switch-project-other-frame-action' (by default
+`projectile-find-file-other-frame') after switching, so the project is
+shown in another frame.  With a prefix ARG invokes `projectile-commander'
+instead."
+  (interactive "P")
+  (let ((projectile-switch-project-action projectile-switch-project-other-frame-action))
+    (projectile-switch-project arg)))
+
 ;;;###autoload
 (defun projectile-switch-to-most-recent-project (&optional arg)
   "Switch to the project recorded in `projectile-most-recent-project'.
@@ -7284,6 +7333,7 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "4 D") #'projectile-dired-other-window)
     (define-key map (kbd "4 f") #'projectile-find-file-other-window)
     (define-key map (kbd "4 g") #'projectile-find-file-dwim-other-window)
+    (define-key map (kbd "4 p") #'projectile-switch-project-other-window)
     (define-key map (kbd "4 t") #'projectile-find-implementation-or-test-other-window)
     (define-key map (kbd "5 a") #'projectile-find-other-file-other-frame)
     (define-key map (kbd "5 b") #'projectile-switch-to-buffer-other-frame)
@@ -7291,6 +7341,7 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "5 D") #'projectile-dired-other-frame)
     (define-key map (kbd "5 f") #'projectile-find-file-other-frame)
     (define-key map (kbd "5 g") #'projectile-find-file-dwim-other-frame)
+    (define-key map (kbd "5 p") #'projectile-switch-project-other-frame)
     (define-key map (kbd "5 t") #'projectile-find-implementation-or-test-other-frame)
     (define-key map (kbd "!") #'projectile-run-shell-command-in-root)
     (define-key map (kbd "&") #'projectile-run-async-shell-command-in-root)
@@ -7434,6 +7485,7 @@ Magit that don't trigger `find-file-hook'."
       ("4d" "dir" projectile-find-dir-other-window)
       ("4D" "dired" projectile-dired-other-window)
       ("4b" "buffer" projectile-switch-to-buffer-other-window)
+      ("4p" "switch project" projectile-switch-project-other-window)
       ("4t" "impl/test" projectile-find-implementation-or-test-other-window)
       ("4o" "display buffer" projectile-display-buffer)]
      ["Other frame"
@@ -7443,6 +7495,7 @@ Magit that don't trigger `find-file-hook'."
       ("5d" "dir" projectile-find-dir-other-frame)
       ("5D" "dired" projectile-dired-other-frame)
       ("5b" "buffer" projectile-switch-to-buffer-other-frame)
+      ("5p" "switch project" projectile-switch-project-other-frame)
       ("5t" "impl/test" projectile-find-implementation-or-test-other-frame)]])
    t))
 

--- a/test/projectile-test.el
+++ b/test/projectile-test.el
@@ -2432,6 +2432,33 @@ by `projectile-files-via-ext-command')."
               (projectile-switch-project-by-name a))
             (expect projectile-most-recent-project :to-equal "/sentinel/")))))))
 
+(describe "projectile-switch-project-other-window/-frame"
+  (it "runs switch-project with the other-window action bound (#1956)"
+    (defvar projectile-test--captured-action)
+    (let ((projectile-test--captured-action nil)
+          (projectile-switch-project-other-window-action 'my-ow-action))
+      (spy-on 'projectile-switch-project :and-call-fake
+              (lambda (&optional _arg)
+                (setq projectile-test--captured-action projectile-switch-project-action)))
+      (projectile-switch-project-other-window)
+      (expect projectile-test--captured-action :to-equal 'my-ow-action)))
+
+  (it "runs switch-project with the other-frame action bound (#1956)"
+    (defvar projectile-test--captured-action)
+    (let ((projectile-test--captured-action nil)
+          (projectile-switch-project-other-frame-action 'my-of-action))
+      (spy-on 'projectile-switch-project :and-call-fake
+              (lambda (&optional _arg)
+                (setq projectile-test--captured-action projectile-switch-project-action)))
+      (projectile-switch-project-other-frame)
+      (expect projectile-test--captured-action :to-equal 'my-of-action)))
+
+  (it "is bound to 4 p / 5 p in projectile-command-map (#1956)"
+    (expect (lookup-key projectile-command-map (kbd "4 p"))
+            :to-equal 'projectile-switch-project-other-window)
+    (expect (lookup-key projectile-command-map (kbd "5 p"))
+            :to-equal 'projectile-switch-project-other-frame)))
+
 (describe "projectile-switch-to-most-recent-project"
   (it "errors when no recent project is recorded"
     (let ((projectile-most-recent-project nil))


### PR DESCRIPTION
Adds `projectile-switch-project-other-window` and `projectile-switch-project-other-frame`, which switch to a project and display it in another window/frame (bound to `4 p` / `5 p`, and in the dispatch transient).

Implements the issue's **Solution 3**: the post-switch action is configurable via new `projectile-switch-project-other-window-action` / `projectile-switch-project-other-frame-action` options (find-file in the other window/frame by default). The commands reuse `projectile-switch-project` and just rebind the action, so the dir-locals handling, prefix-arg commander and most-recent tracking all stay in one place.

Fixes #1956.