### PR TITLE
Prepare for Projectile 3.0: drop Emacs 27.1, remove legacy cruft, add migration guide

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         # Earliest supported + latest in each stable branch + snapshot.
-        emacs_version: ['27.2', '28.2', '29.4', '30.2', 'snapshot']
+        emacs_version: ['28.2', '29.4', '30.2', 'snapshot']
 
     steps:
     - name: Check out the source code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,26 @@
 * `projectile-project-root-cache` now keys entries on cons cells (`(FUNC . DIR)` for per-function results, `('none . DIR)` for the overall failure marker) instead of formatted strings. This is internal state, but third-party code that reaches into the cache directly will need to update.
 * `projectile-parse-dirconfig-file' now returns a `projectile-dirconfig' struct (with `keep', `ignore', `ensure', and `prefixless-ignore' slots) instead of a positional 3-tuple. External callers should use the accessors (`projectile-dirconfig-keep' etc.) rather than `car'/`cadr'/`caddr'.
 * Soft-deprecate prefix-less ignore entries in `.projectile'. Lines without a `+'/`-'/`!' prefix are still treated as ignore patterns for backward compatibility, but a one-time warning is now shown for each project that uses them. Set `projectile-warn-on-prefixless-dirconfig-lines' to nil to silence.
+* **[Breaking]** Remove the legacy single-letter lifecycle keybindings `C`/`K`/`L`/`P`/`u` (configure/package/install/test/run project). Use the `c` prefix instead (`c o`, `c p`, `c i`, `c t`, `c r`).
+* Remove two long-obsolete aliases: `projectile-global-mode` (use `projectile-mode`) and `projectile-project-root-files-functions` (use `projectile-project-root-functions`).
+* Pre-compute file timestamps in `projectile-sort-by-modification-time` and `projectile-sort-by-access-time` to reduce stat calls from O(n log n) to O(n).
+* Cache `projectile-parse-dirconfig-file` results per project root (invalidated by file modification time), avoiding redundant file reads during indexing.
+* Cache `file-truename` results in `projectile-project-buffer-p` when checking multiple buffers, reducing redundant symlink resolution.
+* Use a hash set for deleted file removal in `projectile-dir-files-alien`, improving performance from O(n*m) to O(n+m) when filtering deleted-but-unstaged files.
+* Avoid redundant `projectile-project-root` call in `projectile-detect-project-type` by passing through the already-resolved root.
+* Share `file-truename` cache across buffers in `projectile-open-projects`, matching the optimization already in `projectile-project-buffers`.
+* Remove unnecessary temp buffer creation in `projectile--cache-project-commands-p` (was creating a buffer and re-reading `.dir-locals.el` on every compile/test/run invocation).
+* **[Breaking]** Bump the minimum required Emacs version to 28.1 (from 26.1). This removes ~30 lines of compatibility code (fileloop fallback, `time-convert` fallback, `projectile-flatten` shim), makes `transient` (and therefore `projectile-dispatch`) an unconditional dependency, and fixes the `tags-query-replace` FIXME in `projectile-replace-regexp`.
+* Add `compat` as a dependency, enabling the use of modern Emacs APIs (e.g. `string-replace`) on older Emacs versions.
+* Replace most `cl-lib` sequence functions with `seq.el` equivalents (`seq-filter`, `seq-remove`, `seq-some`, `seq-find`, `seq-sort`, `seq-every-p`, `seq-difference`) and convert `cl-case` to `pcase`.
+* [#1971](https://github.com/bbatsov/projectile/pull/1971): Support `slnx` files for dotnet project types.
+* [#1958](https://github.com/bbatsov/projectile/issues/1958): Exclude `.projectile-cache.eld` from search results (ripgrep/ag/grep) by default.
+* [#1947](https://github.com/bbatsov/projectile/issues/1947): `projectile-project-name` should be marked as safe.
+* Set `projectile-auto-discover` to `nil` by default (to avoid startup slowdowns in some situations).
+* [#1943](https://github.com/bbatsov/projectile/pull/1943): Consider `projectile-indexing-method` to be safe as a dir-local variable if it is one of the preset values.
+* [#1936](https://github.com/bbatsov/projectile/issues/1936): Do not require selecting a project when using `M-x projectile-invalidate-cache`, since there is a global cache that is also cleared by that command, even when not operating on any specific project.
+* Add `build.mill` as an alternative project marker for the Mill project type, matching Mill's current recommended file extension.
+* Replace obsolete `when-let` and `cl-gensym` with `when-let*` and `gensym` for compatibility with Emacs 31+.
 
 ### New features
 
@@ -137,28 +157,6 @@
 * Fix `dired-before-readin-hook` being added as buffer-local instead of global in `projectile-mode`, so it now correctly fires in all dired buffers.
 * Fix `projectile-find-dir-hook` not being cleaned up when disabling `projectile-mode`.
 * Use `display-warning` instead of `message` when cache serialization fails, making the failure visible in the `*Warnings*` buffer.
-
-### Changes
-
-* Pre-compute file timestamps in `projectile-sort-by-modification-time` and `projectile-sort-by-access-time` to reduce stat calls from O(n log n) to O(n).
-* Cache `projectile-parse-dirconfig-file` results per project root (invalidated by file modification time), avoiding redundant file reads during indexing.
-* Cache `file-truename` results in `projectile-project-buffer-p` when checking multiple buffers, reducing redundant symlink resolution.
-* Use a hash set for deleted file removal in `projectile-dir-files-alien`, improving performance from O(n*m) to O(n+m) when filtering deleted-but-unstaged files.
-* Avoid redundant `projectile-project-root` call in `projectile-detect-project-type` by passing through the already-resolved root.
-* Share `file-truename` cache across buffers in `projectile-open-projects`, matching the optimization already in `projectile-project-buffers`.
-* Remove unnecessary temp buffer creation in `projectile--cache-project-commands-p` (was creating a buffer and re-reading `.dir-locals.el` on every compile/test/run invocation).
-* **[Breaking]** Bump minimum required Emacs version from 26.1 to 27.1. This removes ~30 lines of compatibility code (fileloop fallback, `time-convert` fallback, `projectile-flatten` shim) and fixes the `tags-query-replace` FIXME in `projectile-replace-regexp`.
-* Add `compat` as a dependency, enabling the use of modern Emacs APIs (e.g. `string-replace`) on older Emacs versions.
-* Replace most `cl-lib` sequence functions with `seq.el` equivalents (`seq-filter`, `seq-remove`, `seq-some`, `seq-find`, `seq-sort`, `seq-every-p`, `seq-difference`) and convert `cl-case` to `pcase`.
-* [#1971](https://github.com/bbatsov/projectile/pull/1971): Support `slnx` files for dotnet project types.
-* [#1958](https://github.com/bbatsov/projectile/issues/1958): Exclude `.projectile-cache.eld` from search results (ripgrep/ag/grep) by default.
-* [#1957](https://github.com/bbatsov/projectile/pull/1957): Add `:caller` information to calls to `ivy-read` (used by packages like `ivy-rich`).
-* [#1947](https://github.com/bbatsov/projectile/issues/1947): `projectile-project-name` should be marked as safe.
-* Set `projectile-auto-discover` to `nil` by default (to avoid startup slowdowns in some situations).
-* [#1943](https://github.com/bbatsov/projectile/pull/1943): Consider `projectile-indexing-method` to be safe as a dir-local variable if it is one of the preset values.
-* [#1936](https://github.com/bbatsov/projectile/issues/1936): Do not require selecting a project when using `M-x projectile-invalidate-cache`, since there is a global cache that is also cleared by that command, even when not operating on any specific project.
-* Add `build.mill` as an alternative project marker for the Mill project type, matching Mill's current recommended file extension.
-* Replace obsolete `when-let` and `cl-gensym` with `when-let*` and `gensym` for compatibility with Emacs 31+.
 
 ## 2.9.1 (2025-02-13)
 

--- a/Eldev
+++ b/Eldev
@@ -6,13 +6,11 @@
 ;; directory on the load path when running tests.
 (eldev-add-loading-roots 'test "test")
 
-;; `transient' is an optional dependency (it powers `projectile-dispatch',
-;; which is only defined when transient is present).  Pull it in for building
-;; and testing so the transient menu definition is actually loaded and
-;; validated.  transient needs Emacs 28.1+.
-(when (version<= "28.1" emacs-version)
-  (eldev-add-extra-dependencies 'build 'transient)
-  (eldev-add-extra-dependencies 'test 'transient))
+;; `transient' powers `projectile-dispatch'.  It's bundled with Emacs 28.1+
+;; (Projectile's minimum), but pull it in explicitly for building and testing so
+;; a recent version is used and the transient menu definition is validated.
+(eldev-add-extra-dependencies 'build 'transient)
+(eldev-add-extra-dependencies 'test 'transient)
 
 ;; `projectile-consult.el' is an optional Consult integration that ships with
 ;; Projectile but is loaded only on demand (Consult is a soft dependency, not

--- a/doc/modules/ROOT/nav.adoc
+++ b/doc/modules/ROOT/nav.adoc
@@ -6,6 +6,7 @@
 * xref:extensions.adoc[Extensions]
 * xref:projectile_vs_project.adoc[Projectile vs project.el]
 * xref:migrating_from_project_el.adoc[Migrating from project.el]
+* xref:migrating_to_projectile_3.adoc[Migrating to Projectile 3.0]
 * xref:faq.adoc[FAQ]
 * xref:troubleshooting.adoc[Troubleshooting]
 * xref:contributing.adoc[Contributing]

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -584,8 +584,8 @@ command specified in `projectile-switch-project-action` (by default it
 is `projectile-find-file`).
 
 TIP: Invoking the command with a prefix argument (kbd:[C-u s-p p] or kbd:[C-u s-p q]) will trigger
- the Projectile Commander, which gives you quick access to most common commands
- you might want to invoke on a project.
+ the Projectile dispatch menu (`projectile-dispatch`), which gives you quick access to most
+ common commands you might want to invoke on a project.
 
 Depending on your personal workflow and habits, you
 may prefer to alter the value of `projectile-switch-project-action`:

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -49,7 +49,7 @@ Here are some of Projectile's features in no particular order:
 * find references in project (using `xref` internally)
 * visit project in `dired`
 * run `make` in a project with a single key chord
-* support for multiple minibuffer completion/selection libraries (`ido`, `ivy`, `helm` and the default completion system)
+* works with any `completing-read`-based minibuffer completion UI (Vertico, Consult, `fido-mode`, etc.)
 * automatic project discovery (see `projectile-project-search-path`)
 * integration with the built-in `project.el` library
 

--- a/doc/modules/ROOT/pages/installation.adoc
+++ b/doc/modules/ROOT/pages/installation.adoc
@@ -1,6 +1,6 @@
 = Installation
 
-NOTE: Projectile officially supports Emacs 26.1+.
+NOTE: Projectile officially supports Emacs 28.1+.
 
 The recommended way to install Projectile is via `package.el`.
 

--- a/doc/modules/ROOT/pages/migrating_to_projectile_3.adoc
+++ b/doc/modules/ROOT/pages/migrating_to_projectile_3.adoc
@@ -1,0 +1,170 @@
+= Migrating to Projectile 3.0
+
+Projectile 3.0 is a cleanup and modernization release. There are no big new
+concepts to learn - the focus was on removing long-deprecated or low-value
+features and consolidating a few families of near-duplicate commands. Most
+setups will keep working untouched; this page walks through the changes that
+_can_ affect an older configuration and how to adapt.
+
+TIP: If you just want the short version, jump to the <<cheat-sheet,configuration
+cheat sheet>> at the end.
+
+== Requirements
+
+Projectile 3.0 requires *Emacs 28.1 or newer* (2.x supported 27.1, and older
+2.x releases went back further). If you're on an older Emacs, stay on Projectile
+2.x. The bump lets Projectile rely on `transient` unconditionally, so
+`projectile-dispatch` (kbd:[s-p m]) is now always available rather than an
+optional extra.
+
+== Removed features
+
+=== Projectile Commander -> the dispatch menu
+
+The single-key "Commander" (`projectile-commander` and
+`def-projectile-commander-method`) is gone. Its replacement is
+`projectile-dispatch`, a `transient` menu bound to kbd:[s-p m]. A prefix
+argument on project switch (kbd:[C-u s-p p]) also opens it.
+
+If you defined your own commander methods, add them to the dispatch transient
+instead (see `transient-append-suffix` and the `projectile-dispatch` definition).
+
+=== The idle timer
+
+`projectile-enable-idle-timer`, `projectile-idle-timer-seconds` and
+`projectile-idle-timer-hook` were removed. If you relied on running something
+periodically, wire it up yourself:
+
+[source,elisp]
+----
+(run-with-idle-timer 60 t (lambda ()
+                            (when (projectile-project-p)
+                              ;; ...
+                              )))
+----
+
+=== projectile-browse-dirty-projects
+
+Removed. For an overview of repositories with uncommitted changes use
+`magit-list-repositories` or `vc-dir`, which do this far better than Projectile
+ever did.
+
+=== Built-in tags support
+
+All of the built-in `ctags`/`etags`/`gtags` glue is gone:
+`projectile-find-tag`, `projectile-regenerate-tags`,
+`projectile-visit-project-tags-table`, and the `projectile-tags-command` /
+`projectile-tags-backend` options.
+
+Modern code navigation is better served by `xref` (kbd:[M-.]) backed by a
+language server (Eglot/LSP) or `etags`/`ggtags` directly, plus
+`projectile-find-references` (kbd:[s-p s x]) for textual references.
+
+NOTE: `projectile-tags-file-name` is kept, but only so that a project's `TAGS`
+file can be excluded from the index. It no longer drives any command.
+
+=== The ido / ivy / helm completion systems
+
+`projectile-completion-system` used to accept `ido`, `ivy`, `helm`, `default`,
+or `auto` (which detected `ido-mode`/`ivy-mode`/`helm-mode`). The dedicated
+`ido`/`ivy`/`helm`/`auto` values were removed - it now takes `default` (Emacs's
+`completing-read`) or a custom function.
+
+This isn't a loss of functionality: Vertico, Consult, `fido-mode`, Ido's
+`ido-ubiquitous`, and friends all work through `completing-read`, and
+https://github.com/bbatsov/helm-projectile[helm-projectile] /
+https://github.com/ericdanan/counsel-projectile[counsel-projectile] provide
+their own dedicated integration. Any of the old values now simply behaves like
+`default`, so nothing breaks - you can just delete the setting.
+
+=== Legacy keybindings and aliases
+
+The single-letter lifecycle bindings kbd:[s-p C] / kbd:[s-p K] / kbd:[s-p L] /
+kbd:[s-p P] / kbd:[s-p u] (configure / package / install / test / run project)
+were removed. Use the `c` prefix instead: kbd:[s-p c o], kbd:[s-p c p],
+kbd:[s-p c i], kbd:[s-p c t], kbd:[s-p c r].
+
+Two long-obsolete aliases were also deleted: `projectile-global-mode` (use
+`projectile-mode`) and `projectile-project-root-files-functions` (use
+`projectile-project-root-functions`).
+
+== Consolidated commands
+
+=== Search
+
+The search commands now share one entry point, `projectile-search`
+(kbd:[s-p s s]), backed by a pluggable backend. `projectile-search-backend`
+picks the backend (`auto` by default, favouring `ripgrep` then `grep`); you can
+also register your own with `projectile-register-search-backend`. See the
+xref:configuration.adoc#_searching[Searching] section for details.
+
+`projectile-grep`, `projectile-ripgrep` and `projectile-ag` still exist as thin
+wrappers that force a specific backend.
+
+IMPORTANT: One keybinding changed. kbd:[s-p s s] now runs `projectile-search`
+(it used to run `projectile-ag`), and `projectile-ag` moved to kbd:[s-p s a].
+kbd:[s-p s g] (grep) and kbd:[s-p s r] (ripgrep) are unchanged.
+
+=== Shells, REPLs and terminals
+
+Similarly, `projectile-run` (kbd:[s-p x r]) is a single command that opens a
+shell/REPL/terminal in the project root using a backend chosen by
+`projectile-shell-backend` (default `eshell`). The individual commands
+(`projectile-run-eshell`, `projectile-run-vterm`, ..., and their
+`-other-window` variants) are unchanged, and you can add your own terminal with
+`projectile-register-shell-backend`.
+
+=== Dispatch modifiers instead of "other window / other frame" columns
+
+The `projectile-dispatch` menu gained modifier switches - kbd:[-d] (`--display`:
+cycle this window / other window / other frame), kbd:[-r] (`--regexp`),
+kbd:[-n] (`--new-process`) and kbd:[-i] (`--invalidate-cache`) - which replace
+the old dedicated "Other window" and "Other frame" menu columns. The
+`projectile-command-map` kbd:[4 <key>] / kbd:[5 <key>] bindings and the
+individual `*-other-window` / `*-other-frame` commands are untouched.
+
+== Behavior changes
+
+=== projectile-find-references
+
+`projectile-find-references` now honours Projectile's ignore configuration
+(`.projectile` and the globally-ignored files/directories) and searches only the
+project's file set. It previously went through the semantic-symref API, which
+scanned the whole tree and ignored that configuration. For semantic (not
+textual) references, use the built-in `xref-find-references` - it is also scoped
+to the Projectile project now.
+
+[[cheat-sheet]]
+== Configuration cheat sheet
+
+[cols="1,1",options="header"]
+|===
+| Before (2.x) | After (3.0)
+
+| `(setq projectile-completion-system 'ido)` (or `ivy`/`helm`/`auto`)
+| Delete it, or `(setq projectile-completion-system 'default)`; use Vertico/Consult/helm-projectile/counsel-projectile as usual
+
+| `projectile-commander`, `def-projectile-commander-method`
+| `projectile-dispatch` (kbd:[s-p m]) + `transient-append-suffix`
+
+| `projectile-enable-idle-timer`, `projectile-idle-timer-seconds`, `projectile-idle-timer-hook`
+| Roll your own with `run-with-idle-timer`
+
+| `projectile-browse-dirty-projects`
+| `magit-list-repositories` / `vc-dir`
+
+| `projectile-find-tag`, `projectile-regenerate-tags`, `projectile-tags-command`, `projectile-tags-backend`
+| `xref` (kbd:[M-.]) + a language server, and `projectile-find-references`
+
+| kbd:[s-p s s] (was `projectile-ag`)
+| `projectile-search`; `projectile-ag` is now kbd:[s-p s a]
+
+| kbd:[s-p C] / kbd:[s-p K] / kbd:[s-p L] / kbd:[s-p P] / kbd:[s-p u]
+| kbd:[s-p c o] / kbd:[s-p c p] / kbd:[s-p c i] / kbd:[s-p c t] / kbd:[s-p c r]
+
+| `projectile-global-mode`, `projectile-project-root-files-functions`
+| `projectile-mode`, `projectile-project-root-functions`
+
+| Emacs 27.1+
+| Emacs 28.1+
+|===

--- a/doc/modules/ROOT/pages/projectile_vs_project.adoc
+++ b/doc/modules/ROOT/pages/projectile_vs_project.adoc
@@ -24,7 +24,7 @@ NOTE: As of early 2026. (Projectile 2.10 and `project.el` in Emacs 31)
 | 2014 footnote:[It was introduced in Emacs 25.1.]
 
 | Supported Emacs versions
-| 27.1+
+| 28.1+
 | 26+ footnote:[Note that the versions bundled with older Emacsen will miss some of its modern features. `project.el` is distributed as a package as well, so you can still get some of the newer functionality on older Emacsen.]
 
 | Built-in
@@ -431,11 +431,11 @@ Side-by-side mapping of the most common entry points. Useful both when picking b
 
 == Projectile's Pros
 
-* Projectile targets Emacs 27.1, so you can get all the features even with older Emacs releases
+* Projectile targets Emacs 28.1+
 * Projectile has different project indexing strategies, which offer you a lot of flexibility in different situations
 * Projectile supports a lot of project types out-of-the-box (e.g. `ruby`, `Rails`, `cabal` and `dune`), with per-type hooks for compile/test/run/install/package/configure
 * Projectile has a lot more features, although one can argue that some of them are rarely needed
-  ** Projectile's Commander is pretty cool for project switching!
+  ** Projectile's dispatch menu (`projectile-dispatch`, a `transient` interface) is pretty cool for driving a project!
   ** Test/implementation toggling, a related-files framework, persistent on-disk caching, integrations with most Emacs shells out of the box
 * It's easier to contribute to Projectile
   ** Projectile is hosted in GitHub

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -159,7 +159,7 @@ You need to know only a handful of Projectile commands to start benefiting from 
 * Grep (search for text/regexp) in project (kbd:[s-p s g])
 * Replace in project (kbd:[s-p r])
 * Find references in project (kbd:[s-p ?] or kbd:[s-p s x])
-* Invoke any Projectile command via the Projectile Commander (kbd:[s-p m])
+* Invoke any Projectile command via the Projectile dispatch menu (kbd:[s-p m])
 * Toggle between implementation and test (kbd:[s-p t])
 * Toggle between related files (e.g. `foo.h` <-> `foo.c` and `Gemfile` <-> `Gemfile.lock`) (kbd:[s-p a])
 * Run a shell command in the root of the project (kbd:[s-p !] for a sync command and kbd:[s-p &] for an async command)
@@ -447,10 +447,9 @@ find a file and show it in a new frame; or press kbd:[-i] then kbd:[f] to
 invalidate the cache and find a file. This replaces the old dedicated "other
 window" and "other frame" menu columns.
 
-NOTE: `transient` is an optional dependency (it requires Emacs 28.1+), so
-`projectile-dispatch` is only defined when `transient` is installed. It is not
-bound to a key by default; without it kbd:[C-u s-p p] simply falls back to
-`projectile-switch-project-action`.
+NOTE: `projectile-dispatch` is powered by `transient`, which is bundled with
+Emacs 28.1+ (Projectile's minimum), so the menu is always available. It's bound
+to kbd:[s-p m], and kbd:[C-u s-p p] opens it when switching projects.
 
 == Using Projectile with project.el
 

--- a/projectile.el
+++ b/projectile.el
@@ -5,8 +5,8 @@
 ;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: https://github.com/bbatsov/projectile
 ;; Keywords: project, convenience
-;; Version: 2.10.0-snapshot
-;; Package-Requires: ((emacs "27.1") (compat "30"))
+;; Version: 3.0.0-snapshot
+;; Package-Requires: ((emacs "28.1") (compat "30"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -44,6 +44,9 @@
 (require 'compile)
 (require 'grep)
 (require 'fileloop)
+;; `transient' is bundled with Emacs 28.1+ (Projectile's minimum), so it's a
+;; hard dependency, used by `projectile-dispatch'.
+(require 'transient)
 (eval-when-compile
   (require 'find-dired)
   (require 'subr-x))
@@ -53,10 +56,6 @@
 ;; A bunch of variable and function declarations
 ;; needed to appease the byte-compiler.
 (defvar ag-ignore-list)
-;; Defined by the optional `transient' dependency (see `projectile-dispatch').
-(defvar transient-exit-hook)
-(defvar transient-current-command)
-(declare-function transient-args "transient")
 (defvar eshell-buffer-name)
 (defvar explicit-shell-file-name)
 (defvar grep-files-aliases)
@@ -65,9 +64,6 @@
 (defvar eat-buffer-name)
 (defvar ghostel-buffer-name)
 
-;; `projectile-dispatch' is defined later in this file, but only when the
-;; optional `transient' dependency is available, so forward-declare it.
-(declare-function projectile-dispatch "projectile")
 (declare-function make-term "term")
 (declare-function term-mode "term")
 (declare-function term-char-mode "term")
@@ -171,7 +167,7 @@ in batch mode, or while a keyboard macro is executing - those fall back
 to synchronous indexing."
   :group 'projectile
   :type 'boolean
-  :package-version '(projectile . "2.10.0"))
+  :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-kill-buffers-filter 'kill-all
   "Determine which buffers are killed by `projectile-kill-buffers'.
@@ -289,7 +285,7 @@ of those legacy values now behaves like `default'."
   :group 'projectile
   :type '(choice (const :tag "Default (completing-read)" default)
                  (function :tag "Custom function"))
-  :package-version '(projectile . "2.10.0"))
+  :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-keymap-prefix nil
   "Projectile keymap prefix."
@@ -408,8 +404,6 @@ containing a root file."
   :group 'projectile
   :type '(repeat string))
 
-(define-obsolete-variable-alias 'projectile-project-root-files-functions 'projectile-project-root-functions "2.4")
-
 (defcustom projectile-project-root-functions
   '(projectile-root-local
     projectile-root-marked
@@ -457,7 +451,7 @@ non-empty dirconfig is present alongside alien indexing, since the
 silent bypass is a frequent source of confusion."
   :group 'projectile
   :type 'boolean
-  :package-version '(projectile . "2.10.0"))
+  :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-warn-on-prefixless-dirconfig-lines t
   "Whether to warn about deprecated prefix-less ignore entries.
@@ -468,7 +462,7 @@ non-nil, a one-time warning is shown per project that uses any
 such line, listing the offending entries."
   :group 'projectile
   :type 'boolean
-  :package-version '(projectile . "2.10.0"))
+  :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-globally-ignored-files
   (list projectile-tags-file-name projectile-cache-file)
@@ -609,7 +603,7 @@ Like `projectile-switch-project-action', but for the other-window variant.
 Any function that does not take arguments will do."
   :group 'projectile
   :type 'function
-  :package-version '(projectile . "2.10.0"))
+  :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-switch-project-other-frame-action 'projectile-find-file-other-frame
   "Action run by `projectile-switch-project-other-frame' after switching.
@@ -618,7 +612,7 @@ Like `projectile-switch-project-action', but for the other-frame variant.
 Any function that does not take arguments will do."
   :group 'projectile
   :type 'function
-  :package-version '(projectile . "2.10.0"))
+  :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-find-dir-includes-top-level nil
   "If true, add top-level dir to options offered by `projectile-find-dir'."
@@ -644,7 +638,7 @@ asked which backend to use each time."
                  (const :tag "ripgrep" ripgrep)
                  (const :tag "ag" ag)
                  (symbol :tag "Other registered backend"))
-  :package-version '(projectile . "2.10.0"))
+  :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-shell-backend 'eshell
   "The backend `projectile-run' uses to open a shell/REPL/terminal.
@@ -663,7 +657,7 @@ to pick the first available backend, or `prompt' to be asked each time."
                  (const :tag "Automatic" auto)
                  (const :tag "Prompt each time" prompt)
                  (symbol :tag "Other registered backend"))
-  :package-version '(projectile . "2.10.0"))
+  :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-grep-finished-hook nil
   "Hooks run when `projectile-grep' finishes."
@@ -922,7 +916,7 @@ Set to nil to disable listing submodules contents."
   "Command used by projectile to get the ignored files in a hg project."
   :group 'projectile
   :type 'string
-  :package-version '(projectile . "2.10.0"))
+  :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-jj-command "jj file list -T 'path ++ \"\\0\"' --no-pager ."
   "Command used by projectile to get the files in a Jujutsu project."
@@ -975,7 +969,7 @@ fails with an authentication error.  See URL
   "Command used by projectile to get the ignored files in a svn project."
   :group 'projectile
   :type 'string
-  :package-version '(projectile . "2.10.0"))
+  :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-generic-command
   (cond
@@ -1116,7 +1110,7 @@ Should be set via .dir-locals.el.")
 
 ;;; Version information
 
-(defconst projectile-version "2.10.0-snapshot"
+(defconst projectile-version "3.0.0-snapshot"
   "The current version of Projectile.")
 
 (defun projectile--pkg-version ()
@@ -2270,7 +2264,7 @@ special-case disabled commands) or when a remote file-name handler
 declines to start the process (CALLBACK is invoked with an error).
 
 Remote ROOTs are handled via TRAMP (`make-process' is given a non-nil
-`:file-handler', which requires Emacs 27.1+)."
+`:file-handler')."
   (if (not (and (stringp command) (not (string-empty-p command))))
       (progn (funcall callback nil nil) nil)
     (let* ((default-directory root)
@@ -5610,10 +5604,9 @@ search.  Honours Projectile's ignore configuration and runs
                projectile-use-git-grep)
           (vc-git-grep search-regexp (or files "") root-dir)
         ;; paths for find-grep should relative and without trailing /
-        ;; TODO: Replace seq-uniq+append with seq-union when Emacs 28.1 is the minimum version
         (let ((grep-find-ignored-files
-               (seq-uniq (append (projectile--globally-ignored-file-suffixes-glob)
-                                 grep-find-ignored-files)))
+               (seq-union (projectile--globally-ignored-file-suffixes-glob)
+                          grep-find-ignored-files))
               (projectile-grep-find-ignored-paths
                (append (mapcar (lambda (f) (directory-file-name (file-relative-name f root-dir)))
                                (projectile-ignored-directories))
@@ -7178,7 +7171,7 @@ project).  Use `projectile-switch-to-most-recent-project' to jump to it.")
 (defun projectile-switch-project (&optional arg)
   "Switch to a project we have visited before.
 Invokes the command referenced by `projectile-switch-project-action' on switch.
-With a prefix ARG invokes `projectile-dispatch' (when available) instead
+With a prefix ARG invokes `projectile-dispatch' instead
 of `projectile-switch-project-action'."
   (interactive "P")
   (let ((projects (projectile-relevant-known-projects)))
@@ -7194,7 +7187,7 @@ of `projectile-switch-project-action'."
 (defun projectile-switch-open-project (&optional arg)
   "Switch to a project we have currently opened.
 Invokes the command referenced by `projectile-switch-project-action' on switch.
-With a prefix ARG invokes `projectile-dispatch' (when available) instead
+With a prefix ARG invokes `projectile-dispatch' instead
 of `projectile-switch-project-action'."
   (interactive "P")
   (let ((projects (projectile-relevant-open-projects)))
@@ -7219,7 +7212,7 @@ Like `projectile-switch-project', but runs
 `projectile-switch-project-other-window-action' (by default
 `projectile-find-file-other-window') after switching, so the project is
 shown in another window.  With a prefix ARG invokes `projectile-dispatch'
-(when available) instead."
+instead."
   (interactive "P")
   (let ((projectile-switch-project-action projectile-switch-project-other-window-action))
     (projectile-switch-project arg)))
@@ -7232,7 +7225,7 @@ Like `projectile-switch-project', but runs
 `projectile-switch-project-other-frame-action' (by default
 `projectile-find-file-other-frame') after switching, so the project is
 shown in another frame.  With a prefix ARG invokes `projectile-dispatch'
-(when available) instead."
+instead."
   (interactive "P")
   (let ((projectile-switch-project-action projectile-switch-project-other-frame-action))
     (projectile-switch-project arg)))
@@ -7243,7 +7236,7 @@ shown in another frame.  With a prefix ARG invokes `projectile-dispatch'
 That's the project that was current before the most recent project
 switch, so calling this from a buffer in the switched-to project takes
 you back where you came from.  With a prefix ARG invokes
-`projectile-dispatch' (when available) instead of
+`projectile-dispatch' instead of
 `projectile-switch-project-action'."
   (interactive "P")
   (if projectile-most-recent-project
@@ -7288,7 +7281,7 @@ switched-to project."
 (defun projectile-switch-project-by-name (project-to-switch &optional arg)
   "Switch to project by project name PROJECT-TO-SWITCH.
 Invokes the command referenced by `projectile-switch-project-action' on switch.
-With a prefix ARG invokes `projectile-dispatch' (when available) instead
+With a prefix ARG invokes `projectile-dispatch' instead
 of `projectile-switch-project-action'."
   ;; let's make sure that the target directory exists and is actually a project
   ;; we ignore remote folders, as the check breaks for TRAMP unless already connected
@@ -7299,7 +7292,7 @@ of `projectile-switch-project-action'."
   ;; points at it after the switch (captured before `default-directory' is
   ;; rebound below).
   (let ((previous-project (projectile-project-root))
-        (action (if (and arg (fboundp 'projectile-dispatch))
+        (action (if arg
                     'projectile-dispatch
                   projectile-switch-project-action)))
     (run-hooks 'projectile-before-switch-project-hook)
@@ -7782,12 +7775,6 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "c i") #'projectile-install-project)
     (define-key map (kbd "c t") #'projectile-test-project)
     (define-key map (kbd "c r") #'projectile-run-project)
-    ;; TODO: Legacy keybindings that will be removed in Projectile 3
-    (define-key map (kbd "C") #'projectile-configure-project)
-    (define-key map (kbd "K") #'projectile-package-project)
-    (define-key map (kbd "L") #'projectile-install-project)
-    (define-key map (kbd "P") #'projectile-test-project)
-    (define-key map (kbd "u") #'projectile-run-project)
     ;; integration with utilities
     (define-key map (kbd "x r") #'projectile-run)
     (define-key map (kbd "x e") #'projectile-run-eshell)
@@ -7921,15 +7908,8 @@ PROPS is a plist of:
   :prefix-arg "--new-process")
 
 ;; `projectile-dispatch' is a transient menu mirroring `projectile-command-map'.
-;; `transient' is an optional dependency that requires Emacs 28.1+, so it can be
-;; entirely absent (including on Emacs 27, which Projectile still supports and
-;; where transient cannot even be installed).  The prefix is therefore defined
-;; at load time only when transient is present, and via `eval' so the
-;; `transient-define-prefix' macro is not needed at byte-compile time.  The menu
-;; keys deliberately match the `projectile-command-map' bindings.
-(when (require 'transient nil t)
-  (eval
-   '(transient-define-prefix projectile-dispatch ()
+;; The menu keys deliberately match the `projectile-command-map' bindings.
+(transient-define-prefix projectile-dispatch ()
     "Dispatch menu for Projectile commands.
 
 The switches in the Modifiers group tweak how the commands below run:
@@ -7999,7 +7979,6 @@ window or frame (file/buffer/project commands)."
      ["Cache"
       ("i" "invalidate cache" projectile-invalidate-cache)
       ("z" "cache current file" projectile-cache-current-file)]])
-   t))
 
 (defvar projectile-mode-map
   (let ((map (make-sparse-keymap)))
@@ -8155,9 +8134,8 @@ globally ignored directory names and file suffixes are matched at any
 depth, while the files and directories ignored via the project's
 dirconfig (`.projectile') are rooted at the project root with a
 leading `./'."
-  ;; NOTE: Use the project root (the cdr) directly rather than
-  ;; `project-root', which doesn't exist on Emacs 27 (project.el provided
-  ;; `project-roots' there instead).
+  ;; PROJECT is Projectile's own `(projectile . root)' representation, so read
+  ;; the root straight from the cdr rather than going through `project-root'.
   (projectile--project-ignore-globs (cdr project)))
 
 ;;;###autoload
@@ -8212,9 +8190,6 @@ Otherwise behave as if called interactively.
   (add-hook 'savehist-mode-hook
             (lambda()
               (add-to-list 'savehist-additional-variables 'projectile-project-command-history))))
-
-;;;###autoload
-(define-obsolete-function-alias 'projectile-global-mode 'projectile-mode "1.0")
 
 (provide 'projectile)
 

--- a/test/projectile-dispatch-test.el
+++ b/test/projectile-dispatch-test.el
@@ -75,10 +75,10 @@
     (expect captured :to-equal (cons 'projectile-switch-project nil))))
 
 (describe "projectile-dispatch prefix"
-  (it "is a transient prefix exactly when transient is available"
-    (if (featurep 'transient)
-        (expect (get 'projectile-dispatch 'transient--prefix) :to-be-truthy)
-      (expect (fboundp 'projectile-dispatch) :to-be nil))))
+  (it "is defined as a transient prefix"
+    ;; transient is bundled with Emacs 28.1+ (Projectile's minimum), so the
+    ;; dispatch menu is always available.
+    (expect (get 'projectile-dispatch 'transient--prefix) :to-be-truthy)))
 
 (provide 'projectile-dispatch-test)
 


### PR DESCRIPTION
Prep for the 3.0 release. The minimum Emacs is now 28.1, which means `transient` is bundled and `projectile-dispatch` can be defined unconditionally instead of hiding behind a `require ... nil t` dance; the Emacs 27 compat shims go with it. Also drops the legacy single-letter lifecycle keys `C`/`K`/`L`/`P`/`u` (the `c` prefix stays) and two long-obsolete aliases, `projectile-global-mode` and `projectile-project-root-files-functions`.

Docs get a new "Migrating to Projectile 3.0" page, plus fixes for stale references an audit turned up (Commander instead of the dispatch menu, the old ido/ivy/helm completion list, minimum-Emacs mentions).