### PR TITLE
Make projectile-session commands discoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
   * Switching to a project selects its existing tab (restoring that project's window layout) when one is open, or otherwise opens a fresh tab named after the project and populated via `projectile-session-default-action`.
   * Same-named checkouts get distinct tab names (e.g. `work/foo` and `home/foo`); customize the scheme with `projectile-session-tab-name-function`.
   * `projectile-session-switch-to-buffer` completes over just the current tab's project buffers.
-  * Sessions persist across Emacs restarts: `projectile-session-save`, `projectile-session-restore` and `projectile-session-forget` write a project's window layout and buffers to a file under `projectile-session-directory` and read it back.
+  * Sessions persist across Emacs restarts: `projectile-session-save`, `projectile-session-restore` and `projectile-session-forget` write a project's window layout and buffers to a file under `projectile-session-directory` and read it back; `projectile-session-save-all` saves every open project at once.
   * Switching to a project with a saved session restores it (gated by `projectile-session-restore-on-switch`); `projectile-session-autosave` saves sessions on switch-away and on exit.
   * Which buffers are recorded, and how, is extensible via `projectile-session-buffer-serializers`; file-visiting and `dired-mode` buffers work out of the box.
+  * The session commands are bound under the `w` sub-prefix of the command map (`s-p w s`, `s-p w S`, `s-p w r`, `s-p w f`, `s-p w b`), and are also available from `projectile-dispatch` and the Projectile menu.
 
 ## 3.1.0 (2026-07-04)
 

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -803,18 +803,28 @@ Disabling `projectile-session-mode` restores
 `projectile-switch-project-action` to whatever it was when you enabled
 the mode; it leaves `tab-bar-mode` and any existing tabs in place.
 
+The session commands live on the `w` sub-prefix of the Projectile command
+map, and are also reachable from `projectile-dispatch` and the Projectile
+menu:
+
+[cols="1,4"]
+|===
+| Keybinding | Command
+
+| kbd:[s-p w s] | `projectile-session-save`
+| kbd:[s-p w S] | `projectile-session-save-all`
+| kbd:[s-p w r] | `projectile-session-restore`
+| kbd:[s-p w f] | `projectile-session-forget`
+| kbd:[s-p w b] | `projectile-session-switch-to-buffer`
+|===
+
 === Switching buffers within a session
 
-`projectile-session-switch-to-buffer` completes over just the buffers of
-the current tab's project (falling back to a plain `switch-to-buffer`
-when the current tab holds no project). It is deliberately kept as a
-separate, opt-in command rather than a global remapping of
-`switch-to-buffer`, so bind it yourself if you want it, e.g.:
-
-[source,elisp]
-----
-(define-key projectile-command-map (kbd "B") #'projectile-session-switch-to-buffer)
-----
+`projectile-session-switch-to-buffer` (kbd:[s-p w b]) completes over just
+the buffers of the current tab's project, falling back to a plain
+`switch-to-buffer` when the current tab holds no project. It is a separate
+command rather than a global remapping of `switch-to-buffer`, so plain
+`switch-to-buffer` still sees every buffer.
 
 NOTE: This mode makes the aging
 https://github.com/bbatsov/persp-projectile[persp-projectile] unnecessary
@@ -829,6 +839,10 @@ to disk and restore it in a later Emacs:
 * `projectile-session-save` writes the current frame's layout and buffers
   as the current project's session. Since it reads the live frame, it saves
   whichever project's tab is selected.
+* `projectile-session-save-all` saves every open project's session in one
+  go, selecting each project tab in turn (and returning you to the tab you
+  started on). Unlike autosave below, it runs regardless of
+  `projectile-session-autosave`.
 * `projectile-session-restore` recreates that project's buffers and puts
   the saved layout back.
 * `projectile-session-forget` deletes a project's saved session file.

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -407,6 +407,21 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p x G]
 | Start or visit a `ghostel` terminal for the project.
 
+| kbd:[s-p w s]
+| Save the current project's session (see `projectile-session-mode`).
+
+| kbd:[s-p w S]
+| Save every open project's session.
+
+| kbd:[s-p w r]
+| Restore the current project's saved session.
+
+| kbd:[s-p w f]
+| Forget (delete) the current project's saved session.
+
+| kbd:[s-p w b]
+| Switch to a buffer belonging to the current tab's project.
+
 | kbd:[s-p ESC]
 | Switch to the most recently selected Projectile buffer.
 |===

--- a/projectile.el
+++ b/projectile.el
@@ -9806,6 +9806,12 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "t") #'projectile-toggle-between-implementation-and-test)
     (define-key map (kbd "T") #'projectile-find-test-file)
     (define-key map (kbd "v") #'projectile-vc)
+    ;; per-project sessions (see `projectile-session-mode')
+    (define-key map (kbd "w s") #'projectile-session-save)
+    (define-key map (kbd "w S") #'projectile-session-save-all)
+    (define-key map (kbd "w r") #'projectile-session-restore)
+    (define-key map (kbd "w f") #'projectile-session-forget)
+    (define-key map (kbd "w b") #'projectile-session-switch-to-buffer)
     ;; project lifecycle external commands
     (define-key map (kbd "c o") #'projectile-configure-project)
     (define-key map (kbd "c c") #'projectile-compile-project)
@@ -10105,6 +10111,12 @@ window or frame (file/buffer/project commands)."
       ("xG" "ghostel" projectile-dispatch-run-ghostel)
       ("!" "shell command" projectile-run-shell-command-in-root)
       ("&" "async shell command" projectile-run-async-shell-command-in-root)]
+     ["Session"
+      ("ws" "save session" projectile-session-save)
+      ("wS" "save all sessions" projectile-session-save-all)
+      ("wr" "restore session" projectile-session-restore)
+      ("wf" "forget session" projectile-session-forget)
+      ("wb" "switch project buffer" projectile-session-switch-to-buffer)]
      ["Cache"
       ("i" "invalidate cache" projectile-invalidate-cache)
       ("z" "cache current file" projectile-cache-current-file)]]))
@@ -10210,6 +10222,13 @@ window or frame (file/buffer/project commands)."
          ["Repeat last task" projectile-repeat-last-task]
          "--"
          ["Repeat last build command" projectile-repeat-last-command])
+        ("Session"
+         ["Save session" projectile-session-save]
+         ["Save all sessions" projectile-session-save-all]
+         ["Restore session" projectile-session-restore]
+         ["Forget session" projectile-session-forget]
+         "--"
+         ["Switch to project buffer" projectile-session-switch-to-buffer])
         "--"
         ["About" projectile-version]))
     map)
@@ -10484,6 +10503,13 @@ Session files whose version does not match are ignored on restore.")
   "The `projectile-switch-project-action' saved when the mode was enabled.
 Restored when `projectile-session-mode' is disabled.")
 
+(defvar projectile-session--closing-tab nil
+  "A project tab currently being closed, or nil.
+Bound while re-simplifying survivor names from
+`projectile-session--on-tab-close' (the pre-close hook, where the closing
+tab is still present in the tab list) so `projectile-session--project-tabs'
+omits it and its name no longer counts as a clash.")
+
 (declare-function dired-noselect "dired")
 
 (defun projectile-session--current-tab ()
@@ -10522,8 +10548,14 @@ TRAMP round-trip."
                   (file-equal-p a b))))))
 
 (defun projectile-session--project-tabs ()
-  "Return the open tabs that are bound to a project."
-  (seq-filter #'projectile-session--tab-root (tab-bar-tabs)))
+  "Return the open tabs that are bound to a project.
+The tab held in `projectile-session--closing-tab' (one being closed) is
+omitted, so survivor names recomputed from the pre-close hook don't still
+treat the closing tab as an open clash."
+  (seq-filter (lambda (tab)
+                (and (not (eq tab projectile-session--closing-tab))
+                     (projectile-session--tab-root tab)))
+              (tab-bar-tabs)))
 
 (defun projectile-session--project-tab (root)
   "Return the open tab bound to project ROOT, or nil when there is none."
@@ -10604,6 +10636,25 @@ parameter), which a manual `tab-bar-rename-tab' breaks."
                       (projectile-session--tab-root tab))))))
   (force-mode-line-update t))
 
+(defun projectile-session--on-tab-close (tab &optional _last)
+  "Re-simplify survivor tab names after project TAB is closed.
+Wired onto `tab-bar-tab-pre-close-functions', so a project tab that was
+disambiguated only because of TAB (e.g. \"work/foo\" beside TAB's
+\"home/foo\") reverts to its plain name once TAB goes away.
+
+That hook fires while TAB is still in the tab list, so TAB is bound as
+`projectile-session--closing-tab' to exclude it from the recomputation.
+It is used rather than a post-close hook because Emacs has no post-close
+tab hook at Projectile's 28.1 floor (`tab-bar-tab-pre-close-functions'
+dates to 27.1; `tab-bar-tab-post-close-functions' does not exist), which
+keeps this 28.1-safe."
+  (when (projectile-session--tab-root tab)
+    (let ((projectile-session--closing-tab tab))
+      ;; never let a naming error (e.g. a custom `projectile-session-tab-name-function'
+      ;; that signals) escape this pre-close hook and abort the tab close
+      (ignore-errors
+        (projectile-session--refresh-tab-names)))))
+
 (defun projectile-session--make-project-tab (root)
   "Create and select a fresh tab bound to project ROOT.
 The new tab is stamped with ROOT and named; populating it is left to the
@@ -10612,10 +10663,34 @@ caller."
   (projectile-session--set-tab-root (projectile-session--current-tab) root)
   (projectile-session--refresh-tab-names))
 
+(defun projectile-session--current-tab-index ()
+  "Return the 1-based index of the selected frame's current tab."
+  (1+ (or (cl-position 'current-tab (tab-bar-tabs) :key #'car :test #'eq) 0)))
+
+(defun projectile-session--select-tab-by-root (root)
+  "Select the open project tab bound to ROOT, if any.
+Returns non-nil when a tab was selected.  Resolves the tab to a 1-based
+index in a single pass and selects by index, so it is robust to
+`tab-bar-select-tab' rebuilding tab cons cells as it switches away from
+the current tab (a captured cons would go stale mid-loop)."
+  (let ((index 0) (target nil))
+    (dolist (tab (tab-bar-tabs))
+      (setq index (1+ index))
+      (when (and (not target)
+                 (projectile-session--same-root-p
+                  (projectile-session--tab-root tab) root))
+        (setq target index)))
+    (when target
+      (tab-bar-select-tab target)
+      t)))
+
 (defun projectile-session--select-tab (tab)
-  "Select TAB, restoring the project layout it holds."
-  (when-let* ((index (cl-position tab (tab-bar-tabs) :test #'eq)))
-    (tab-bar-select-tab (1+ index))))
+  "Select TAB, restoring the project layout it holds.
+Selection goes through the tab's project root, so it stays correct even
+after other tabs' cons cells have been rebuilt."
+  (let ((root (projectile-session--tab-root tab)))
+    (when root
+      (projectile-session--select-tab-by-root root))))
 
 (defun projectile-session--adopt-current-tab ()
   "Bind the current tab to the current project, when there is one.
@@ -10935,19 +11010,51 @@ project is still the one being switched away from."
   (when projectile-session-autosave
     (ignore-errors (projectile-session-save))))
 
+(defun projectile-session--save-all-tabs ()
+  "Save the session of every open project tab, selecting each in turn.
+Each project tab is selected so its own window layout is what gets saved,
+then the originally-selected tab is restored.  Tabs are re-resolved by
+root on each iteration rather than by a cons captured up front, because
+`tab-bar-select-tab' rebuilds cons cells as it switches tabs (a stale cons
+would save the wrong layout under a project's root).  The per-tab body is
+guarded so a tab that can't be selected or saved (its root gone, say)
+neither abandons the remaining projects nor lets an error escape (this
+also matters on `kill-emacs-hook').  Return the number of tabs whose
+session was actually written."
+  (let ((origin (projectile-session--current-tab-index))
+        (roots (delq nil (mapcar #'projectile-session--tab-root
+                                 (projectile-session--project-tabs))))
+        (saved 0))
+    (dolist (root roots)
+      (ignore-errors
+        (when (and (projectile-session--select-tab-by-root root)
+                   (projectile-session-save root))
+          (setq saved (1+ saved)))))
+    (ignore-errors (tab-bar-select-tab origin))
+    saved))
+
+;;;###autoload
+(defun projectile-session-save-all ()
+  "Save the session of every open project in one go.
+Every open project tab's window layout and buffers are saved (see
+`projectile-session-save'); a tab whose layout has no serializable buffer
+is skipped.  Unlike autosave, this runs regardless of
+`projectile-session-autosave'.  When called interactively, report how many
+sessions were saved."
+  (interactive)
+  ;; `--save-all-tabs' selects each project tab in turn and restores the
+  ;; originally-selected one afterwards.
+  (let ((saved (projectile-session--save-all-tabs)))
+    (when (called-interactively-p 'any)
+      (message "Saved %d project session%s" saved (if (= saved 1) "" "s")))
+    saved))
+
 (defun projectile-session--autosave-on-kill ()
   "Save every open project's session when autosave is enabled.
-Wired onto `kill-emacs-hook'.  Each project tab is selected in turn (the
-frame is going away anyway) so its own layout is what gets saved."
+Wired onto `kill-emacs-hook'; the frame is going away, so the tab left
+selected by `projectile-session--save-all-tabs' does not matter."
   (when projectile-session-autosave
-    (dolist (tab (projectile-session--project-tabs))
-      ;; Guard the whole per-tab body: a tab that can't be selected (its
-      ;; root gone, say) must not abandon the remaining projects, and must
-      ;; never let an error escape a `kill-emacs-hook' function.
-      (ignore-errors
-        (let ((root (projectile-session--tab-root tab)))
-          (projectile-session--select-tab tab)
-          (projectile-session-save root))))))
+    (projectile-session--save-all-tabs)))
 
 ;;;###autoload
 (define-minor-mode projectile-session-mode
@@ -10987,6 +11094,11 @@ existing tabs untouched."
     (add-hook 'projectile-before-switch-project-hook
               #'projectile-session--maybe-autosave)
     (add-hook 'kill-emacs-hook #'projectile-session--autosave-on-kill)
+    ;; Re-simplify a survivor's name when its same-named sibling tab is
+    ;; closed.  `add-hook' is idempotent for an `eq' function, so a double
+    ;; enable can't stack duplicates.
+    (add-hook 'tab-bar-tab-pre-close-functions
+              #'projectile-session--on-tab-close)
     (projectile-session--adopt-current-tab))
    (t
     (when (eq projectile-switch-project-action
@@ -10996,7 +11108,9 @@ existing tabs untouched."
     (setq projectile-session--saved-switch-action nil)
     (remove-hook 'projectile-before-switch-project-hook
                  #'projectile-session--maybe-autosave)
-    (remove-hook 'kill-emacs-hook #'projectile-session--autosave-on-kill))))
+    (remove-hook 'kill-emacs-hook #'projectile-session--autosave-on-kill)
+    (remove-hook 'tab-bar-tab-pre-close-functions
+                 #'projectile-session--on-tab-close))))
 
 (provide 'projectile)
 

--- a/test/projectile-session-test.el
+++ b/test/projectile-session-test.el
@@ -229,6 +229,11 @@
   "Create and return a fresh temporary session directory."
   (make-temp-file "projectile-session-test" t))
 
+(defun projectile-session-test--session-files (data)
+  "Return the list of :file paths recorded in session DATA."
+  (delq nil (mapcar (lambda (buf) (plist-get (cdr buf) :file))
+                    (plist-get data :buffers))))
+
 (describe "projectile-session file naming"
   (it "keys files by root, stable and collision-free"
     (let ((projectile-session-directory "/state/sessions/"))
@@ -636,13 +641,17 @@
   (it "keeps saving the other tabs when one can't be selected on kill"
     (let ((projectile-session-autosave t)
           (saved '()))
+      (spy-on 'projectile-session--current-tab-index :and-return-value 1)
+      (spy-on 'tab-bar-select-tab)
       (spy-on 'projectile-session--project-tabs
               :and-return-value (list 'tab-a 'tab-b 'tab-c))
       (spy-on 'projectile-session--tab-root
               :and-call-fake (lambda (tab) (format "/%s/" tab)))
-      (spy-on 'projectile-session--select-tab
-              :and-call-fake (lambda (tab)
-                               (when (eq tab 'tab-b) (error "cannot select tab-b"))))
+      (spy-on 'projectile-session--select-tab-by-root
+              :and-call-fake (lambda (root)
+                               (if (equal root "/tab-b/")
+                                   (error "cannot select tab-b")
+                                 t)))
       (spy-on 'projectile-session-save
               :and-call-fake (lambda (root) (push root saved) t))
       ;; tab-b throws on select, but that must not abandon tab-a and tab-c
@@ -650,6 +659,150 @@
       (expect saved :to-contain "/tab-a/")
       (expect saved :to-contain "/tab-c/")
       (expect saved :not :to-contain "/tab-b/"))))
+
+(describe "projectile-session-save-all"
+  (before-each
+    (setq projectile-session-test--dir (projectile-session-test--make-dir))
+    (projectile-session-test--reset-tabs))
+
+  (after-each
+    (projectile-session-test--reset-tabs)
+    (when (and projectile-session-test--dir
+               (file-directory-p projectile-session-test--dir))
+      (delete-directory projectile-session-test--dir t)))
+
+  ;; Real-tab test: each project tab must be saved with ITS OWN layout, and
+  ;; the user restored to the tab they started on.  This is what a mocked spec
+  ;; can't catch: `tab-bar-select-tab' rebuilds cons cells as it switches, so
+  ;; selecting by a captured cons mid-loop saved the wrong tab's layout.
+  (it "saves each project tab's own layout and returns to the starting tab"
+    (let* ((projectile-session-directory projectile-session-test--dir)
+           (ta (make-temp-file "projectile-session-all-a" nil ".txt"))
+           (tb (make-temp-file "projectile-session-all-b" nil ".txt"))
+           (root-a "/proj/alpha/")
+           (root-b "/proj/beta/")
+           (ba (find-file-noselect ta))
+           (bb (find-file-noselect tb)))
+      (unwind-protect
+          (progn
+            ;; tab A shows file A, tab B shows file B; B is current
+            (projectile-session--make-project-tab root-a)
+            (delete-other-windows) (switch-to-buffer ba)
+            (projectile-session--make-project-tab root-b)
+            (delete-other-windows) (switch-to-buffer bb)
+            (expect (projectile-session-save-all) :to-equal 2)
+            (let ((files-a (projectile-session-test--session-files
+                            (projectile-session--read root-a)))
+                  (files-b (projectile-session-test--session-files
+                            (projectile-session--read root-b))))
+              (expect files-a :to-contain ta)
+              (expect files-a :not :to-contain tb)
+              (expect files-b :to-contain tb)
+              (expect files-b :not :to-contain ta))
+            ;; started save-all on tab B, must end up back on tab B
+            (expect (projectile-session--tab-root (projectile-session--current-tab))
+                    :to-equal root-b))
+        (when (buffer-live-p ba) (kill-buffer ba))
+        (when (buffer-live-p bb) (kill-buffer bb))
+        (delete-file ta)
+        (delete-file tb))))
+
+  (it "skips a tab that errors without abandoning the rest"
+    (let ((saved '()))
+      (spy-on 'projectile-session--current-tab-index :and-return-value 1)
+      (spy-on 'tab-bar-select-tab)
+      (spy-on 'projectile-session--project-tabs
+              :and-return-value (list 'tab-a 'tab-b 'tab-c))
+      (spy-on 'projectile-session--tab-root
+              :and-call-fake (lambda (tab) (format "/%s/" tab)))
+      (spy-on 'projectile-session--select-tab-by-root
+              :and-call-fake (lambda (root)
+                               (if (equal root "/tab-b/")
+                                   (error "cannot select tab-b")
+                                 t)))
+      (spy-on 'projectile-session-save
+              :and-call-fake (lambda (root) (push root saved) t))
+      ;; tab-b throws on select, but that must not abandon tab-a and tab-c
+      (expect (projectile-session-save-all) :to-equal 2)
+      (expect saved :to-contain "/tab-a/")
+      (expect saved :to-contain "/tab-c/")
+      (expect saved :not :to-contain "/tab-b/")))
+
+  (it "does not count a tab whose layout has nothing to save"
+    (spy-on 'projectile-session--current-tab-index :and-return-value 1)
+    (spy-on 'tab-bar-select-tab)
+    (spy-on 'projectile-session--project-tabs
+            :and-return-value (list 'tab-a 'tab-b))
+    (spy-on 'projectile-session--tab-root
+            :and-call-fake (lambda (tab) (format "/%s/" tab)))
+    (spy-on 'projectile-session--select-tab-by-root :and-return-value t)
+    ;; tab-b has no serializable buffer, so `projectile-session-save' returns nil
+    (spy-on 'projectile-session-save
+            :and-call-fake (lambda (root) (equal root "/tab-a/")))
+    (expect (projectile-session-save-all) :to-equal 1)))
+
+(describe "projectile-session survivor re-simplify"
+  (before-each
+    (projectile-session-test--reset-tabs))
+
+  (after-each
+    (projectile-session-test--reset-tabs))
+
+  (it "reverts a survivor's name when its clashing sibling tab is closed"
+    (let ((tab-bar-tab-pre-close-functions
+           (list #'projectile-session--on-tab-close)))
+      (projectile-session--make-project-tab "/work/foo/")
+      (projectile-session--make-project-tab "/home/foo/")
+      ;; both are disambiguated while they coexist
+      (let ((names (projectile-session-test--tab-names)))
+        (expect names :to-contain "work/foo")
+        (expect names :to-contain "home/foo"))
+      ;; close the current (home/foo) tab; the pre-close hook must re-simplify
+      ;; the survivor even though the closing tab is still in the tab list
+      (tab-bar-close-tab)
+      (let ((names (projectile-session-test--tab-names)))
+        (expect names :to-contain "foo")
+        (expect names :not :to-contain "work/foo"))))
+
+  (it "adds and removes the pre-close hook with the mode"
+    (let ((projectile-switch-project-action 'projectile-find-file)
+          (tab-bar-tab-pre-close-functions nil))
+      (spy-on 'projectile-project-root :and-return-value nil)
+      (projectile-session-mode 1)
+      (expect (memq 'projectile-session--on-tab-close
+                    tab-bar-tab-pre-close-functions)
+              :to-be-truthy)
+      (projectile-session-mode -1)
+      (expect (memq 'projectile-session--on-tab-close
+                    tab-bar-tab-pre-close-functions)
+              :to-be nil)))
+
+  (it "does not block a tab from closing when name refresh errors"
+    (let ((tab-bar-tab-pre-close-functions
+           (list #'projectile-session--on-tab-close)))
+      ;; build the tabs with the normal namer first
+      (projectile-session--set-tab-root
+       (projectile-session--current-tab) "/work/foo/")
+      (projectile-session--make-project-tab "/home/foo/")
+      (let ((count (length (tab-bar-tabs)))
+            ;; now make the pre-close name refresh signal
+            (projectile-session-tab-name-function
+             (lambda (_root) (error "boom in naming"))))
+        (tab-bar-close-tab)
+        (expect (length (tab-bar-tabs)) :to-equal (1- count))))))
+
+(describe "projectile-session keybindings"
+  (it "binds the w sub-prefix to the session commands"
+    (expect (lookup-key projectile-command-map (kbd "w s"))
+            :to-equal #'projectile-session-save)
+    (expect (lookup-key projectile-command-map (kbd "w S"))
+            :to-equal #'projectile-session-save-all)
+    (expect (lookup-key projectile-command-map (kbd "w r"))
+            :to-equal #'projectile-session-restore)
+    (expect (lookup-key projectile-command-map (kbd "w f"))
+            :to-equal #'projectile-session-forget)
+    (expect (lookup-key projectile-command-map (kbd "w b"))
+            :to-equal #'projectile-session-switch-to-buffer)))
 
 (provide 'projectile-session-test)
 


### PR DESCRIPTION
Makes the session commands discoverable: a `w` sub-prefix in `projectile-command-map` (`w s` save, `w S` save-all, `w r` restore, `w f` forget, `w b` project-scoped switch-to-buffer), a Session group in the `projectile-dispatch` transient and in the Easy Menu, plus the usage.adoc key table and a pass over the sessions docs. The feature is still called "session" throughout; `w` is just a free letter. Also adds `projectile-session-save-all`, and makes a surviving tab revert its name (`work/foo` back to `foo`) when its same-named sibling closes.

One real bug fell out, which also existed in the merged autosave-on-kill path: `projectile-session--select-tab` located tabs by an `eq`-matched cons cell, but `tab-bar-select-tab` rebuilds a tab's cons when it switches away, so mid-loop selects silently failed and save-all/autosave then wrote the wrong tab's layout under a project's root, leaving you on the wrong tab. It now selects via a freshly computed index/root. Also guarded the tab-close name refresh so a custom naming function that errors cannot make a tab un-closeable.

Follow-up to #2065/#2066.