### PR TITLE
Rank project files by frecency in completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* `projectile-find-file` and `projectile-find-file-dwim` now rank the files you work with first: visits are recorded per project and candidates are ordered by frequency and recency (with decay), applied via completion metadata so it works with any completion UI and under every indexing method, including `alien`. Controlled by `projectile-enable-frecency` (default on); the history is persisted in `projectile-frecency-file` and capped by `projectile-frecency-max-files`.
 * [#978](https://github.com/bbatsov/projectile/issues/978): Add `projectile-project-changed-functions`, run whenever the current project changes - including implicitly via visiting a file or directory of another project - with the new and previous project root as arguments.
 * [#1442](https://github.com/bbatsov/projectile/pull/1442): `projectile-sort-order` can now be set to a function that receives the list of project files and returns them in the desired order.
 * [#1984](https://github.com/bbatsov/projectile/pull/1984): The VCS markers are now customizable via `projectile-vcs-markers`, whose order breaks ties between markers in the same directory - so colocated `jj`+`git` repositories can be detected as `jj` by moving `.jj` first.

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -288,6 +288,37 @@ with shorter paths first:
       (lambda (files) (seq-sort-by #'length #'< files)))
 ----
 
+== File ranking (frecency)
+
+Since Projectile 3.1, `projectile-find-file` (and its dwim variant)
+rank the files you actually work with first: Projectile records file
+visits per project and orders completion candidates by "frecency", a
+combination of visit frequency and recency (frequent visits decay with
+a half-life of two weeks). Files you've never visited keep their
+original order after the ranked ones.
+
+Unlike `projectile-sort-order`, the ranking is applied through
+completion metadata (`display-sort-function`), so it works with any
+completion UI that honors it (the default completion UI, Vertico,
+Icomplete, ...) and under *every* indexing method, including `alien`.
+
+The feature is enabled by default. To turn it off:
+
+[source,elisp]
+----
+(setq projectile-enable-frecency nil)
+----
+
+The visit history is persisted across sessions in
+`projectile-frecency-file` and capped per project by
+`projectile-frecency-max-files` (200 by default). Concurrent Emacs
+sessions merge their histories on save rather than overwriting each
+other. Remote (TRAMP) projects are not tracked.
+
+NOTE: For tracked files the frecency order takes precedence over
+`projectile-sort-order`, since completion UIs apply the metadata sort
+to whatever candidate order they receive.
+
 == Caching
 
 === Project files

--- a/projectile.el
+++ b/projectile.el
@@ -1692,6 +1692,198 @@ is tracked in `projectile--current-project'."
                                           (projectile-project-cache-file)))
     (projectile-invalidate-cache nil)))
 
+
+;;; File frecency
+;;
+;; Tracks which project files are visited and how often, so that
+;; `projectile-find-file' (and friends) can rank the files you actually
+;; work with first.  The ranking is applied through completion metadata
+;; (`display-sort-function'), so it works with any completion UI that
+;; honors it (the default completion UI, Vertico, Icomplete, ...) and
+;; under every indexing method, including `alien'.
+
+(defcustom projectile-enable-frecency t
+  "When non-nil, rank project files by frecency in completion.
+Projectile records file visits per project and sorts completion
+candidates by a combination of visit frequency and recency, so the
+files you work with the most show up first in `projectile-find-file'
+and related commands.
+
+The history is persisted in `projectile-frecency-file'."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "3.1.0"))
+
+(defcustom projectile-frecency-file
+  (expand-file-name "projectile-frecency.eld" user-emacs-directory)
+  "File where Projectile persists the per-project file visit history."
+  :group 'projectile
+  :type 'file
+  :package-version '(projectile . "3.1.0"))
+
+(defcustom projectile-frecency-max-files 200
+  "Maximum number of files tracked per project.
+When the limit is exceeded, the lowest-ranking entries are dropped."
+  :group 'projectile
+  :type 'natnum
+  :package-version '(projectile . "3.1.0"))
+
+(defvar projectile--frecency-table nil
+  "Hash of project root to a hash of relative file name to (COUNT . TIME).
+TIME is the last visit in seconds since the epoch.  nil until loaded
+from `projectile-frecency-file' by `projectile--frecency-data'.")
+
+(defvar projectile--frecency-dirty nil
+  "Non-nil when the frecency data changed since it was last saved.")
+
+(defun projectile--frecency-data ()
+  "Return the frecency table, loading it from disk on first use.
+A malformed history file yields an empty table with a warning; it
+must never break `find-file' (the recording hook would re-signal on
+every file visit otherwise)."
+  (or projectile--frecency-table
+      (setq projectile--frecency-table
+            (condition-case err
+                (let ((table (make-hash-table :test 'equal)))
+                  (dolist (project (projectile-unserialize
+                                    projectile-frecency-file))
+                    (let ((files (make-hash-table :test 'equal)))
+                      (dolist (entry (cdr project))
+                        (puthash (nth 0 entry)
+                                 (cons (nth 1 entry) (nth 2 entry))
+                                 files))
+                      (puthash (car project) files table)))
+                  table)
+              (error
+               (display-warning
+                'projectile
+                (format "Malformed frecency file '%s' ignored (%s)"
+                        projectile-frecency-file (error-message-string err))
+                :warning)
+               (make-hash-table :test 'equal))))))
+
+(defun projectile--frecency-score (entry now)
+  "Compute the frecency score of ENTRY (COUNT . TIME) at time NOW.
+The visit count decays with a half-life of two weeks, so a file
+visited often long ago eventually ranks below one visited recently."
+  (let ((age-days (/ (max 0 (- now (cdr entry))) 86400.0)))
+    (* (car entry) (expt 0.5 (/ age-days 14.0)))))
+
+(defun projectile--frecency-prune (files)
+  "Drop the lowest-scoring entries of FILES down to the configured limit."
+  (let ((now (projectile-time-seconds))
+        (entries nil))
+    (maphash (lambda (file entry)
+               (push (cons file (projectile--frecency-score entry now)) entries))
+             files)
+    (dolist (victim (nthcdr projectile-frecency-max-files
+                            (seq-sort-by #'cdr #'> entries)))
+      (remhash (car victim) files))))
+
+(defun projectile--frecency-record (project-root)
+  "Record a visit to the current buffer's file under PROJECT-ROOT.
+Remote projects are not tracked, to keep the visit hook free of
+TRAMP round-trips."
+  (when (and projectile-enable-frecency
+             project-root
+             buffer-file-name
+             (not (file-remote-p project-root)))
+    (let ((file (file-relative-name buffer-file-name project-root)))
+      ;; Skip files that don't sit under the root as spelled - either
+      ;; genuinely outside the project, or reached through a
+      ;; differently-spelled root (e.g. a symlinked path).  Tracking a
+      ;; ../-relative name would never match a completion candidate.
+      (unless (string-prefix-p ".." file)
+        (let* ((table (projectile--frecency-data))
+               (files (or (gethash project-root table)
+                          (puthash project-root
+                                   (make-hash-table :test 'equal) table)))
+               (entry (gethash file files)))
+          (puthash file (cons (1+ (or (car entry) 0))
+                              (projectile-time-seconds))
+                   files)
+          (setq projectile--frecency-dirty t)
+          (when (> (hash-table-count files) (* 2 projectile-frecency-max-files))
+            (projectile--frecency-prune files)))))))
+
+(defun projectile--frecency-sort-function (project-root)
+  "Return a completion sort function ranking PROJECT-ROOT's files, or nil.
+The returned function puts tracked files first, ordered by
+`projectile--frecency-score', and preserves the order of the rest.
+Return nil when frecency is disabled or nothing is tracked yet."
+  (when (and projectile-enable-frecency project-root)
+    (when-let* ((files (gethash project-root (projectile--frecency-data))))
+      (when (> (hash-table-count files) 0)
+        (let ((scores (make-hash-table :test 'equal
+                                       :size (hash-table-count files)))
+              (now (projectile-time-seconds)))
+          (maphash (lambda (file entry)
+                     (puthash file (projectile--frecency-score entry now)
+                              scores))
+                   files)
+          (lambda (candidates)
+            (let (frecent rest)
+              (dolist (cand candidates)
+                (if (gethash cand scores)
+                    (push cand frecent)
+                  (push cand rest)))
+              (nconc (sort (nreverse frecent)
+                           (lambda (a b)
+                             (> (gethash a scores) (gethash b scores))))
+                     (nreverse rest)))))))))
+
+(defun projectile--frecency-merge-from-disk ()
+  "Merge newer on-disk frecency entries into the in-memory table.
+Another Emacs session may have saved since we loaded, so a plain
+overwrite would discard its data (the same reason
+`projectile-merge-known-projects' exists).  For each file present in
+both, the higher visit count and the later timestamp win."
+  (let ((disk-table (let ((projectile--frecency-table nil))
+                      (projectile--frecency-data)))
+        (table projectile--frecency-table))
+    (maphash
+     (lambda (root disk-files)
+       (let ((files (or (gethash root table)
+                        (puthash root (make-hash-table :test 'equal) table))))
+         (maphash
+          (lambda (file disk-entry)
+            (let ((entry (gethash file files)))
+              (puthash file
+                       (if entry
+                           (cons (max (car entry) (car disk-entry))
+                                 (max (cdr entry) (cdr disk-entry)))
+                         disk-entry)
+                       files)))
+          disk-files)))
+     disk-table)))
+
+(defun projectile--frecency-save ()
+  "Persist the frecency data to `projectile-frecency-file'.
+Merges with the data on disk first, so concurrent Emacs sessions
+don't wipe out each other's history.  The dirty flag is kept when
+the file isn't writable, so a later save can retry."
+  (when (and projectile--frecency-dirty projectile--frecency-table)
+    (if (not (file-writable-p projectile-frecency-file))
+        (display-warning
+         'projectile
+         (format "Frecency file '%s' is not writable" projectile-frecency-file)
+         :warning)
+      (projectile--frecency-merge-from-disk)
+      (let (data)
+        (maphash
+         (lambda (root files)
+           (projectile--frecency-prune files)
+           (when (> (hash-table-count files) 0)
+             (let (file-entries)
+               (maphash (lambda (file entry)
+                          (push (list file (car entry) (cdr entry))
+                                file-entries))
+                        files)
+               (push (cons root file-entries) data))))
+         projectile--frecency-table)
+        (projectile-serialize data projectile-frecency-file))
+      (setq projectile--frecency-dirty nil))))
+
 ;;;###autoload
 (defun projectile-discover-projects-in-directory (directory &optional depth)
   "Discover any projects in DIRECTORY and add them to the projectile cache.
@@ -3552,14 +3744,17 @@ Never use on many files since it's going to recalculate the
 project-root for every file."
   (expand-file-name name (projectile-project-root dir)))
 
-(cl-defun projectile-completing-read (prompt choices &key initial-input action caller)
+(cl-defun projectile-completing-read (prompt choices &key initial-input action caller sort-function)
   "Present a project tailored PROMPT with CHOICES.
 
 Reads with `completing-read', unless `projectile-completion-system' is a
 function, in which case that function is called with PROMPT and CHOICES.
 
 INITIAL-INPUT is passed to `completing-read'.  ACTION, when non-nil, is
-called on the selected candidate and its result returned.  CALLER is
+called on the selected candidate and its result returned.  SORT-FUNCTION,
+when non-nil, is exposed as the completion metadata's
+`display-sort-function' and `cycle-sort-function', so completion UIs
+that honor metadata present the candidates in that order.  CALLER is
 accepted for backward compatibility but no longer used."
   (ignore caller)
   (let* ((prompt (projectile-prepend-project-name prompt))
@@ -3572,7 +3767,10 @@ accepted for backward compatibility but no longer used."
                    ;; marginalia and embark enhance how candidates are
                    ;; presented.
                    (if (eq action 'metadata)
-                       '(metadata . ((category . project-file)))
+                       `(metadata (category . project-file)
+                                  ,@(when sort-function
+                                      `((display-sort-function . ,sort-function)
+                                        (cycle-sort-function . ,sort-function))))
                      (complete-with-action action choices string pred)))
                  nil nil initial-input))))
     (if action (funcall action res) res)))
@@ -3885,14 +4083,17 @@ Subroutine for `projectile-find-file-dwim' and
   (let* ((project-root (projectile-acquire-root))
          (project-files (projectile-project-files project-root))
          (files (projectile-select-files project-files invalidate-cache))
+         (sort-function (projectile--frecency-sort-function project-root))
          (file (cond ((= (length files) 1)
                       (car files))
                      ((length> files 1)
                       (projectile-completing-read "Switch to: " files
-                                                  :caller 'projectile-read-file))
+                                                  :caller 'projectile-read-file
+                                                  :sort-function sort-function))
                      (t
                       (projectile-completing-read "Switch to: " project-files
-                                                  :caller 'projectile-read-file))))
+                                                  :caller 'projectile-read-file
+                                                  :sort-function sort-function))))
          (ff (or ff-variant #'find-file)))
     (funcall ff (expand-file-name file project-root))
     (run-hooks 'projectile-find-file-hook)))
@@ -3996,7 +4197,9 @@ would be `find-file-other-window' or `find-file-other-frame'"
   (let* ((project-root (projectile-acquire-root))
          (file (projectile-completing-read "Find file: "
                                            (projectile-project-files project-root)
-                                           :caller 'projectile-read-file))
+                                           :caller 'projectile-read-file
+                                           :sort-function
+                                           (projectile--frecency-sort-function project-root)))
          (ff (or ff-variant #'find-file)))
     (when file
       (funcall ff (expand-file-name file project-root))
@@ -8652,6 +8855,7 @@ blanket guard was overly broad."
       (projectile-cache-files-find-file-hook project-root))
     (projectile-track-known-projects-find-file-hook project-root)
     (projectile--maybe-run-project-changed-functions project-root)
+    (projectile--frecency-record project-root)
     (unless remote
       (when projectile-dynamic-mode-line
         (projectile-update-mode-line)))))
@@ -8750,6 +8954,7 @@ Otherwise behave as if called interactively.
     (add-hook 'projectile-find-dir-hook #'projectile-track-known-projects-find-file-hook t)
     (add-hook 'dired-before-readin-hook #'projectile-track-known-projects-find-file-hook t)
     (add-hook 'dired-before-readin-hook #'projectile--maybe-run-project-changed-functions t)
+    (add-hook 'kill-emacs-hook #'projectile--frecency-save)
     (when projectile-dynamic-mode-line
       (add-hook 'window-configuration-change-hook #'projectile-update-mode-line-on-window-change))
     (advice-add 'compilation-find-file :around #'compilation-find-file-projectile-find-compilation-buffer)
@@ -8760,6 +8965,8 @@ Otherwise behave as if called interactively.
     (remove-hook 'projectile-find-dir-hook #'projectile-track-known-projects-find-file-hook)
     (remove-hook 'dired-before-readin-hook #'projectile-track-known-projects-find-file-hook)
     (remove-hook 'dired-before-readin-hook #'projectile--maybe-run-project-changed-functions)
+    (projectile--frecency-save)
+    (remove-hook 'kill-emacs-hook #'projectile--frecency-save)
     (remove-hook 'window-configuration-change-hook #'projectile-update-mode-line-on-window-change)
     (advice-remove 'compilation-find-file #'compilation-find-file-projectile-find-compilation-buffer)
     (advice-remove 'delete-file #'delete-file-projectile-remove-from-cache))))

--- a/test/projectile-frecency-test.el
+++ b/test/projectile-frecency-test.el
@@ -1,0 +1,217 @@
+;;; projectile-frecency-test.el --- Tests for the file frecency ranking -*- lexical-binding: t -*-
+
+;; Copyright © 2011-2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for the per-project file visit tracking and the frecency-based
+;; completion sorting.
+
+;;; Code:
+
+(require 'projectile-test-helpers)
+
+(defmacro projectile-test-with-frecency (&rest body)
+  "Run BODY with isolated, empty frecency state."
+  `(let ((projectile-enable-frecency t)
+         (projectile-frecency-max-files 200)
+         (projectile--frecency-table (make-hash-table :test 'equal))
+         (projectile--frecency-dirty nil)
+         (projectile-frecency-file
+          (expand-file-name (format "frecency-%d.eld" (random 100000))
+                            temporary-file-directory)))
+     (unwind-protect
+         (progn ,@body)
+       (when (file-exists-p projectile-frecency-file)
+         (delete-file projectile-frecency-file)))))
+
+(defun projectile-test--record-visit (root file &optional time)
+  "Record a visit to FILE under ROOT at TIME (defaults to now)."
+  (when time
+    (spy-on 'projectile-time-seconds :and-return-value time))
+  (with-temp-buffer
+    (setq buffer-file-name (expand-file-name file root))
+    (projectile--frecency-record root)))
+
+(describe "projectile--frecency-record"
+  (it "records visits with counts and timestamps"
+    (projectile-test-with-frecency
+     (projectile-test--record-visit "/proj/" "src/a.el" 1000)
+     (projectile-test--record-visit "/proj/" "src/a.el" 2000)
+     (let ((entry (gethash "src/a.el"
+                           (gethash "/proj/" projectile--frecency-table))))
+       (expect (car entry) :to-equal 2)
+       (expect (cdr entry) :to-equal 2000)
+       (expect projectile--frecency-dirty :to-be-truthy))))
+
+  (it "does nothing when frecency is disabled"
+    (projectile-test-with-frecency
+     (let ((projectile-enable-frecency nil))
+       (projectile-test--record-visit "/proj/" "a.el")
+       (expect (hash-table-count projectile--frecency-table) :to-equal 0))))
+
+  (it "does not track remote projects"
+    (projectile-test-with-frecency
+     (projectile-test--record-visit "/ssh:host:/proj/" "a.el")
+     (expect (hash-table-count projectile--frecency-table) :to-equal 0)))
+
+  (it "does not track files resolving outside the project"
+    (projectile-test-with-frecency
+     (with-temp-buffer
+       (setq buffer-file-name "/elsewhere/a.el")
+       (projectile--frecency-record "/proj/"))
+     (expect (gethash "/proj/" projectile--frecency-table) :to-be nil))))
+
+(describe "projectile--frecency-score"
+  (it "ranks a recent visit above an old one with the same count"
+    (let ((now 1000000))
+      (expect (projectile--frecency-score (cons 1 now) now)
+              :to-be-greater-than
+              (projectile--frecency-score (cons 1 (- now (* 14 86400))) now))))
+
+  (it "lets recency overtake a higher count eventually"
+    (let ((now 1000000))
+      ;; 10 visits four weeks ago decay to 2.5; 3 visits now stay 3.
+      (expect (projectile--frecency-score (cons 3 now) now)
+              :to-be-greater-than
+              (projectile--frecency-score (cons 10 (- now (* 28 86400))) now)))))
+
+(describe "projectile--frecency-sort-function"
+  (it "returns nil when nothing is tracked"
+    (projectile-test-with-frecency
+     (expect (projectile--frecency-sort-function "/proj/") :to-be nil)))
+
+  (it "returns nil when frecency is disabled"
+    (projectile-test-with-frecency
+     (projectile-test--record-visit "/proj/" "a.el")
+     (let ((projectile-enable-frecency nil))
+       (expect (projectile--frecency-sort-function "/proj/") :to-be nil))))
+
+  (it "puts tracked files first by score and preserves the rest"
+    (projectile-test-with-frecency
+     (projectile-test--record-visit "/proj/" "often.el" 1000)
+     (projectile-test--record-visit "/proj/" "often.el" 1000)
+     (projectile-test--record-visit "/proj/" "once.el" 1000)
+     (spy-on 'projectile-time-seconds :and-return-value 1000)
+     (let ((sorter (projectile--frecency-sort-function "/proj/")))
+       (expect (funcall sorter '("z.el" "once.el" "a.el" "often.el"))
+               :to-equal '("often.el" "once.el" "z.el" "a.el"))))))
+
+(describe "projectile--frecency-prune"
+  (it "drops the lowest scoring entries beyond the limit"
+    (projectile-test-with-frecency
+     (let ((projectile-frecency-max-files 2))
+       (projectile-test--record-visit "/proj/" "a.el" 1000)
+       (projectile-test--record-visit "/proj/" "a.el" 1000)
+       (projectile-test--record-visit "/proj/" "b.el" 1000)
+       (projectile-test--record-visit "/proj/" "b.el" 1000)
+       (projectile-test--record-visit "/proj/" "b.el" 1000)
+       (projectile-test--record-visit "/proj/" "old.el" 10)
+       (let ((files (gethash "/proj/" projectile--frecency-table)))
+         (projectile--frecency-prune files)
+         (expect (hash-table-count files) :to-equal 2)
+         (expect (gethash "old.el" files) :to-be nil))))))
+
+(describe "frecency persistence"
+  (it "round-trips the data through the frecency file"
+    (projectile-test-with-frecency
+     (projectile-test--record-visit "/proj/" "src/a.el" 1234)
+     (projectile--frecency-save)
+     (expect projectile--frecency-dirty :to-be nil)
+     ;; Force a reload from disk.
+     (setq projectile--frecency-table nil)
+     (let ((entry (gethash "src/a.el"
+                           (gethash "/proj/" (projectile--frecency-data)))))
+       (expect entry :to-equal '(1 . 1234)))))
+
+  (it "does not write when nothing changed"
+    (projectile-test-with-frecency
+     (projectile--frecency-save)
+     (expect (file-exists-p projectile-frecency-file) :to-be nil)))
+
+  (it "ignores a malformed frecency file instead of breaking recording"
+    ;; A corrupted cache file must never make `find-file' error - the
+    ;; load used to re-signal on every visit.
+    (projectile-test-with-frecency
+     (with-temp-file projectile-frecency-file (insert "hello world"))
+     (setq projectile--frecency-table nil)
+     (spy-on 'display-warning)
+     (expect (hash-table-count (projectile--frecency-data)) :to-equal 0)
+     (expect 'display-warning :to-have-been-called)
+     ;; Recording still works afterwards.
+     (projectile-test--record-visit "/proj/" "a.el" 1000)
+     (expect (gethash "a.el" (gethash "/proj/" projectile--frecency-table))
+             :to-equal '(1 . 1000))))
+
+  (it "caps the saved data at projectile-frecency-max-files per project"
+    (projectile-test-with-frecency
+     (let ((projectile-frecency-max-files 2))
+       (projectile-test--record-visit "/proj/" "a.el" 1000)
+       (projectile-test--record-visit "/proj/" "a.el" 1000)
+       (projectile-test--record-visit "/proj/" "b.el" 1000)
+       (projectile-test--record-visit "/proj/" "b.el" 1000)
+       (projectile-test--record-visit "/proj/" "c.el" 900)
+       (projectile--frecency-save)
+       (setq projectile--frecency-table nil)
+       (expect (hash-table-count
+                (gethash "/proj/" (projectile--frecency-data)))
+               :to-equal 2))))
+
+  (it "merges another session's newer data instead of overwriting it"
+    (projectile-test-with-frecency
+     ;; Another session saved while we were running: its file has an
+     ;; entry we don't have, plus different numbers for one we do.
+     (projectile-test--record-visit "/proj/" "mine.el" 1000)
+     (projectile-test--record-visit "/proj/" "shared.el" 1000)
+     (with-temp-file projectile-frecency-file
+       (insert (prin1-to-string
+                '(("/proj/" ("theirs.el" 3 2000) ("shared.el" 7 500))))))
+     (projectile--frecency-save)
+     (setq projectile--frecency-table nil)
+     (let ((files (gethash "/proj/" (projectile--frecency-data))))
+       (expect (gethash "mine.el" files) :to-equal '(1 . 1000))
+       (expect (gethash "theirs.el" files) :to-equal '(3 . 2000))
+       ;; max count, latest timestamp
+       (expect (gethash "shared.el" files) :to-equal '(7 . 1000))))))
+
+(describe "projectile-completing-read sort metadata"
+  (it "exposes the sort function via completion metadata"
+    (let (captured)
+      (spy-on 'completing-read :and-call-fake
+              (lambda (_prompt collection &rest _)
+                (setq captured (funcall collection "" nil 'metadata))
+                "x"))
+      (spy-on 'projectile-prepend-project-name :and-call-fake #'identity)
+      (let ((sorter #'identity))
+        (projectile-completing-read "Prompt: " '("x") :sort-function sorter)
+        (expect (alist-get 'display-sort-function (cdr captured)) :to-be sorter)
+        (expect (alist-get 'cycle-sort-function (cdr captured)) :to-be sorter)
+        (expect (alist-get 'category (cdr captured)) :to-equal 'project-file))))
+
+  (it "omits the sort metadata when no sort function is given"
+    (let (captured)
+      (spy-on 'completing-read :and-call-fake
+              (lambda (_prompt collection &rest _)
+                (setq captured (funcall collection "" nil 'metadata))
+                "x"))
+      (spy-on 'projectile-prepend-project-name :and-call-fake #'identity)
+      (projectile-completing-read "Prompt: " '("x"))
+      (expect (alist-get 'display-sort-function (cdr captured)) :to-be nil))))
+
+(provide 'projectile-frecency-test)
+;;; projectile-frecency-test.el ends here


### PR DESCRIPTION
`projectile-find-file` and `projectile-find-file-dwim` now put the files you actually work with first. Visits are recorded per project off the existing `find-file-hook` (remote projects are skipped so the hook stays free of TRAMP round-trips) and ranked by visit count with a two-week half-life decay; unvisited files keep their original order behind the ranked ones.

The ranking is applied through completion metadata (`display-sort-function`/`cycle-sort-function`) rather than by reordering the candidate list, so it works with any UI that honors metadata and under every indexing method, including `alien`, which `projectile-sort-order` never reached. History persists in `projectile-frecency-file`, capped per project by `projectile-frecency-max-files` (200). `projectile-enable-frecency` (default on) turns it all off.