### PR TITLE
Persist project sessions across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
   * Switching to a project selects its existing tab (restoring that project's window layout) when one is open, or otherwise opens a fresh tab named after the project and populated via `projectile-session-default-action`.
   * Same-named checkouts get distinct tab names (e.g. `work/foo` and `home/foo`); customize the scheme with `projectile-session-tab-name-function`.
   * `projectile-session-switch-to-buffer` completes over just the current tab's project buffers.
-  * Persisting sessions to disk and restoring them across restarts is planned for a later release.
+  * Sessions persist across Emacs restarts: `projectile-session-save`, `projectile-session-restore` and `projectile-session-forget` write a project's window layout and buffers to a file under `projectile-session-directory` and read it back.
+  * Switching to a project with a saved session restores it (gated by `projectile-session-restore-on-switch`); `projectile-session-autosave` saves sessions on switch-away and on exit.
+  * Which buffers are recorded, and how, is extensible via `projectile-session-buffer-serializers`; file-visiting and `dired-mode` buffers work out of the box.
 
 ## 3.1.0 (2026-07-04)
 

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -818,9 +818,77 @@ separate, opt-in command rather than a global remapping of
 
 NOTE: This mode makes the aging
 https://github.com/bbatsov/persp-projectile[persp-projectile] unnecessary
-for tab-based project workflows. Persisting the tabs to disk and
-restoring them across Emacs restarts is not implemented yet, but is
-planned for a future release.
+for tab-based project workflows.
+
+=== Persisting sessions across restarts
+
+A project's tab keeps its layout only while Emacs is running. You can also
+persist a project's session (its window layout plus the buffers it shows)
+to disk and restore it in a later Emacs:
+
+* `projectile-session-save` writes the current frame's layout and buffers
+  as the current project's session. Since it reads the live frame, it saves
+  whichever project's tab is selected.
+* `projectile-session-restore` recreates that project's buffers and puts
+  the saved layout back.
+* `projectile-session-forget` deletes a project's saved session file.
+
+Sessions are stored one file per project under
+`projectile-session-directory` (by default a `projectile-sessions/`
+directory under `user-emacs-directory`). Each file is named after the
+project and keyed by a hash of its root, so distinct roots never collide
+and the same root maps to the same file across restarts.
+
+With `projectile-session-restore-on-switch` (on by default), switching to a
+project that has no open tab but does have a saved session restores that
+session instead of running `projectile-session-default-action`.
+
+Set `projectile-session-autosave` to save automatically: the outgoing
+project's session is saved when you switch away from it, and every open
+project's session is saved when Emacs exits. Layouts with no serializable
+buffer are skipped.
+
+[source,elisp]
+----
+(setq projectile-session-autosave t)
+----
+
+==== Registering buffer serializers
+
+Which buffers a session records, and how, is controlled by
+`projectile-session-buffer-serializers`, an alist mapping a key to a
+`(serialize . deserialize)` pair. The key is a major-mode symbol, the
+symbol `t` (any file-visiting buffer), or a predicate function of one
+argument (the buffer). `serialize` runs with the buffer current and
+returns a `read`-able record (or nil to decline it); `deserialize` takes
+such a record and recreates the live buffer (or returns nil when it
+can't, e.g. the file is gone).
+
+Out of the box, ordinary file-visiting buffers (recording the file and
+point) and `dired-mode` buffers (recording the directory) round-trip.
+Buffers no serializer handles are simply skipped. To persist other kinds
+of buffers, e.g. Magit or eshell, add a handler keyed by their major mode:
+
+[source,elisp]
+----
+(defun my-eshell-serialize (_buffer)
+  (list :dir default-directory))
+
+(defun my-eshell-deserialize (record)
+  (let ((default-directory (plist-get record :dir)))
+    (save-window-excursion (eshell t))))
+
+(add-to-list 'projectile-session-buffer-serializers
+             '(eshell-mode . (my-eshell-serialize . my-eshell-deserialize)))
+----
+
+Handlers keyed by a major-mode symbol or by `t` round-trip fully; restore
+dispatches on that key.
+
+NOTE: On restore, a window whose buffer can't be recreated (its file was
+deleted, say) falls back to a placeholder buffer so the restore never
+errors. This is handled explicitly to keep working on Projectile's Emacs
+28.1 floor, which predates Emacs 30's `window-restore-killed-buffer-windows`.
 
 == Known Projects
 

--- a/projectile.el
+++ b/projectile.el
@@ -10406,9 +10406,85 @@ component."
   :type 'function
   :package-version '(projectile . "3.2.0"))
 
+(defcustom projectile-session-directory
+  (expand-file-name "projectile-sessions/" user-emacs-directory)
+  "Directory under which per-project session files are stored.
+Each project's saved layout and buffers live in a single file here, named
+after the project (see `projectile-session--file')."
+  :group 'projectile
+  :type 'directory
+  :package-version '(projectile . "3.2.0"))
+
+(defcustom projectile-session-restore-on-switch t
+  "Whether switching to a project restores its saved session.
+When non-nil and the project being switched to has no open tab but does
+have a session saved on disk, `projectile-session-switch-project-action'
+restores that session (recreating its buffers and layout) instead of
+running `projectile-session-default-action'."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "3.2.0"))
+
+(defcustom projectile-session-autosave nil
+  "Whether `projectile-session-mode' saves sessions automatically.
+When non-nil, the outgoing project's session is saved when you switch
+away from it, and every open project's session is saved when Emacs exits.
+Degenerate layouts with no serializable buffer are skipped."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "3.2.0"))
+
+(defcustom projectile-session-buffer-serializers
+  '((dired-mode
+     . (projectile-session--serialize-dired
+        . projectile-session--deserialize-dired))
+    (t
+     . (projectile-session--serialize-file
+        . projectile-session--deserialize-file)))
+  "How buffers are turned into readable records and back.
+
+An alist whose entries have the shape (KEY SERIALIZE . DESERIALIZE),
+i.e. KEY mapped to a (SERIALIZE . DESERIALIZE) pair:
+
+KEY selects which buffers an entry handles.  It is one of:
+- a major-mode symbol - matches buffers whose mode is (derived from) it;
+- the symbol t - matches any buffer visiting a file (keep it last, so
+  mode-specific handlers win);
+- a predicate function of one argument (the buffer).
+
+SERIALIZE is called with the buffer current and returns a readable record
+\(any `read'-able sexp), or nil to decline the buffer.  DESERIALIZE is
+called with such a record and must recreate and return the live buffer,
+or nil when it cannot (e.g. the file is gone), in which case the buffer's
+window is dropped on restore rather than erroring.
+
+The first entry whose KEY matches and whose SERIALIZE returns non-nil wins.
+Buffers no entry handles are skipped, not saved.
+
+Handlers keyed by a major-mode symbol or by t round-trip cleanly: restore
+dispatches on that key.  A record produced by a predicate-keyed handler is
+stored under the buffer's major mode and, on restore, is handled by the
+first predicate-keyed entry that has a DESERIALIZE; so if you register
+several predicate handlers, give them distinct major-mode keys instead when
+they must restore differently.  To persist e.g. Magit or eshell buffers,
+add an entry keyed by their major mode, for instance:
+
+  (add-to-list \\='projectile-session-buffer-serializers
+               \\='(magit-status-mode
+                 . (my-serialize-magit . my-deserialize-magit)))"
+  :group 'projectile
+  :type '(alist :key-type sexp :value-type sexp)
+  :package-version '(projectile . "3.2.0"))
+
+(defconst projectile-session--format-version 1
+  "Format version stamped into session files written on disk.
+Session files whose version does not match are ignored on restore.")
+
 (defvar projectile-session--saved-switch-action nil
   "The `projectile-switch-project-action' saved when the mode was enabled.
 Restored when `projectile-session-mode' is disabled.")
+
+(declare-function dired-noselect "dired")
 
 (defun projectile-session--current-tab ()
   "Return the current tab of the selected frame."
@@ -10555,8 +10631,9 @@ rather than left unowned."
   "Tab-aware switch action installed by `projectile-session-mode'.
 When the target project already has a tab, select it and restore its
 live window layout instead of re-running the switch action.  Otherwise
-create a new tab for the project, stamp and name it, and populate it by
-calling `projectile-session-default-action'."
+create a new tab for the project and either restore its saved session (see
+`projectile-session-restore-on-switch') or populate it by calling
+`projectile-session-default-action'."
   (let* ((root (projectile-project-root))
          (tab (and root (projectile-session--project-tab root))))
     (cond
@@ -10567,7 +10644,10 @@ calling `projectile-session-default-action'."
       ;; project regardless of what buffer `tab-bar-new-tab' left current
       ;; (e.g. a non-default `tab-bar-new-tab-choice').
       (let ((default-directory root))
-        (funcall projectile-session-default-action)))
+        (unless (and projectile-session-restore-on-switch
+                     (projectile-session--saved-p root)
+                     (projectile-session-restore root))
+          (funcall projectile-session-default-action))))
      (t (funcall projectile-session-default-action)))))
 
 ;;;###autoload
@@ -10584,6 +10664,290 @@ When the current tab holds no project, fall back to the plain
           "Switch to project buffer: "
           (mapcar #'buffer-name (projectile-project-buffers root))))
       (call-interactively #'switch-to-buffer))))
+
+;;; Session persistence
+;;
+;; A project's live layout is a native tab, but tabs don't survive an Emacs
+;; restart.  To persist one we write a small readable sexp per project: the
+;; window layout as `window-state-get' with the WRITABLE flag (so it stays a
+;; plain, re-readable sexp) plus a manifest of the buffers it shows, each
+;; turned into a record by `projectile-session-buffer-serializers'.  Restoring
+;; recreates the buffers first (window-state only references them by name and
+;; won't recreate them) and then puts the layout back, replacing any buffer it
+;; couldn't recreate with a placeholder so the restore never errors.
+
+(defun projectile-session--buffer-matches-p (key buffer)
+  "Return non-nil when serializer KEY applies to BUFFER.
+KEY is a major-mode symbol, the symbol t (any file-visiting buffer), or a
+predicate function of one argument."
+  (cond
+   ((eq key t) (and (buffer-file-name buffer) t))
+   ((symbolp key) (with-current-buffer buffer (derived-mode-p key)))
+   (t (funcall key buffer))))
+
+(defun projectile-session--buffer-kind (key buffer)
+  "Return the symbol under which BUFFER's record is stored for serializer KEY.
+A symbol KEY (a mode or t) is its own kind and restore dispatches on it; a
+predicate KEY falls back to BUFFER's major mode."
+  (if (symbolp key)
+      key
+    (buffer-local-value 'major-mode buffer)))
+
+(defun projectile-session--readable-p (object)
+  "Return non-nil when OBJECT survives a `prin1'/`read' round-trip.
+Guards against a custom serializer returning a record that embeds a live
+object (buffer, marker, window) which can't be read back.  Binds
+`print-circle' so shared or circular structure prints, and reads, finitely
+rather than hanging."
+  (ignore-errors
+    (let ((print-circle t))
+      (read (prin1-to-string object))
+      t)))
+
+(defun projectile-session--serialize-buffer (buffer)
+  "Serialize BUFFER via the first matching entry of the serializer registry.
+Return a cons (KIND . RECORD), or nil when no entry handles BUFFER.
+Each registry entry is tried in isolation: a matcher or serializer that
+errors, or that yields a non-readable record, is skipped rather than
+aborting the whole session save."
+  (catch 'done
+    (dolist (entry projectile-session-buffer-serializers)
+      (ignore-errors
+        (let ((key (car entry))
+              (serialize (cadr entry)))
+          (when (projectile-session--buffer-matches-p key buffer)
+            (let ((record (with-current-buffer buffer (funcall serialize buffer))))
+              (when (and record (projectile-session--readable-p record))
+                (throw 'done
+                       (cons (projectile-session--buffer-kind key buffer)
+                             record))))))))
+    nil))
+
+(defun projectile-session--deserializer (kind)
+  "Return the deserialize function able to restore a record of KIND.
+Prefer an entry whose key is exactly KIND (a mode symbol or t).  Records
+produced by a predicate-keyed serializer are stored under the buffer's
+major mode, which no `assq' can match, so fall back to the first
+predicate-keyed entry that carries a deserializer."
+  (let ((exact (assq kind projectile-session-buffer-serializers)))
+    (if exact
+        (cddr exact)
+      (catch 'found
+        (dolist (entry projectile-session-buffer-serializers)
+          (when (and (functionp (car entry)) (cddr entry))
+            (throw 'found (cddr entry))))
+        nil))))
+
+(defun projectile-session--recreate-buffer (saved)
+  "Recreate the buffer described by SAVED, a (KIND . RECORD) cons.
+Return the live buffer, or nil when no deserializer handles KIND or the
+deserializer declines (e.g. the underlying file is gone)."
+  (let ((deserialize (projectile-session--deserializer (car saved))))
+    (when deserialize
+      (funcall deserialize (cdr saved)))))
+
+(defun projectile-session--serialize-file (buffer)
+  "Serialize file-visiting BUFFER as a (:file PATH :point N) record."
+  (when (buffer-file-name buffer)
+    (list :file (buffer-file-name buffer) :point (point))))
+
+(defun projectile-session--deserialize-file (record)
+  "Recreate the file buffer described by RECORD, or nil when the file is gone."
+  (let ((file (plist-get record :file)))
+    (when (and file (file-exists-p file))
+      (let ((buffer (find-file-noselect file)))
+        (when (buffer-live-p buffer)
+          (let ((point (plist-get record :point)))
+            (when (integerp point)
+              (with-current-buffer buffer
+                (goto-char (min point (point-max))))))
+          buffer)))))
+
+(defun projectile-session--serialize-dired (buffer)
+  "Serialize dired BUFFER as a (:dir DIRECTORY) record."
+  (with-current-buffer buffer
+    (when (derived-mode-p 'dired-mode)
+      (list :dir (expand-file-name default-directory)))))
+
+(defun projectile-session--deserialize-dired (record)
+  "Recreate the dired buffer described by RECORD, or nil when it's gone."
+  (let ((dir (plist-get record :dir)))
+    (when (and dir (file-directory-p dir))
+      (dired-noselect dir))))
+
+(defun projectile-session--placeholder-buffer ()
+  "Return a live placeholder buffer for windows whose buffer is missing."
+  (get-buffer-create " *projectile-session-placeholder*"))
+
+(defun projectile-session--sanitize-window-state (state)
+  "Return a copy of window STATE with missing buffers replaced.
+Any window referencing a buffer that isn't live is pointed at a
+placeholder buffer instead, so `window-state-put' can't error out.  This
+is the Emacs 28 substitute for `window-restore-killed-buffer-windows'
+\(added in Emacs 30)."
+  (cond
+   ((and (consp state)
+         (eq (car state) 'buffer)
+         (stringp (cadr state))
+         (not (get-buffer (cadr state))))
+    (cons 'buffer
+          (cons (buffer-name (projectile-session--placeholder-buffer))
+                (cddr state))))
+   ((consp state)
+    (cons (projectile-session--sanitize-window-state (car state))
+          (projectile-session--sanitize-window-state (cdr state))))
+   (t state)))
+
+(defun projectile-session--file (root)
+  "Return the absolute session file name for project ROOT.
+The name pairs a readable, filesystem-safe project name with a hash of
+ROOT's canonical path, so distinct roots never collide and the same root
+maps to the same file across restarts."
+  (let* ((canonical (directory-file-name
+                     ;; Canonicalize with `file-truename' so a symlinked root
+                     ;; and its target map to the same file, matching M1's
+                     ;; `projectile-session--same-root-p'.  Skip it for remote
+                     ;; roots to avoid a TRAMP round-trip.
+                     (if (file-remote-p root)
+                         (expand-file-name root)
+                       (file-truename root))))
+         (name (projectile-session--project-name root))
+         (safe (replace-regexp-in-string "[^A-Za-z0-9_.-]" "_" (or name "project")))
+         (hash (md5 canonical)))
+    (expand-file-name (concat safe "-" hash ".eld")
+                      projectile-session-directory)))
+
+(defun projectile-session--saved-p (root)
+  "Return non-nil when project ROOT has a session saved on disk."
+  (file-exists-p (projectile-session--file root)))
+
+(defun projectile-session--write (root data)
+  "Write session DATA for project ROOT, creating the session directory.
+Return non-nil only when the file was actually written, so callers don't
+report success for an unwritable session directory.  Binds `print-circle'
+so shared or circular structure in a record can't hang the write."
+  (let ((file (projectile-session--file root)))
+    (ignore-errors (make-directory (file-name-directory file) t))
+    (and (file-writable-p file)
+         (progn
+           (let ((print-circle t))
+             (projectile-serialize data file))
+           (file-exists-p file)))))
+
+(defun projectile-session--read (root)
+  "Read and return project ROOT's session data, or nil.
+Data whose format version doesn't match is ignored."
+  (let ((data (projectile-unserialize (projectile-session--file root))))
+    (and (consp data)
+         (equal (plist-get data :projectile-session-version)
+                projectile-session--format-version)
+         data)))
+
+(defun projectile-session--frame-buffers ()
+  "Return the distinct buffers shown in the selected frame's windows."
+  (delete-dups (mapcar #'window-buffer (window-list nil 'nomini))))
+
+;;;###autoload
+(defun projectile-session-save (&optional project)
+  "Save the current window layout and buffers as PROJECT's session.
+PROJECT defaults to the current project's root.  The layout is captured
+from the selected frame, so this saves whichever project's tab is
+current.  Buffers are recorded via `projectile-session-buffer-serializers';
+a layout with no serializable buffer is not saved.  Return non-nil on a
+successful save."
+  (interactive)
+  (let ((root (or project (projectile-project-root))))
+    (unless root
+      (user-error "Not in a project"))
+    (let* ((buffers (projectile-session--frame-buffers))
+           (records (delq nil (mapcar #'projectile-session--serialize-buffer
+                                      buffers))))
+      (cond
+       ((null records)
+        (when (called-interactively-p 'any)
+          (message "No serializable buffers to save for %s" root))
+        nil)
+       ((projectile-session--write
+         root
+         (list :projectile-session-version projectile-session--format-version
+               :root root
+               :buffers records
+               :window-state (window-state-get (frame-root-window) t)))
+        (when (called-interactively-p 'any)
+          (message "Saved session for %s" root))
+        t)
+       (t
+        (when (called-interactively-p 'any)
+          (message "Could not write session for %s" root))
+        nil)))))
+
+;;;###autoload
+(defun projectile-session-restore (&optional project)
+  "Restore PROJECT's saved session into the selected frame.
+PROJECT defaults to the current project's root.  Buffers are recreated
+first, then the saved window layout is put back; windows whose buffer
+can't be recreated fall back to a placeholder.  Return non-nil when a
+session was restored."
+  (interactive)
+  (let* ((root (or project (projectile-project-root)))
+         (data (and root (projectile-session--read root))))
+    (cond
+     (data
+      (let ((recreated nil))
+        (dolist (saved (plist-get data :buffers))
+          (when (ignore-errors (buffer-live-p (projectile-session--recreate-buffer saved)))
+            (setq recreated t)))
+        (cond
+         (recreated
+          (let ((state (plist-get data :window-state)))
+            (when state
+              (window-state-put (projectile-session--sanitize-window-state state)
+                                (frame-root-window) 'safe)))
+          t)
+         ;; Nothing could be recreated (every saved file is gone, say);
+         ;; return nil so `restore-on-switch' falls back to populating the
+         ;; tab instead of leaving the user in an all-placeholder frame.
+         (t
+          (when (called-interactively-p 'any)
+            (message "No buffers could be restored for %s" (or root "current project")))
+          nil))))
+     ((called-interactively-p 'any)
+      (user-error "No saved session for %s" (or root "current project"))))))
+
+;;;###autoload
+(defun projectile-session-forget (&optional project)
+  "Delete PROJECT's saved session file.
+PROJECT defaults to the current project's root."
+  (interactive)
+  (let ((root (or project (projectile-project-root))))
+    (unless root
+      (user-error "Not in a project"))
+    (let ((file (projectile-session--file root)))
+      (when (file-exists-p file)
+        (delete-file file)
+        (when (called-interactively-p 'any)
+          (message "Forgot session for %s" root))))))
+
+(defun projectile-session--maybe-autosave ()
+  "Save the current project's session when autosave is enabled.
+Wired onto `projectile-before-switch-project-hook', where the current
+project is still the one being switched away from."
+  (when projectile-session-autosave
+    (ignore-errors (projectile-session-save))))
+
+(defun projectile-session--autosave-on-kill ()
+  "Save every open project's session when autosave is enabled.
+Wired onto `kill-emacs-hook'.  Each project tab is selected in turn (the
+frame is going away anyway) so its own layout is what gets saved."
+  (when projectile-session-autosave
+    (dolist (tab (projectile-session--project-tabs))
+      ;; Guard the whole per-tab body: a tab that can't be selected (its
+      ;; root gone, say) must not abandon the remaining projects, and must
+      ;; never let an error escape a `kill-emacs-hook' function.
+      (ignore-errors
+        (let ((root (projectile-session--tab-root tab)))
+          (projectile-session--select-tab tab)
+          (projectile-session-save root))))))
 
 ;;;###autoload
 (define-minor-mode projectile-session-mode
@@ -10617,13 +10981,22 @@ existing tabs untouched."
                 #'projectile-session-switch-project-action)
       (setq projectile-session--saved-switch-action projectile-switch-project-action))
     (setq projectile-switch-project-action #'projectile-session-switch-project-action)
+    ;; Autosave wiring.  `add-hook' is idempotent for an `eq' function, so a
+    ;; double enable can't stack duplicates; the actual saving is gated on
+    ;; `projectile-session-autosave' inside the hook functions.
+    (add-hook 'projectile-before-switch-project-hook
+              #'projectile-session--maybe-autosave)
+    (add-hook 'kill-emacs-hook #'projectile-session--autosave-on-kill)
     (projectile-session--adopt-current-tab))
    (t
     (when (eq projectile-switch-project-action
               #'projectile-session-switch-project-action)
       (setq projectile-switch-project-action
             projectile-session--saved-switch-action))
-    (setq projectile-session--saved-switch-action nil))))
+    (setq projectile-session--saved-switch-action nil)
+    (remove-hook 'projectile-before-switch-project-hook
+                 #'projectile-session--maybe-autosave)
+    (remove-hook 'kill-emacs-hook #'projectile-session--autosave-on-kill))))
 
 (provide 'projectile)
 

--- a/test/projectile-session-test.el
+++ b/test/projectile-session-test.el
@@ -222,6 +222,435 @@
     (expect 'projectile-project-buffers :not :to-have-been-called)
     (expect 'call-interactively :to-have-been-called-with #'switch-to-buffer)))
 
+(defvar projectile-session-test--dir nil
+  "Temporary directory holding session files during a test.")
+
+(defun projectile-session-test--make-dir ()
+  "Create and return a fresh temporary session directory."
+  (make-temp-file "projectile-session-test" t))
+
+(describe "projectile-session file naming"
+  (it "keys files by root, stable and collision-free"
+    (let ((projectile-session-directory "/state/sessions/"))
+      (spy-on 'projectile-session--project-name
+              :and-call-fake (lambda (root) (file-name-nondirectory
+                                             (directory-file-name root))))
+      (let ((foo1 (projectile-session--file "/a/foo/"))
+            (foo1-again (projectile-session--file "/a/foo/"))
+            (foo2 (projectile-session--file "/b/foo/")))
+        ;; same root -> same file
+        (expect foo1 :to-equal foo1-again)
+        ;; same project name, different root -> different file
+        (expect foo1 :not :to-equal foo2)
+        ;; readable project-name prefix and the session directory are used
+        (expect (file-name-directory foo1) :to-equal "/state/sessions/")
+        (expect (string-prefix-p "foo-" (file-name-nondirectory foo1))
+                :to-be t))))
+
+  (it "sanitizes unsafe characters in the project name"
+    (let ((projectile-session-directory "/state/sessions/"))
+      (spy-on 'projectile-session--project-name
+              :and-return-value "we ird/name")
+      (let ((file (file-name-nondirectory (projectile-session--file "/x/y/"))))
+        (expect (string-match-p "[ /]" file) :to-be nil)))))
+
+(describe "projectile-session buffer serializers"
+  (it "round-trips a file-visiting buffer with point"
+    (let ((tmp (make-temp-file "projectile-session-file" nil ".txt")))
+      (unwind-protect
+          (progn
+            (with-temp-file tmp (insert "hello world\nsecond line\n"))
+            (let* ((buf (find-file-noselect tmp)))
+              (unwind-protect
+                  (let (saved)
+                    (with-current-buffer buf (goto-char 5))
+                    (setq saved (projectile-session--serialize-buffer buf))
+                    (expect (car saved) :to-be t)
+                    (expect (plist-get (cdr saved) :file) :to-equal tmp)
+                    (expect (plist-get (cdr saved) :point) :to-equal 5)
+                    ;; round-trip must be readable and recreate the buffer
+                    (let ((round (read (prin1-to-string saved))))
+                      (kill-buffer buf)
+                      (let ((restored (projectile-session--recreate-buffer round)))
+                        (expect (buffer-live-p restored) :to-be t)
+                        (expect (buffer-file-name restored) :to-equal tmp)
+                        (with-current-buffer restored
+                          (expect (point) :to-equal 5))
+                        (kill-buffer restored))))
+                (when (buffer-live-p buf) (kill-buffer buf)))))
+        (delete-file tmp))))
+
+  (it "round-trips a dired buffer via its directory"
+    (let* ((dir (make-temp-file "projectile-session-dired" t))
+           (buf (dired-noselect dir)))
+      (unwind-protect
+          (let ((saved (projectile-session--serialize-buffer buf)))
+            (expect (car saved) :to-equal 'dired-mode)
+            (expect (plist-get (cdr saved) :dir)
+                    :to-equal (file-name-as-directory (expand-file-name dir)))
+            (kill-buffer buf)
+            (let ((restored (projectile-session--recreate-buffer
+                             (read (prin1-to-string saved)))))
+              (expect (buffer-live-p restored) :to-be t)
+              (with-current-buffer restored
+                (expect (derived-mode-p 'dired-mode) :to-be-truthy))
+              (kill-buffer restored)))
+        (when (buffer-live-p buf) (kill-buffer buf))
+        (delete-directory dir t))))
+
+  (it "recreates nothing when a saved file is gone"
+    (let ((saved (cons t (list :file "/no/such/file.txt" :point 1))))
+      (expect (projectile-session--recreate-buffer saved) :to-be nil)))
+
+  (it "honors a custom serializer for a non-file buffer"
+    (let* ((projectile-session-buffer-serializers
+            (cons '(special-mode
+                    . (projectile-session-test--ser-special
+                       . projectile-session-test--deser-special))
+                  projectile-session-buffer-serializers))
+           (buf (get-buffer-create "session-special")))
+      (unwind-protect
+          (progn
+            (with-current-buffer buf
+              (special-mode)
+              (setq-local projectile-session-test--payload "abc"))
+            (cl-letf (((symbol-function 'projectile-session-test--ser-special)
+                       (lambda (_buffer)
+                         (list :payload projectile-session-test--payload)))
+                      ((symbol-function 'projectile-session-test--deser-special)
+                       (lambda (record)
+                         (let ((b (get-buffer-create "session-special")))
+                           (with-current-buffer b
+                             (setq-local projectile-session-test--payload
+                                         (plist-get record :payload)))
+                           b))))
+              (let ((saved (projectile-session--serialize-buffer buf)))
+                (expect (car saved) :to-equal 'special-mode)
+                (expect (plist-get (cdr saved) :payload) :to-equal "abc")
+                (let ((restored (projectile-session--recreate-buffer
+                                 (read (prin1-to-string saved)))))
+                  (with-current-buffer restored
+                    (expect projectile-session-test--payload :to-equal "abc"))))))
+        (when (buffer-live-p buf) (kill-buffer buf)))))
+
+  (it "skips a buffer no serializer handles"
+    (let ((buf (get-buffer-create "session-plain")))
+      (unwind-protect
+          (progn
+            (with-current-buffer buf (fundamental-mode))
+            (expect (projectile-session--serialize-buffer buf) :to-be nil))
+        (kill-buffer buf))))
+
+  (it "isolates a throwing serializer and falls through to the next entry"
+    (let ((tmp (make-temp-file "projectile-session-throw" nil ".txt")))
+      (let* ((projectile-session-buffer-serializers
+              (cons (cons 'text-mode
+                          (cons #'projectile-session-test--ser-boom #'ignore))
+                    projectile-session-buffer-serializers))
+             (buf (find-file-noselect tmp)))
+        (unwind-protect
+            (cl-letf (((symbol-function 'projectile-session-test--ser-boom)
+                       (lambda (_b) (error "boom"))))
+              (with-current-buffer buf (text-mode))
+              ;; the text-mode entry throws; must fall through to the `t' handler
+              (let ((saved (projectile-session--serialize-buffer buf)))
+                (expect (car saved) :to-be t)
+                (expect (plist-get (cdr saved) :file) :to-equal tmp)))
+          (when (buffer-live-p buf) (kill-buffer buf))
+          (delete-file tmp)))))
+
+  (it "drops a record that can't be read back"
+    (let* ((projectile-session-buffer-serializers
+            (list (cons 'fundamental-mode
+                        (cons #'projectile-session-test--ser-live #'ignore))))
+           (buf (get-buffer-create "session-live")))
+      (unwind-protect
+          (cl-letf (((symbol-function 'projectile-session-test--ser-live)
+                     ;; embeds a live buffer object, which prin1/read can't round-trip
+                     (lambda (b) (list :live b))))
+            (with-current-buffer buf (fundamental-mode))
+            (expect (projectile-session--serialize-buffer buf) :to-be nil))
+        (kill-buffer buf))))
+
+  (it "round-trips a predicate-keyed serializer"
+    (let* ((projectile-session-buffer-serializers
+            (list (cons (lambda (b)
+                          (with-current-buffer b (derived-mode-p 'special-mode)))
+                        (cons #'projectile-session-test--ser-pred
+                              #'projectile-session-test--deser-pred))))
+           (buf (get-buffer-create "session-pred")))
+      (unwind-protect
+          (cl-letf (((symbol-function 'projectile-session-test--ser-pred)
+                     (lambda (_b) (list :tag "hi")))
+                    ((symbol-function 'projectile-session-test--deser-pred)
+                     (lambda (_record) (get-buffer-create "session-pred-restored"))))
+            (with-current-buffer buf (special-mode))
+            (let ((saved (projectile-session--serialize-buffer buf)))
+              ;; a predicate key stores the buffer's major mode as the kind
+              (expect (car saved) :to-equal 'special-mode)
+              ;; ...and restore must still resolve the predicate entry's deserializer
+              (let ((restored (projectile-session--recreate-buffer
+                               (read (prin1-to-string saved)))))
+                (expect (buffer-live-p restored) :to-be t))))
+        (when (buffer-live-p buf) (kill-buffer buf))
+        (when (get-buffer "session-pred-restored")
+          (kill-buffer "session-pred-restored"))))))
+
+(describe "projectile-session save and restore"
+  (before-each
+    (setq projectile-session-test--dir (projectile-session-test--make-dir))
+    (projectile-session-test--reset-tabs))
+
+  (after-each
+    (projectile-session-test--reset-tabs)
+    (when (and projectile-session-test--dir
+               (file-directory-p projectile-session-test--dir))
+      (delete-directory projectile-session-test--dir t)))
+
+  (it "writes a readable versioned sexp and restores the layout"
+    (let ((tmp1 (make-temp-file "projectile-session-a" nil ".txt"))
+          (tmp2 (make-temp-file "projectile-session-b" nil ".txt")))
+      (unwind-protect
+          (let* ((projectile-session-directory projectile-session-test--dir)
+                 (buf1 (find-file-noselect tmp1))
+                 (buf2 (find-file-noselect tmp2)))
+            (unwind-protect
+                (progn
+                  ;; lay out two windows, one per file
+                  (delete-other-windows)
+                  (switch-to-buffer buf1)
+                  (split-window)
+                  (other-window 1)
+                  (switch-to-buffer buf2)
+                  (expect (projectile-session-save "/proj/root/") :to-be-truthy)
+                  ;; on-disk data is a readable, versioned plist
+                  (let* ((file (projectile-session--file "/proj/root/"))
+                         (data (with-temp-buffer
+                                 (insert-file-contents file)
+                                 (read (buffer-string)))))
+                    (expect (plist-get data :projectile-session-version)
+                            :to-equal projectile-session--format-version)
+                    (expect (plist-get data :root) :to-equal "/proj/root/")
+                    (expect (length (plist-get data :buffers)) :to-equal 2))
+                  ;; tear the layout down, then restore it
+                  (kill-buffer buf1)
+                  (kill-buffer buf2)
+                  (delete-other-windows)
+                  (switch-to-buffer "*scratch*")
+                  (expect (projectile-session-restore "/proj/root/") :to-be-truthy)
+                  (let ((names (mapcar (lambda (w)
+                                         (buffer-file-name (window-buffer w)))
+                                       (window-list nil 'nomini))))
+                    (expect names :to-contain tmp1)
+                    (expect names :to-contain tmp2)))
+              (dolist (b (list buf1 buf2))
+                (when (buffer-live-p b) (kill-buffer b)))
+              (dolist (n (list (file-name-nondirectory tmp1)
+                               (file-name-nondirectory tmp2)))
+                (when (get-buffer n) (kill-buffer n)))))
+        (delete-file tmp1)
+        (delete-file tmp2))))
+
+  (it "does not error restoring a layout whose file is gone"
+    (let ((tmp (make-temp-file "projectile-session-gone" nil ".txt")))
+      (let* ((projectile-session-directory projectile-session-test--dir)
+             (buf (find-file-noselect tmp)))
+        (unwind-protect
+            (progn
+              (delete-other-windows)
+              (switch-to-buffer buf)
+              (projectile-session-save "/gone/root/")
+              (kill-buffer buf)
+              (delete-file tmp)
+              (switch-to-buffer "*scratch*")
+              ;; the file the layout points at is gone; restore must not error,
+              ;; and returns nil (nothing recreated) so a caller can fall back
+              (expect (projectile-session-restore "/gone/root/") :to-be nil))
+          (when (buffer-live-p buf) (kill-buffer buf))
+          (when (get-buffer (file-name-nondirectory tmp))
+            (kill-buffer (file-name-nondirectory tmp)))
+          (when (file-exists-p tmp) (delete-file tmp))))))
+
+  (it "saves nothing for a degenerate layout"
+    (let ((projectile-session-directory projectile-session-test--dir))
+      (delete-other-windows)
+      (switch-to-buffer "*scratch*")
+      (expect (projectile-session-save "/empty/root/") :to-be nil)
+      (expect (projectile-session--saved-p "/empty/root/") :to-be nil)))
+
+  (it "reports failure when the session file cannot be written"
+    ;; point the session directory *under a regular file* so make-directory and
+    ;; the write fail; save must return nil rather than lying about success
+    (let ((blocker (make-temp-file "projectile-session-blocker"))
+          (tmp (make-temp-file "projectile-session-w" nil ".txt")))
+      (let* ((projectile-session-directory (expand-file-name "sub" blocker))
+             (buf (find-file-noselect tmp)))
+        (unwind-protect
+            (progn
+              (delete-other-windows)
+              (switch-to-buffer buf)
+              (expect (projectile-session-save "/blocked/root/") :to-be nil))
+          (when (buffer-live-p buf) (kill-buffer buf))
+          (delete-file tmp)
+          (delete-file blocker)))))
+
+  (it "placeholders a dead pane in a split layout without erroring"
+    (let* ((projectile-session-directory projectile-session-test--dir)
+           (t1 (make-temp-file "projectile-session-mix-a" nil ".txt"))
+           (t2 (make-temp-file "projectile-session-mix-b" nil ".txt"))
+           (b1 (find-file-noselect t1))
+           (b2 (find-file-noselect t2)))
+      (unwind-protect
+          (progn
+            (delete-other-windows)
+            (switch-to-buffer b1)
+            (split-window-right)
+            (other-window 1)
+            (switch-to-buffer b2)
+            (projectile-session-save "/mix/root/")
+            ;; only t2 goes away; t1 stays recreatable
+            (kill-buffer b2) (delete-file t2)
+            (kill-buffer b1)
+            (delete-other-windows)
+            (switch-to-buffer "*scratch*")
+            ;; t1 recreatable so restore proceeds; the dead t2 pane is sanitized
+            ;; to a placeholder and window-state-put must not error
+            (expect (projectile-session-restore "/mix/root/") :to-be t))
+        (when (buffer-live-p b1) (kill-buffer b1))
+        (when (buffer-live-p b2) (kill-buffer b2))
+        (when (file-exists-p t1) (delete-file t1))
+        (when (file-exists-p t2) (delete-file t2)))))
+
+  (it "forgets a saved session by deleting its file"
+    (let ((tmp (make-temp-file "projectile-session-forget" nil ".txt")))
+      (let* ((projectile-session-directory projectile-session-test--dir)
+             (buf (find-file-noselect tmp)))
+        (unwind-protect
+            (progn
+              (delete-other-windows)
+              (switch-to-buffer buf)
+              (projectile-session-save "/forget/root/")
+              (expect (projectile-session--saved-p "/forget/root/") :to-be t)
+              (projectile-session-forget "/forget/root/")
+              (expect (projectile-session--saved-p "/forget/root/") :to-be nil))
+          (when (buffer-live-p buf) (kill-buffer buf))
+          (delete-file tmp))))))
+
+(describe "projectile-session restore-on-switch"
+  (before-each
+    (setq projectile-session-test--dir (projectile-session-test--make-dir))
+    (projectile-session-test--reset-tabs))
+
+  (after-each
+    (projectile-session-test--reset-tabs)
+    (when (and projectile-session-test--dir
+               (file-directory-p projectile-session-test--dir))
+      (delete-directory projectile-session-test--dir t)))
+
+  (it "restores instead of populating when a session exists on disk"
+    (let ((projectile-session-directory projectile-session-test--dir)
+          (projectile-session-restore-on-switch t)
+          (projectile-session-default-action 'projectile-session-test--populate))
+      (spy-on 'projectile-session-test--populate)
+      (spy-on 'projectile-project-root :and-return-value "/switch/proj/")
+      (spy-on 'projectile-session--saved-p :and-return-value t)
+      (spy-on 'projectile-session-restore :and-return-value t)
+      (projectile-session-switch-project-action)
+      (expect 'projectile-session-restore
+              :to-have-been-called-with "/switch/proj/")
+      (expect 'projectile-session-test--populate :not :to-have-been-called)))
+
+  (it "populates when restore-on-switch is off"
+    (let ((projectile-session-directory projectile-session-test--dir)
+          (projectile-session-restore-on-switch nil)
+          (projectile-session-default-action 'projectile-session-test--populate))
+      (spy-on 'projectile-session-test--populate)
+      (spy-on 'projectile-project-root :and-return-value "/switch/proj/")
+      (spy-on 'projectile-session--saved-p :and-return-value t)
+      (spy-on 'projectile-session-restore)
+      (projectile-session-switch-project-action)
+      (expect 'projectile-session-restore :not :to-have-been-called)
+      (expect 'projectile-session-test--populate :to-have-been-called)))
+
+  (it "populates when there is no saved session"
+    (let ((projectile-session-directory projectile-session-test--dir)
+          (projectile-session-restore-on-switch t)
+          (projectile-session-default-action 'projectile-session-test--populate))
+      (spy-on 'projectile-session-test--populate)
+      (spy-on 'projectile-project-root :and-return-value "/switch/proj/")
+      (spy-on 'projectile-session--saved-p :and-return-value nil)
+      (spy-on 'projectile-session-restore)
+      (projectile-session-switch-project-action)
+      (expect 'projectile-session-restore :not :to-have-been-called)
+      (expect 'projectile-session-test--populate :to-have-been-called))))
+
+(describe "projectile-session autosave wiring"
+  (before-each
+    (projectile-session-test--reset-tabs))
+
+  (after-each
+    (when projectile-session-mode
+      (projectile-session-mode -1))
+    (projectile-session-test--reset-tabs))
+
+  (it "adds and removes the autosave hooks with the mode"
+    (let ((projectile-switch-project-action 'projectile-find-file)
+          (projectile-before-switch-project-hook nil)
+          (kill-emacs-hook nil))
+      (spy-on 'projectile-project-root :and-return-value nil)
+      (projectile-session-mode 1)
+      (expect (memq 'projectile-session--maybe-autosave
+                    projectile-before-switch-project-hook)
+              :to-be-truthy)
+      (expect (memq 'projectile-session--autosave-on-kill kill-emacs-hook)
+              :to-be-truthy)
+      (projectile-session-mode -1)
+      (expect (memq 'projectile-session--maybe-autosave
+                    projectile-before-switch-project-hook)
+              :to-be nil)
+      (expect (memq 'projectile-session--autosave-on-kill kill-emacs-hook)
+              :to-be nil)))
+
+  (it "does not stack duplicate hooks on a double enable"
+    (let ((projectile-switch-project-action 'projectile-find-file)
+          (projectile-before-switch-project-hook nil)
+          (kill-emacs-hook nil))
+      (spy-on 'projectile-project-root :and-return-value nil)
+      (projectile-session-mode 1)
+      (projectile-session-mode 1)
+      (expect (length (delq nil (mapcar
+                                 (lambda (h)
+                                   (eq h 'projectile-session--maybe-autosave))
+                                 projectile-before-switch-project-hook)))
+              :to-equal 1)))
+
+  (it "autosaves the outgoing project only when enabled"
+    (let ((projectile-session-autosave nil))
+      (spy-on 'projectile-session-save)
+      (projectile-session--maybe-autosave)
+      (expect 'projectile-session-save :not :to-have-been-called)
+      (setq projectile-session-autosave t)
+      (projectile-session--maybe-autosave)
+      (expect 'projectile-session-save :to-have-been-called)))
+
+  (it "keeps saving the other tabs when one can't be selected on kill"
+    (let ((projectile-session-autosave t)
+          (saved '()))
+      (spy-on 'projectile-session--project-tabs
+              :and-return-value (list 'tab-a 'tab-b 'tab-c))
+      (spy-on 'projectile-session--tab-root
+              :and-call-fake (lambda (tab) (format "/%s/" tab)))
+      (spy-on 'projectile-session--select-tab
+              :and-call-fake (lambda (tab)
+                               (when (eq tab 'tab-b) (error "cannot select tab-b"))))
+      (spy-on 'projectile-session-save
+              :and-call-fake (lambda (root) (push root saved) t))
+      ;; tab-b throws on select, but that must not abandon tab-a and tab-c
+      (projectile-session--autosave-on-kill)
+      (expect saved :to-contain "/tab-a/")
+      (expect saved :to-contain "/tab-c/")
+      (expect saved :not :to-contain "/tab-b/"))))
+
 (provide 'projectile-session-test)
 
 ;;; projectile-session-test.el ends here


### PR DESCRIPTION
Second milestone of the per-project session feature (builds on `projectile-session-mode` from #2065): persist a project's window layout and buffers to disk and restore them across restarts. No new dependencies, works at the Emacs 28.1 floor.

Layout is captured with `window-state-get` and written as a version-tagged `.eld` per project under `projectile-session-directory`. Buffers go through `projectile-session-buffer-serializers`, a registry mapping a major mode (or `t`, or a predicate) to a serialize/deserialize pair; file-visiting and dired buffers ship out of the box. Windows whose buffer can't be recreated are rewritten to a placeholder so a stale layout never errors - the deliberate 28.1 substitute for Emacs 30's `window-restore-killed-buffer-windows`. `projectile-session-restore-on-switch` (default t) restores a saved layout instead of populating a fresh tab; `projectile-session-autosave` is opt-in.

Corrupt or hostile `.eld` files can't execute code (`read` never evals) and can't break switching - the window-state sanitizer is a full tree walk.