### PR TITLE
Add projectile-session-mode for per-project tab-bar tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## master (unreleased)
 
+### New features
+
+* Add `projectile-session-mode`, a global minor mode that gives each project its own `tab-bar` tab.
+  * Switching to a project selects its existing tab (restoring that project's window layout) when one is open, or otherwise opens a fresh tab named after the project and populated via `projectile-session-default-action`.
+  * Same-named checkouts get distinct tab names (e.g. `work/foo` and `home/foo`); customize the scheme with `projectile-session-tab-name-function`.
+  * `projectile-session-switch-to-buffer` completes over just the current tab's project buffers.
+  * Persisting sessions to disk and restoring them across restarts is planned for a later release.
+
 ## 3.1.0 (2026-07-04)
 
 ### New features

--- a/Eldev
+++ b/Eldev
@@ -26,3 +26,11 @@
         `(:or ,eldev-standard-excludes
               "./projectile-consult.el"
               "./test/projectile-consult-test.el")))
+
+;; Eldev regenerates `projectile-pkg.el' from the package headers on every
+;; build.  Some CI images then byte-compile the leftover copy and, under
+;; `--warnings-as-errors', fail on its missing `lexical-binding' cookie (which
+;; a generated `define-package' file doesn't carry).  It's generated metadata,
+;; not project source, so keep it out of the build/lint filesets.
+(setf eldev-standard-excludes
+      `(:or ,eldev-standard-excludes "./projectile-pkg.el"))

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -768,6 +768,60 @@ want to set
 in order to allow for the occasions where you want to select the
 top-level directory.
 
+== Per-project sessions
+
+`projectile-session-mode` is a global minor mode that gives every project
+its own https://www.gnu.org/software/emacs/manual/html_node/emacs/Tab-Bars.html[tab-bar]
+tab, so each project keeps its own window layout and you flip between
+projects by flipping between tabs.
+
+[source,elisp]
+----
+(projectile-session-mode +1)
+----
+
+Enabling the mode turns on `tab-bar-mode` and makes project switching
+tab-aware:
+
+* Switching to a project that already has a tab *selects that tab*,
+  restoring the project's live window layout, rather than re-opening a
+  file and clobbering it.
+* Switching to a project for the first time opens a fresh tab dedicated
+  to it, names the tab after the project, and populates it by running
+  `projectile-session-default-action` (by default `projectile-find-file`).
+
+If you enable the mode while already visiting a project, the tab you're
+on is adopted for that project instead of being left unowned.
+
+Tabs are named after their project. Two checkouts that share a name
+(e.g. two `foo` directories) are disambiguated by prepending a
+parent-directory component, so you get `work/foo` and `home/foo`. You can
+override the naming entirely via `projectile-session-tab-name-function`,
+a function that receives a project root and returns the tab name.
+
+Disabling `projectile-session-mode` restores
+`projectile-switch-project-action` to whatever it was when you enabled
+the mode; it leaves `tab-bar-mode` and any existing tabs in place.
+
+=== Switching buffers within a session
+
+`projectile-session-switch-to-buffer` completes over just the buffers of
+the current tab's project (falling back to a plain `switch-to-buffer`
+when the current tab holds no project). It is deliberately kept as a
+separate, opt-in command rather than a global remapping of
+`switch-to-buffer`, so bind it yourself if you want it, e.g.:
+
+[source,elisp]
+----
+(define-key projectile-command-map (kbd "B") #'projectile-session-switch-to-buffer)
+----
+
+NOTE: This mode makes the aging
+https://github.com/bbatsov/persp-projectile[persp-projectile] unnecessary
+for tab-based project workflows. Persisting the tabs to disk and
+restoring them across Emacs restarts is not implemented yet, but is
+planned for a future release.
+
 == Known Projects
 
 Projectile stores the list of known projects in a file on disk.  You can

--- a/projectile.el
+++ b/projectile.el
@@ -10370,6 +10370,261 @@ Otherwise behave as if called interactively.
     (projectile--register-savehist-variables)
   (add-hook 'savehist-mode-hook #'projectile--register-savehist-variables))
 
+;;; Per-project sessions
+;;
+;; `projectile-session-mode' gives every project its own `tab-bar' tab.
+;; Each project tab is a native tab-bar tab, so it keeps its own window
+;; layout for free, and is bound to a project by stamping the project
+;; root onto a tab parameter (`projectile-root').  Switching to a project
+;; selects its existing tab (restoring that project's layout) when one is
+;; open, or otherwise opens a fresh, project-named tab and populates it.
+;;
+;; This milestone only deals with live, in-session tabs; persisting the
+;; tabs to disk and restoring them across restarts is planned for a
+;; follow-up, hence the deliberately storage-neutral naming.
+
+;; `tab-bar' is built in since Emacs 27.1, comfortably below Projectile's
+;; floor, so it's always available.
+(require 'tab-bar)
+
+(defcustom projectile-session-default-action 'projectile-find-file
+  "Action used to populate a project's freshly created tab.
+Called with no arguments by `projectile-session-switch-project-action'
+when a project is switched to for the first time (and thus gets a new
+tab).  Any command that takes no arguments will do."
+  :group 'projectile
+  :type 'function
+  :package-version '(projectile . "3.2.0"))
+
+(defcustom projectile-session-tab-name-function 'projectile-session-default-tab-name
+  "Function computing the tab name for a project.
+It is called with the project root and must return a string.  The
+default, `projectile-session-default-tab-name', names the tab after the
+project and disambiguates same-named projects with a parent-directory
+component."
+  :group 'projectile
+  :type 'function
+  :package-version '(projectile . "3.2.0"))
+
+(defvar projectile-session--saved-switch-action nil
+  "The `projectile-switch-project-action' saved when the mode was enabled.
+Restored when `projectile-session-mode' is disabled.")
+
+(defun projectile-session--current-tab ()
+  "Return the current tab of the selected frame."
+  (assq 'current-tab (tab-bar-tabs)))
+
+(defun projectile-session--tab-root (tab)
+  "Return the project root stamped on TAB, or nil when it holds no project."
+  (alist-get 'projectile-root (cdr tab)))
+
+(defun projectile-session--set-tab-root (tab root)
+  "Stamp TAB with project ROOT."
+  (setf (alist-get 'projectile-root (cdr tab)) root))
+
+(defun projectile-session--set-tab-name (tab name)
+  "Give TAB the explicit NAME.
+`explicit-name' is set so `tab-bar' doesn't overwrite NAME with its own
+automatic naming.  NAME is also recorded in the `projectile-auto-name'
+tab parameter so `projectile-session--refresh-tab-names' can tell a name
+Projectile assigned from one the user set with `tab-bar-rename-tab'."
+  (setf (alist-get 'name (cdr tab)) name)
+  (setf (alist-get 'explicit-name (cdr tab)) t)
+  (setf (alist-get 'projectile-auto-name (cdr tab)) name))
+
+(defun projectile-session--same-root-p (a b)
+  "Return non-nil when project roots A and B denote the same directory.
+Identical paths match directly.  Otherwise local paths are compared with
+`file-equal-p' (so symlinks and abbreviations still match); remote paths
+never reach `file-equal-p', so an unconnected host doesn't trigger a
+TRAMP round-trip."
+  (and a b
+       (let ((a (file-name-as-directory a))
+             (b (file-name-as-directory b)))
+         (or (string-equal a b)
+             (and (not (or (file-remote-p a) (file-remote-p b)))
+                  (file-equal-p a b))))))
+
+(defun projectile-session--project-tabs ()
+  "Return the open tabs that are bound to a project."
+  (seq-filter #'projectile-session--tab-root (tab-bar-tabs)))
+
+(defun projectile-session--project-tab (root)
+  "Return the open tab bound to project ROOT, or nil when there is none."
+  (seq-find (lambda (tab)
+              (projectile-session--same-root-p
+               (projectile-session--tab-root tab) root))
+            (tab-bar-tabs)))
+
+(defun projectile-session--project-name (root)
+  "Return the project name for ROOT.
+Unlike `projectile-project-name', the name is always derived from ROOT
+via `projectile-project-name-function', so it stays correct while the
+dynamic `projectile-project-name' is bound during a project switch."
+  (funcall projectile-project-name-function root))
+
+(defun projectile-session--parent-components (root)
+  "Return ROOT's ancestor directory names, nearest parent first."
+  (let ((components (split-string (directory-file-name (expand-file-name root))
+                                  "/" t)))
+    ;; drop ROOT's own final component; reverse so the nearest parent leads
+    (reverse (butlast components))))
+
+(defun projectile-session--name-with-parents (root name depth)
+  "Return NAME prefixed with ROOT's DEPTH nearest parent directories.
+With DEPTH 0 the plain NAME is returned; with DEPTH 1 the immediate
+parent is prepended (e.g. \"shared/foo\"), and so on, in path order."
+  (let ((prefix (reverse (seq-take (projectile-session--parent-components root)
+                                   depth))))
+    (if prefix
+        (concat (string-join prefix "/") "/" name)
+      name)))
+
+(defun projectile-session-default-tab-name (root)
+  "Return the tab name for the project rooted at ROOT.
+Use the project's name, prepending as many parent-directory components as
+it takes to stay distinct from every other open project tab that shares
+the name, so same-named checkouts (even ones whose immediate parent also
+matches) remain distinguishable."
+  (let* ((name (projectile-session--project-name root))
+         ;; roots of the other open project tabs that share this name;
+         ;; `delq'/`mapcar' rather than `seq-keep', which is Emacs 29.1+
+         (clashers (delq nil
+                         (mapcar
+                          (lambda (tab)
+                            (let ((other (projectile-session--tab-root tab)))
+                              (and (not (projectile-session--same-root-p other root))
+                                   (equal (projectile-session--project-name other) name)
+                                   other)))
+                          (projectile-session--project-tabs)))))
+    (if (null clashers)
+        name
+      (let ((max-depth (length (projectile-session--parent-components root)))
+            (depth 1))
+        (while (and (< depth max-depth)
+                    (let ((candidate (projectile-session--name-with-parents
+                                      root name depth)))
+                      (seq-some
+                       (lambda (other)
+                         (equal candidate (projectile-session--name-with-parents
+                                           other name depth)))
+                       clashers)))
+          (setq depth (1+ depth)))
+        (projectile-session--name-with-parents root name depth)))))
+
+(defun projectile-session--refresh-tab-names ()
+  "Recompute and apply names for every open project tab.
+Naming every project tab (not just the newest) lets same-named projects
+become disambiguated the moment a clash appears.  Tabs the user renamed
+by hand are left alone: a tab is only renamed while its current name
+still matches the one Projectile last assigned it (its `projectile-auto-name'
+parameter), which a manual `tab-bar-rename-tab' breaks."
+  (dolist (tab (projectile-session--project-tabs))
+    (let ((auto (alist-get 'projectile-auto-name (cdr tab)))
+          (current (alist-get 'name (cdr tab))))
+      (when (or (null auto) (equal auto current))
+        (projectile-session--set-tab-name
+         tab (funcall projectile-session-tab-name-function
+                      (projectile-session--tab-root tab))))))
+  (force-mode-line-update t))
+
+(defun projectile-session--make-project-tab (root)
+  "Create and select a fresh tab bound to project ROOT.
+The new tab is stamped with ROOT and named; populating it is left to the
+caller."
+  (tab-bar-new-tab)
+  (projectile-session--set-tab-root (projectile-session--current-tab) root)
+  (projectile-session--refresh-tab-names))
+
+(defun projectile-session--select-tab (tab)
+  "Select TAB, restoring the project layout it holds."
+  (when-let* ((index (cl-position tab (tab-bar-tabs) :test #'eq)))
+    (tab-bar-select-tab (1+ index))))
+
+(defun projectile-session--adopt-current-tab ()
+  "Bind the current tab to the current project, when there is one.
+Called on mode enable so the tab you're already sitting on is adopted
+rather than left unowned."
+  (when-let* ((root (projectile-project-root))
+              (tab (projectile-session--current-tab)))
+    (unless (projectile-session--tab-root tab)
+      (projectile-session--set-tab-root tab root)
+      (projectile-session--refresh-tab-names))))
+
+(defun projectile-session-switch-project-action ()
+  "Tab-aware switch action installed by `projectile-session-mode'.
+When the target project already has a tab, select it and restore its
+live window layout instead of re-running the switch action.  Otherwise
+create a new tab for the project, stamp and name it, and populate it by
+calling `projectile-session-default-action'."
+  (let* ((root (projectile-project-root))
+         (tab (and root (projectile-session--project-tab root))))
+    (cond
+     (tab (projectile-session--select-tab tab))
+     (root
+      (projectile-session--make-project-tab root)
+      ;; Bind `default-directory' so the populate action lists the new
+      ;; project regardless of what buffer `tab-bar-new-tab' left current
+      ;; (e.g. a non-default `tab-bar-new-tab-choice').
+      (let ((default-directory root))
+        (funcall projectile-session-default-action)))
+     (t (funcall projectile-session-default-action)))))
+
+;;;###autoload
+(defun projectile-session-switch-to-buffer ()
+  "Switch to a buffer belonging to the current tab's project.
+Complete over just the buffers of the project bound to the current tab.
+When the current tab holds no project, fall back to the plain
+`switch-to-buffer'."
+  (interactive)
+  (let ((root (projectile-session--tab-root (projectile-session--current-tab))))
+    (if root
+        (switch-to-buffer
+         (projectile-completing-read
+          "Switch to project buffer: "
+          (mapcar #'buffer-name (projectile-project-buffers root))))
+      (call-interactively #'switch-to-buffer))))
+
+;;;###autoload
+(define-minor-mode projectile-session-mode
+  "Global minor mode giving each project its own `tab-bar' tab.
+
+When enabled, `tab-bar-mode' is turned on and project switching becomes
+tab-aware: switching to a project selects its existing tab, restoring
+that project's live window layout, when one is open; otherwise it opens
+a fresh tab dedicated to the project and populates it via
+`projectile-session-default-action'.  Each project tab is stamped with
+its root and named after the project (see
+`projectile-session-tab-name-function').
+
+If the mode is enabled from inside a project, the tab you're already on
+is adopted so it isn't left unowned.
+
+Disabling the mode restores `projectile-switch-project-action' to the
+value it had when the mode was enabled; it leaves `tab-bar-mode' and any
+existing tabs untouched."
+  :group 'projectile
+  :global t
+  :require 'projectile
+  (cond
+   (projectile-session-mode
+    (unless (bound-and-true-p tab-bar-mode)
+      (tab-bar-mode 1))
+    ;; Guard the save so re-enabling an already-on mode (config re-eval, a
+    ;; startup hook, `custom-set' plus code) can't capture our own action as
+    ;; the "saved" value and lose the user's real one on the next disable.
+    (unless (eq projectile-switch-project-action
+                #'projectile-session-switch-project-action)
+      (setq projectile-session--saved-switch-action projectile-switch-project-action))
+    (setq projectile-switch-project-action #'projectile-session-switch-project-action)
+    (projectile-session--adopt-current-tab))
+   (t
+    (when (eq projectile-switch-project-action
+              #'projectile-session-switch-project-action)
+      (setq projectile-switch-project-action
+            projectile-session--saved-switch-action))
+    (setq projectile-session--saved-switch-action nil))))
+
 (provide 'projectile)
 
 ;;; projectile.el ends here

--- a/test/projectile-session-test.el
+++ b/test/projectile-session-test.el
@@ -1,0 +1,227 @@
+;;; projectile-session-test.el --- Tests for per-project session tabs -*- lexical-binding: t -*-
+
+;; Copyright © 2011-2026 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for `projectile-session-mode' and its tab-per-project behavior.
+
+;;; Code:
+
+(require 'projectile-test-helpers)
+(require 'tab-bar)
+
+(defun projectile-session-test--reset-tabs ()
+  "Reset the selected frame to a single, unowned tab."
+  (set-frame-parameter nil 'tabs nil)
+  ;; Recreate a fresh single current-tab.
+  (tab-bar-tabs))
+
+(defun projectile-session-test--populate ()
+  "Stand-in populate action; spied on in tests."
+  nil)
+
+(defun projectile-session-test--tab-names ()
+  "Return the names of all open tabs on the selected frame."
+  (mapcar (lambda (tab) (alist-get 'name (cdr tab))) (tab-bar-tabs)))
+
+(describe "projectile-session-mode"
+  (before-each
+    (projectile-session-test--reset-tabs))
+
+  (after-each
+    (when projectile-session-mode
+      (projectile-session-mode -1))
+    (projectile-session-test--reset-tabs))
+
+  (describe "wiring"
+    (it "installs and restores the switch-project action"
+      (let ((projectile-switch-project-action 'projectile-find-file))
+        (spy-on 'projectile-project-root :and-return-value nil)
+        (projectile-session-mode 1)
+        (expect projectile-switch-project-action
+                :to-equal #'projectile-session-switch-project-action)
+        (projectile-session-mode -1)
+        (expect projectile-switch-project-action :to-equal 'projectile-find-file)
+        (expect projectile-session--saved-switch-action :to-be nil)))
+
+    (it "leaves a user-changed action alone on disable"
+      (let ((projectile-switch-project-action 'projectile-find-file))
+        (spy-on 'projectile-project-root :and-return-value nil)
+        (projectile-session-mode 1)
+        ;; the user rebinds the action while the mode is on
+        (setq projectile-switch-project-action 'projectile-dired)
+        (projectile-session-mode -1)
+        (expect projectile-switch-project-action :to-equal 'projectile-dired)))
+
+    (it "does not lose the saved action when re-enabled while already on"
+      (let ((projectile-switch-project-action 'projectile-find-file))
+        (spy-on 'projectile-project-root :and-return-value nil)
+        (projectile-session-mode 1)
+        ;; a second enable must not capture our own action as the saved value
+        (projectile-session-mode 1)
+        (projectile-session-mode -1)
+        (expect projectile-switch-project-action :to-equal 'projectile-find-file))))
+
+  (describe "adoption on enable"
+    (it "stamps the current tab with the current project"
+      (let ((projectile-switch-project-action 'projectile-find-file))
+        (spy-on 'projectile-project-root :and-return-value "/x/proj/")
+        (projectile-session-mode 1)
+        (let ((tab (projectile-session--current-tab)))
+          (expect (projectile-session--tab-root tab) :to-equal "/x/proj/")
+          (expect (alist-get 'name (cdr tab)) :to-equal "proj"))))
+
+    (it "does nothing when not inside a project"
+      (let ((projectile-switch-project-action 'projectile-find-file))
+        (spy-on 'projectile-project-root :and-return-value nil)
+        (projectile-session-mode 1)
+        (expect (projectile-session--tab-root (projectile-session--current-tab))
+                :to-be nil)))))
+
+(describe "projectile-session-switch-project-action"
+  (before-each
+    (projectile-session-test--reset-tabs))
+
+  (after-each
+    (projectile-session-test--reset-tabs))
+
+  (it "creates and populates a new tab on first switch"
+    (let ((projectile-session-default-action 'projectile-session-test--populate))
+      (spy-on 'projectile-session-test--populate)
+      (spy-on 'projectile-project-root :and-return-value "/one/foo/")
+      (projectile-session-switch-project-action)
+      (expect (length (projectile-session--project-tabs)) :to-equal 1)
+      (expect (projectile-session--tab-root (projectile-session--current-tab))
+              :to-equal "/one/foo/")
+      (expect 'projectile-session-test--populate :to-have-been-called)))
+
+  (it "selects the existing tab instead of re-populating on a repeat switch"
+    (let ((projectile-session-default-action 'projectile-session-test--populate)
+          (current-root nil))
+      (spy-on 'projectile-session-test--populate)
+      (spy-on 'projectile-project-root
+              :and-call-fake (lambda (&optional _dir) current-root))
+      ;; open foo, then bar; now the current tab is bar's
+      (setq current-root "/one/foo/")
+      (projectile-session-switch-project-action)
+      (setq current-root "/two/bar/")
+      (projectile-session-switch-project-action)
+      (expect (projectile-session--tab-root (projectile-session--current-tab))
+              :to-equal "/two/bar/")
+      ;; switching back to foo must select its tab, not create/populate again
+      (spy-calls-reset 'projectile-session-test--populate)
+      (setq current-root "/one/foo/")
+      (projectile-session-switch-project-action)
+      (expect (projectile-session--tab-root (projectile-session--current-tab))
+              :to-equal "/one/foo/")
+      (expect 'projectile-session-test--populate :not :to-have-been-called)
+      (expect (length (projectile-session--project-tabs)) :to-equal 2)))
+
+  (it "binds default-directory to the project root while populating"
+    (let ((projectile-session-default-action 'projectile-session-test--populate)
+          (seen-dir nil))
+      (spy-on 'projectile-session-test--populate
+              :and-call-fake (lambda () (setq seen-dir default-directory)))
+      (spy-on 'projectile-project-root :and-return-value "/one/foo/")
+      (projectile-session-switch-project-action)
+      (expect seen-dir :to-equal "/one/foo/"))))
+
+(describe "projectile-session tab naming"
+  (before-each
+    (projectile-session-test--reset-tabs))
+
+  (after-each
+    (projectile-session-test--reset-tabs))
+
+  (it "names a lone project tab after the project"
+    (projectile-session--make-project-tab "/solo/bar/")
+    (expect (projectile-session--tab-root (projectile-session--current-tab))
+            :to-equal "/solo/bar/")
+    (expect (alist-get 'name (cdr (projectile-session--current-tab)))
+            :to-equal "bar"))
+
+  (it "disambiguates same-named projects with a parent component"
+    (projectile-session--make-project-tab "/work/foo/")
+    (projectile-session--make-project-tab "/home/foo/")
+    (let ((names (projectile-session-test--tab-names)))
+      (expect names :to-contain "work/foo")
+      (expect names :to-contain "home/foo")))
+
+  (it "adds a second parent component when the first also clashes"
+    (projectile-session--make-project-tab "/p/shared/foo/")
+    (projectile-session--make-project-tab "/q/shared/foo/")
+    (let ((names (projectile-session-test--tab-names)))
+      (expect names :to-contain "p/shared/foo")
+      (expect names :to-contain "q/shared/foo")))
+
+  (it "leaves a hand-renamed tab alone when refreshing names"
+    (projectile-session--make-project-tab "/work/foo/")
+    ;; the user renames the tab by hand (only the name, not the auto-name param)
+    (setf (alist-get 'name (cdr (projectile-session--current-tab))) "MyWork")
+    ;; opening another same-named project refreshes names, but must skip the
+    ;; hand-renamed tab
+    (projectile-session--make-project-tab "/home/foo/")
+    (let ((names (projectile-session-test--tab-names)))
+      (expect names :to-contain "MyWork")
+      (expect names :not :to-contain "work/foo")))
+
+  (it "honors a custom tab-name function"
+    (let ((projectile-session-tab-name-function
+           (lambda (root) (concat "P:" (directory-file-name root)))))
+      (projectile-session--make-project-tab "/some/thing/")
+      (expect (alist-get 'name (cdr (projectile-session--current-tab)))
+              :to-equal "P:/some/thing"))))
+
+(describe "projectile-session-switch-to-buffer"
+  (before-each
+    (projectile-session-test--reset-tabs))
+
+  (after-each
+    (projectile-session-test--reset-tabs))
+
+  (it "completes over just the current tab's project buffers"
+    (let ((buf-a (get-buffer-create "session-a"))
+          (buf-b (get-buffer-create "session-b")))
+      (unwind-protect
+          (progn
+            (projectile-session--set-tab-root
+             (projectile-session--current-tab) "/proj/")
+            (spy-on 'projectile-project-buffers
+                    :and-return-value (list buf-a buf-b))
+            (spy-on 'projectile-completing-read
+                    :and-call-fake (lambda (_prompt choices &rest _) (car choices)))
+            (spy-on 'switch-to-buffer)
+            (projectile-session-switch-to-buffer)
+            (expect 'projectile-project-buffers :to-have-been-called-with "/proj/")
+            (expect 'switch-to-buffer :to-have-been-called-with "session-a"))
+        (kill-buffer buf-a)
+        (kill-buffer buf-b))))
+
+  (it "falls back to plain switch-to-buffer with no project tab"
+    (spy-on 'projectile-project-buffers)
+    (spy-on 'call-interactively)
+    (projectile-session-switch-to-buffer)
+    (expect 'projectile-project-buffers :not :to-have-been-called)
+    (expect 'call-interactively :to-have-been-called-with #'switch-to-buffer)))
+
+(provide 'projectile-session-test)
+
+;;; projectile-session-test.el ends here


### PR DESCRIPTION
`projectile-session-mode` is a global minor mode that gives each project its own `tab-bar` tab. Switching to a project selects its existing tab and restores that project's live window layout instead of clobbering it by re-running the switch action; a project without a tab yet gets a fresh one, named after the project and populated via `projectile-session-default-action` (default `projectile-find-file`). Same-named checkouts get disambiguated names (`work/foo` vs `home/foo`, overridable via `projectile-session-tab-name-function`), and tabs you rename by hand are left alone. Built on the built-in tab-bar, so no new dependencies and it works at our Emacs 28.1 floor.

`projectile-session-switch-to-buffer` completes over just the current tab's project buffers - opt-in, it does not remap `switch-to-buffer` globally. Commands are autoloaded but unbound by default. This obsoletes `persp-projectile` for tab-based workflows. Cross-restart persistence (layout and buffers to disk) is the next milestone and will land separately.