### PR TITLE
Share a helper across the remaining display-variant commands

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -2728,26 +2728,30 @@ choices."
            (projectile-project-buffer-names))
    :caller 'projectile-read-buffer))
 
+(defun projectile--switch-to-buffer (switch-fn)
+  "Read a project buffer and display it with SWITCH-FN.
+SWITCH-FN is a `switch-to-buffer'-like command; passing
+`switch-to-buffer-other-window' or `switch-to-buffer-other-frame'
+yields the other-window/-frame variants."
+  (funcall switch-fn (projectile-read-buffer-to-switch "Switch to buffer: ")))
+
 ;;;###autoload
 (defun projectile-switch-to-buffer ()
   "Switch to a project buffer."
   (interactive)
-  (switch-to-buffer
-   (projectile-read-buffer-to-switch "Switch to buffer: ")))
+  (projectile--switch-to-buffer #'switch-to-buffer))
 
 ;;;###autoload
 (defun projectile-switch-to-buffer-other-window ()
   "Switch to a project buffer and show it in another window."
   (interactive)
-  (switch-to-buffer-other-window
-   (projectile-read-buffer-to-switch "Switch to buffer: ")))
+  (projectile--switch-to-buffer #'switch-to-buffer-other-window))
 
 ;;;###autoload
 (defun projectile-switch-to-buffer-other-frame ()
   "Switch to a project buffer and show it in another frame."
   (interactive)
-  (switch-to-buffer-other-frame
-   (projectile-read-buffer-to-switch "Switch to buffer: ")))
+  (projectile--switch-to-buffer #'switch-to-buffer-other-frame))
 
 ;;;###autoload
 (defun projectile-display-buffer ()
@@ -5131,6 +5135,13 @@ test file."
             (t (error "Determined test file to be \"%s\", which does not exist.  Set `projectile-create-missing-test-files' to allow `projectile-find-implementation-or-test' to create new files" test-file))))))
 
 ;;;###autoload
+(defun projectile--find-implementation-or-test-in (ff-variant)
+  "Open the matching implementation or test file using FF-VARIANT.
+FF-VARIANT is a `find-file'-like command; passing
+`find-file-other-window' or `find-file-other-frame' yields the
+corresponding display variants."
+  (funcall ff-variant (projectile-find-implementation-or-test (buffer-file-name))))
+
 (defun projectile-find-implementation-or-test-other-window ()
   "Open matching implementation or test file in other window.
 
@@ -5138,8 +5149,7 @@ See the documentation of `projectile--find-matching-file' and
 `projectile--find-matching-test' for how implementation and test files
 are determined."
   (interactive)
-  (find-file-other-window
-   (projectile-find-implementation-or-test (buffer-file-name))))
+  (projectile--find-implementation-or-test-in #'find-file-other-window))
 
 ;;;###autoload
 (defun projectile-find-implementation-or-test-other-frame ()
@@ -5149,8 +5159,7 @@ See the documentation of `projectile--find-matching-file' and
 `projectile--find-matching-test' for how implementation and test files
 are determined."
   (interactive)
-  (find-file-other-frame
-   (projectile-find-implementation-or-test (buffer-file-name))))
+  (projectile--find-implementation-or-test-in #'find-file-other-frame))
 
 ;;;###autoload
 (defun projectile-toggle-between-implementation-and-test ()
@@ -6426,38 +6435,38 @@ The buffers are killed according to the value of
           (save-buffer)))
       (message "[%s] Saved %d buffers" project-name (length modified-buffers)))))
 
+(defun projectile--dired (dired-fn &optional arg)
+  "Open the project root in dired using DIRED-FN.
+DIRED-FN is a `dired'-like command; passing `dired-other-window' or
+`dired-other-frame' yields the other-window/-frame variants.  With ARG,
+prompt for a known project to open instead of the current one."
+  (funcall dired-fn
+           (if arg
+               (projectile-completing-read
+                "Dired in project: " (projectile-relevant-known-projects)
+                :caller 'projectile-read-project)
+             (projectile-acquire-root))))
+
 ;;;###autoload
 (defun projectile-dired (&optional arg)
   "Open `dired' at the root of the project.
 With a prefix argument ARG, prompt for a known project to open in dired."
   (interactive "P")
-  (dired (if arg
-             (projectile-completing-read
-              "Dired in project: " (projectile-relevant-known-projects)
-              :caller 'projectile-read-project)
-           (projectile-acquire-root))))
+  (projectile--dired #'dired arg))
 
 ;;;###autoload
 (defun projectile-dired-other-window (&optional arg)
   "Open `dired' at the root of the project in another window.
 With a prefix argument ARG, prompt for a known project to open in dired."
   (interactive "P")
-  (dired-other-window (if arg
-                           (projectile-completing-read
-                            "Dired in project: " (projectile-relevant-known-projects)
-                            :caller 'projectile-read-project)
-                         (projectile-acquire-root))))
+  (projectile--dired #'dired-other-window arg))
 
 ;;;###autoload
 (defun projectile-dired-other-frame (&optional arg)
   "Open `dired' at the root of the project in another frame.
 With a prefix argument ARG, prompt for a known project to open in dired."
   (interactive "P")
-  (dired-other-frame (if arg
-                          (projectile-completing-read
-                           "Dired in project: " (projectile-relevant-known-projects)
-                           :caller 'projectile-read-project)
-                        (projectile-acquire-root))))
+  (projectile--dired #'dired-other-frame arg))
 
 ;;;###autoload
 (defun projectile-vc (&optional project-root)

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -257,4 +257,32 @@
     (let ((projectile-project-types '((test-type))))
       (expect (projectile-default-generic-command 'test-type 'compile-command) :to-equal nil))))
 
+(describe "display-variant commands"
+  ;; The other-window/-frame variants share a helper and differ only in the
+  ;; display function they hand off to.
+  (it "projectile-dired opens the project root with dired"
+    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    (spy-on 'dired)
+    (projectile-dired)
+    (expect 'dired :to-have-been-called-with "/proj/"))
+
+  (it "projectile-dired-other-window uses dired-other-window"
+    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    (spy-on 'dired-other-window)
+    (projectile-dired-other-window)
+    (expect 'dired-other-window :to-have-been-called-with "/proj/"))
+
+  (it "projectile-switch-to-buffer-other-frame uses switch-to-buffer-other-frame"
+    (spy-on 'projectile-read-buffer-to-switch :and-return-value "buf")
+    (spy-on 'switch-to-buffer-other-frame)
+    (projectile-switch-to-buffer-other-frame)
+    (expect 'switch-to-buffer-other-frame :to-have-been-called-with "buf"))
+
+  (it "projectile-find-implementation-or-test-other-window uses find-file-other-window"
+    (spy-on 'buffer-file-name :and-return-value "/proj/x_test.el")
+    (spy-on 'projectile-find-implementation-or-test :and-return-value "/proj/x.el")
+    (spy-on 'find-file-other-window)
+    (projectile-find-implementation-or-test-other-window)
+    (expect 'find-file-other-window :to-have-been-called-with "/proj/x.el")))
+
 ;;; projectile-commands-test.el ends here


### PR DESCRIPTION
Follow-up cleanup while surveying the display-variant families.

Turns out most are **already** consolidated: `find-file`, `find-file-dwim`, `find-other-file` and `find-dir` route their this-window / other-window / other-frame commands through a shared helper that takes the display function (`ff-variant` / `dired-variant`). This applies the same pattern to the three families that still copied their whole body across variants:

- `dired` → `projectile--dired (dired-fn arg)`
- `switch-to-buffer` → `projectile--switch-to-buffer (switch-fn)`
- `find-implementation-or-test` → `projectile--find-implementation-or-test-in (ff-variant)`

No behavior change - the commands and their keybindings are untouched; the variants just become one-liners. Added specs asserting each variant hands off to the right display function. 477 specs green + clean `--warnings-as-errors`.

(So the display-variant "consolidation" was much smaller than the ~24-command framing suggested - the find-* families were already done. This just completes the invariant that every family shares a helper.)