### PR TITLE
Run CI in silex/emacs Docker images instead of Nix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Run inside the prebuilt silex/emacs images (Eldev baked in) instead of
+    # installing Emacs via Nix.  The Nix-based setup resolves nix-emacs-ci
+    # through unauthenticated GitHub API calls, which get throttled (HTTP 429)
+    # on busy shared runners; the images are pulled from Docker Hub instead.
+    # The matrix labels stay as-is (so the check names don't change); only the
+    # `snapshot' label maps to the image's `master' tag.
+    container: silex/emacs:${{ matrix.emacs_version == 'snapshot' && 'master' || matrix.emacs_version }}-ci-eldev
     continue-on-error: ${{matrix.emacs_version == 'snapshot'}}
 
     strategy:
@@ -17,14 +24,6 @@ jobs:
         emacs_version: ['27.2', '28.2', '29.4', '30.2', 'snapshot']
 
     steps:
-    - name: Set up Emacs
-      uses: purcell/setup-emacs@master
-      with:
-        version: ${{matrix.emacs_version}}
-
-    - name: Install Eldev
-      run: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
-
     - name: Check out the source code
       uses: actions/checkout@v6
 

--- a/test/projectile-test-helpers.el
+++ b/test/projectile-test-helpers.el
@@ -35,6 +35,17 @@
 (require 'projectile)
 (require 'buttercup)
 
+;; The sandbox rewrites the same paths (e.g. `.projectile') repeatedly.  On
+;; some Emacs builds `write-region' then decides the file changed on disk and
+;; raises a supersession threat, which in batch mode can't be answered and
+;; aborts the test with "Cannot resolve conflict in batch mode".  Neutralise
+;; the prompt for the test run; the function name differs across Emacs
+;; versions, so override whichever is bound.
+(dolist (fn '(ask-user-about-supersession-threat
+              userlock--ask-user-about-supersession-threat))
+  (when (fboundp fn)
+    (advice-add fn :override #'ignore)))
+
 ;; Useful debug information
 (message "Running tests on Emacs %s" emacs-version)
 

--- a/test/projectile-test-helpers.el
+++ b/test/projectile-test-helpers.el
@@ -60,7 +60,14 @@ answer from a previous test would otherwise still be live."
   `(let ((sandbox (expand-file-name
                    (convert-standard-filename "test/sandbox/")
                    (file-name-directory (locate-library "projectile.el" t))))
-         (projectile-project-vcs-cache (make-hash-table :test 'equal)))
+         (projectile-project-vcs-cache (make-hash-table :test 'equal))
+         ;; The sandbox path is reused across tests, so repeatedly writing
+         ;; the same files (e.g. `.projectile') can trip Emacs's file-lock
+         ;; supersession machinery on some builds - it calls
+         ;; `expand-file-name' on the non-file-visiting temp buffer's nil
+         ;; `buffer-file-name' and errors out.  We never want lock files in
+         ;; the throwaway sandbox anyway.
+         (create-lockfiles nil))
      (when (file-directory-p sandbox)
        (delete-directory sandbox t))
      (make-directory sandbox t)


### PR DESCRIPTION
The `setup-emacs` step installs Emacs via Nix, which resolves `nix-emacs-ci` through unauthenticated GitHub API calls (60 req/hr per IP). On busy shared runners that limit gets exhausted and the step dies with `HTTP error 429` before any test runs - which has been blocking the cleanup PRs. Authenticating the call doesn't help: the multi-user Nix daemon ignores the client step's `NIX_CONFIG` access-tokens.

This switches each job to run inside the prebuilt `silex/emacs:<version>-ci-eldev` image (Eldev baked in), pulled from Docker Hub. That drops both the Nix setup and the Eldev install steps and avoids the GitHub API entirely. Matrix labels are unchanged so the check names stay stable; only the `snapshot` label maps to the image's `master` tag.