### PR TITLE
Tolerate a non-zero indexing exit when output was produced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 
 ### Bugs fixed
 
+* [#2042](https://github.com/bbatsov/projectile/issues/2042): A non-zero exit from the indexing command (`fd`, `git ls-files`, `find`, ...) no longer aborts `projectile-find-file` when the command still produced a file listing. External listers like `fd` routinely exit non-zero on benign conditions (e.g. an unreadable directory hit mid-traversal); that output is now used. A `user-error` is still raised when a non-zero exit produced no output at all, so a genuinely broken/missing command is still surfaced rather than mistaken for an empty project.
 * [#1663](https://github.com/bbatsov/projectile/issues/1663): Projects matched by `projectile-ignored-projects` (or `projectile-ignored-project-function`) are now excluded from `projectile-relevant-known-projects`, so they no longer show up in `projectile-switch-project` even when they were added to the known projects before being ignored. Previously the ignore list was only consulted when adding a project.
 * [#1909](https://github.com/bbatsov/projectile/issues/1909): A project type registered with a predicate `marker-files` function now receives the project root as its argument when detecting the current project's type. Previously it was passed `nil`, so such a function could never match the current project.
 * [#1829](https://github.com/bbatsov/projectile/issues/1829): `projectile-project-root` no longer errors with `(wrong-type-argument stringp nil)` when `default-directory` is nil (which can happen in some non-file buffers); it returns nil instead.

--- a/projectile.el
+++ b/projectile.el
@@ -2108,6 +2108,17 @@ its asynchronous counterpart so both produce identical results."
               (string-remove-prefix "./" f))
             (split-string (string-trim shell-output) "\0" t))))
 
+(defun projectile--surface-ext-command-errors (errors-file)
+  "Copy ERRORS-FILE's contents into the `*projectile-files-errors*' buffer.
+Return non-nil when ERRORS-FILE held any text.  Shared by the synchronous
+and asynchronous indexing-command runners so a failing command's stderr is
+available for inspection."
+  (with-current-buffer (get-buffer-create "*projectile-files-errors*")
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      (ignore-errors (insert-file-contents errors-file))
+      (> (buffer-size) 0))))
+
 (defun projectile-files-via-ext-command (root command &optional pathspecs)
   "Get a list of relative file names in the project ROOT by executing COMMAND.
 
@@ -2123,17 +2134,20 @@ their command to accept positional paths.
 If `command' is nil or an empty string, return nil.
 This allows commands to be disabled.
 
-Signals a `user-error' when COMMAND exits non-zero so that failures
-on the indexing path (most commonly a binary like `fd' or `git'
-missing on a remote host) surface immediately instead of being
-mistaken for an empty project.  Stderr is captured into the
+When COMMAND exits non-zero but still produced output, that output is
+used: external listers such as `fd' routinely exit non-zero on benign
+conditions (e.g. an unreadable directory encountered mid-traversal)
+while having listed everything else.  A `user-error' is signalled only
+when a non-zero exit produced no output at all, so a genuinely broken
+command (most commonly a binary like `fd' or `git' missing on a remote
+host) surfaces immediately instead of being mistaken for an empty
+project.  Either way COMMAND's stderr is captured into the
 `*projectile-files-errors*' buffer.
 
 Only text sent to standard output is taken into account."
   (when (and (stringp command) (not (string-empty-p command)))
     (let ((default-directory root)
           (full-command (projectile--ext-command-line command pathspecs))
-          (errors-buffer (get-buffer-create "*projectile-files-errors*"))
           (errors-file (make-temp-file "projectile-files-errors")))
       (unwind-protect
           (with-temp-buffer
@@ -2144,17 +2158,24 @@ Only text sent to standard output is taken into account."
             ;; on the happy path.
             (let ((exit-code
                    (process-file-shell-command full-command nil
-                                               (list t errors-file))))
+                                               (list t errors-file)))
+                  (files (projectile--ext-command-output-files)))
               (when (and (numberp exit-code) (not (zerop exit-code)))
-                (with-current-buffer errors-buffer
-                  (let ((inhibit-read-only t))
-                    (erase-buffer)
-                    (insert-file-contents errors-file)))
-                (user-error
-                 "Projectile indexing command failed with exit code %d: %s\n\
+                (let ((had-stderr (projectile--surface-ext-command-errors errors-file)))
+                  (cond
+                   ;; Non-zero exit but we still got a listing: trust it.  Only
+                   ;; mention it (quietly) when there was stderr worth seeing.
+                   (files
+                    (when had-stderr
+                      (message "Projectile: `%s' exited with code %d but produced output; using it (see *projectile-files-errors*)"
+                               full-command exit-code)))
+                   ;; Non-zero exit and nothing on stdout: a real failure.
+                   (t
+                    (user-error
+                     "Projectile indexing command failed with exit code %d: %s\n\
 See the *projectile-files-errors* buffer for details"
-                 exit-code full-command))
-              (projectile--ext-command-output-files)))
+                     exit-code full-command)))))
+              files))
         (when (file-exists-p errors-file)
           (delete-file errors-file))))))
 
@@ -2168,8 +2189,11 @@ synchronous command.
 
 CALLBACK is funcalled with two arguments when COMMAND finishes: the list
 of files (nil on failure) and an error description string (nil on
-success).  On a non-zero exit the command's stderr is copied into the
-`*projectile-files-errors*' buffer, matching the synchronous runner.
+success).  As in `projectile-files-via-ext-command', a non-zero exit
+that still produced output is treated as success (the output is passed
+to CALLBACK); only a non-zero exit with no output is reported as an
+error.  Either way the command's stderr is copied into the
+`*projectile-files-errors*' buffer.
 
 PATHSPECS is handled exactly as in `projectile-files-via-ext-command'.
 
@@ -2211,20 +2235,28 @@ Remote ROOTs are handled via TRAMP (`make-process' is given a non-nil
                      ;; `signal' status, but we must not then report a bogus
                      ;; failure or clobber the errors buffer - just clean up.
                      (unless (process-get proc 'projectile-aborted)
-                       (let ((exit-code (process-exit-status proc)))
-                         (if (and (numberp exit-code) (zerop exit-code))
-                             (funcall callback
-                                      (with-current-buffer stdout-buffer
-                                        (projectile--ext-command-output-files))
-                                      nil)
-                           (with-current-buffer (get-buffer-create "*projectile-files-errors*")
-                             (let ((inhibit-read-only t))
-                               (erase-buffer)
-                               (ignore-errors (insert-file-contents errors-file))))
+                       (let ((exit-code (process-exit-status proc))
+                             (files (with-current-buffer stdout-buffer
+                                      (projectile--ext-command-output-files))))
+                         (cond
+                          ;; Clean exit: pass the listing through.
+                          ((and (numberp exit-code) (zerop exit-code))
+                           (funcall callback files nil))
+                          ;; Non-zero exit but we still got a listing: trust it,
+                          ;; mirroring the synchronous runner.  Surface stderr
+                          ;; and mention it quietly when there's anything to see.
+                          (files
+                           (when (projectile--surface-ext-command-errors errors-file)
+                             (message "Projectile: `%s' exited with code %s but produced output; using it (see *projectile-files-errors*)"
+                                      command exit-code))
+                           (funcall callback files nil))
+                          ;; Non-zero exit and nothing on stdout: a real failure.
+                          (t
+                           (projectile--surface-ext-command-errors errors-file)
                            (funcall callback
                                     nil
                                     (format "exit code %s: %s"
-                                            exit-code command)))))
+                                            exit-code command))))))
                    (when (buffer-live-p stdout-buffer) (kill-buffer stdout-buffer))
                    (when (file-exists-p errors-file)
                      (ignore-errors (delete-file errors-file)))))))))

--- a/test/projectile-async-test.el
+++ b/test/projectile-async-test.el
@@ -82,6 +82,18 @@ that stores into it as the async callback."
       (expect (with-current-buffer "*projectile-files-errors*" (buffer-string))
               :to-match "boom")))
 
+  (it "uses the output when the command exits non-zero but still produced some"
+    ;; A non-zero exit with output (e.g. fd hitting an unreadable dir) must be
+    ;; treated as success, not a failure - see #2042.
+    (projectile-test-with-async-result result
+      (projectile-files-via-ext-command-async
+       temporary-file-directory "printf 'foo\\0bar\\0'; exit 1"
+       (lambda (files err)
+         (setf (nth 1 result) files (nth 2 result) err (nth 0 result) t)))
+      (expect (projectile-test-wait-for (lambda () (nth 0 result))) :to-be-truthy)
+      (expect (nth 1 result) :to-equal '("foo" "bar"))
+      (expect (nth 2 result) :to-be nil)))
+
   (it "invokes the callback with an empty list for a disabled (nil/empty) command"
     (projectile-test-with-async-result result
       (expect (projectile-files-via-ext-command-async

--- a/test/projectile-indexing-test.el
+++ b/test/projectile-indexing-test.el
@@ -496,12 +496,21 @@
               (expect (projectile-files-via-ext-command temporary-file-directory "echo filename")
                       :to-equal '("filename")))
 
-          (it "signals a user-error when the command exits non-zero"
+          (it "signals a user-error when the command exits non-zero with no output"
               ;; `false' is a portable way to force a non-zero exit; the previous
               ;; behavior was to silently return nil, which made fd-on-remote
               ;; failures look like empty projects.
               (expect (projectile-files-via-ext-command temporary-file-directory "false")
                       :to-throw 'user-error))
+
+          (it "uses the output when the command exits non-zero but still produced some"
+              ;; External listers such as `fd' routinely exit non-zero on benign
+              ;; conditions (e.g. an unreadable directory) while having listed
+              ;; everything else, so a non-zero exit with output must not abort
+              ;; (see #2042).
+              (expect (projectile-files-via-ext-command
+                       temporary-file-directory "printf 'foo\\0bar\\0'; exit 1")
+                      :to-equal '("foo" "bar")))
 
           (it "supports magic file handlers"
               (expect (projectile-files-via-ext-command "#magic#" "echo filename") :to-equal '("magic")))


### PR DESCRIPTION
Fixes #2042.

Surfacing non-zero exits from the indexing command (added recently in this dev cycle) turned out to be too aggressive. External listers like `fd` routinely exit non-zero on benign conditions - e.g. hitting an unreadable directory mid-traversal - while still listing everything else. Making that a fatal `user-error` broke `projectile-find-file` for those users (the reporter saw `exit code 1: fd ...` with an empty `*projectile-files-errors*`, i.e. no actual error output).

Now a non-zero exit is fatal **only when the command produced no output at all** - the "fd/git missing on a remote host" case the check was originally added for. When there's output, we use it, copy any stderr into `*projectile-files-errors*`, and mention it (quietly, via `message`) only when there's something worth seeing. Applies symmetrically to the sync and async runners.

Added specs for both runners covering the non-zero-exit-with-output case; the existing no-output failure specs still hold.