### PR TITLE
Add session restore-all and startup restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
   * `projectile-session-switch-to-buffer` completes over just the current tab's project buffers.
   * Sessions persist across Emacs restarts: `projectile-session-save`, `projectile-session-restore` and `projectile-session-forget` write a project's window layout and buffers to a file under `projectile-session-directory` and read it back; `projectile-session-save-all` saves every open project at once.
   * Switching to a project with a saved session restores it (gated by `projectile-session-restore-on-switch`); `projectile-session-autosave` saves sessions on switch-away and on exit.
+  * `projectile-session-restore-all` reopens every saved project's session, each into its own tab (skipping projects already open and dropping stale sessions whose files are gone); set `projectile-session-restore-on-startup` to run it automatically at Emacs startup.
   * Which buffers are recorded, and how, is extensible via `projectile-session-buffer-serializers`; file-visiting and `dired-mode` buffers work out of the box.
-  * The session commands are bound under the `w` sub-prefix of the command map (`s-p w s`, `s-p w S`, `s-p w r`, `s-p w f`, `s-p w b`), and are also available from `projectile-dispatch` and the Projectile menu.
+  * The session commands are bound under the `w` sub-prefix of the command map (`s-p w s`, `s-p w S`, `s-p w r`, `s-p w R`, `s-p w f`, `s-p w b`), and are also available from `projectile-dispatch` and the Projectile menu.
 
 ## 3.1.0 (2026-07-04)
 

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -814,6 +814,7 @@ menu:
 | kbd:[s-p w s] | `projectile-session-save`
 | kbd:[s-p w S] | `projectile-session-save-all`
 | kbd:[s-p w r] | `projectile-session-restore`
+| kbd:[s-p w R] | `projectile-session-restore-all`
 | kbd:[s-p w f] | `projectile-session-forget`
 | kbd:[s-p w b] | `projectile-session-switch-to-buffer`
 |===
@@ -845,6 +846,8 @@ to disk and restore it in a later Emacs:
   `projectile-session-autosave`.
 * `projectile-session-restore` recreates that project's buffers and puts
   the saved layout back.
+* `projectile-session-restore-all` reopens every saved project's session,
+  each into its own tab (see below).
 * `projectile-session-forget` deletes a project's saved session file.
 
 Sessions are stored one file per project under
@@ -866,6 +869,32 @@ buffer are skipped.
 ----
 (setq projectile-session-autosave t)
 ----
+
+==== Restoring every session at once
+
+`projectile-session-restore-all` (kbd:[s-p w R]) reopens every saved
+project's session in one go, each into its own tab. A project that already
+has an open tab is left alone rather than duplicated, so it's safe to run
+repeatedly. A session whose files are all gone (say the project was moved
+or deleted) recreates nothing; its scratch tab is closed again instead of
+being left empty, and it doesn't count toward the number restored. When
+everything is done you land on the first project that was restored.
+
+To have Emacs reopen your saved projects automatically at startup, enable
+the mode and set `projectile-session-restore-on-startup` in your init:
+
+[source,elisp]
+----
+(projectile-session-mode +1)
+(setq projectile-session-restore-on-startup t)
+----
+
+This runs `projectile-session-restore-all` once from `emacs-startup-hook`,
+after your init files have finished loading, giving you a desktop-style
+restore of all your projects. Because the handler is installed when the
+mode is enabled and `emacs-startup-hook` fires only once, enabling the mode
+after Emacs has already started never triggers a restore; set it up in your
+init for the startup behavior.
 
 ==== Registering buffer serializers
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -416,6 +416,9 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p w r]
 | Restore the current project's saved session.
 
+| kbd:[s-p w R]
+| Reopen every saved project's session, each into its own tab.
+
 | kbd:[s-p w f]
 | Forget (delete) the current project's saved session.
 

--- a/projectile.el
+++ b/projectile.el
@@ -9810,6 +9810,7 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "w s") #'projectile-session-save)
     (define-key map (kbd "w S") #'projectile-session-save-all)
     (define-key map (kbd "w r") #'projectile-session-restore)
+    (define-key map (kbd "w R") #'projectile-session-restore-all)
     (define-key map (kbd "w f") #'projectile-session-forget)
     (define-key map (kbd "w b") #'projectile-session-switch-to-buffer)
     ;; project lifecycle external commands
@@ -10115,6 +10116,7 @@ window or frame (file/buffer/project commands)."
       ("ws" "save session" projectile-session-save)
       ("wS" "save all sessions" projectile-session-save-all)
       ("wr" "restore session" projectile-session-restore)
+      ("wR" "restore all sessions" projectile-session-restore-all)
       ("wf" "forget session" projectile-session-forget)
       ("wb" "switch project buffer" projectile-session-switch-to-buffer)]
      ["Cache"
@@ -10226,6 +10228,7 @@ window or frame (file/buffer/project commands)."
          ["Save session" projectile-session-save]
          ["Save all sessions" projectile-session-save-all]
          ["Restore session" projectile-session-restore]
+         ["Restore all sessions" projectile-session-restore-all]
          ["Forget session" projectile-session-forget]
          "--"
          ["Switch to project buffer" projectile-session-switch-to-buffer])
@@ -10440,6 +10443,18 @@ When non-nil and the project being switched to has no open tab but does
 have a session saved on disk, `projectile-session-switch-project-action'
 restores that session (recreating its buffers and layout) instead of
 running `projectile-session-default-action'."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "3.2.0"))
+
+(defcustom projectile-session-restore-on-startup nil
+  "Whether to reopen every saved project session when Emacs starts.
+When non-nil and `projectile-session-mode' is enabled, a handler added to
+`emacs-startup-hook' runs `projectile-session-restore-all' once, reopening
+each saved project into its own tab after your init files have finished
+loading.  Because that hook is installed on mode enable and
+`emacs-startup-hook' fires only once, right after startup, enabling the
+mode *after* Emacs has finished starting never triggers a restore."
   :group 'projectile
   :type 'boolean
   :package-version '(projectile . "3.2.0"))
@@ -10909,14 +10924,40 @@ so shared or circular structure in a record can't hang the write."
              (projectile-serialize data file))
            (file-exists-p file)))))
 
-(defun projectile-session--read (root)
-  "Read and return project ROOT's session data, or nil.
-Data whose format version doesn't match is ignored."
-  (let ((data (projectile-unserialize (projectile-session--file root))))
+(defun projectile-session--read-file (file)
+  "Read and return the session data stored in FILE, or nil.
+Data that isn't a well-formed session plist of the current version is
+ignored, so an unreadable or stale file is skipped rather than erroring."
+  (let ((data (projectile-unserialize file)))
     (and (consp data)
          (equal (plist-get data :projectile-session-version)
                 projectile-session--format-version)
          data)))
+
+(defun projectile-session--read (root)
+  "Read and return project ROOT's session data, or nil.
+Data whose format version doesn't match is ignored."
+  (projectile-session--read-file (projectile-session--file root)))
+
+(defun projectile-session--saved-roots ()
+  "Return the roots of every project with a session saved on disk.
+Scan `projectile-session-directory' for session files, read each (skipping
+any that is unreadable or of a mismatched version, via
+`projectile-session--read-file'), and collect the `:root' it stores.  The
+result is sorted so `projectile-session-restore-all' reopens tabs in a
+stable order across calls and restarts."
+  (let ((dir projectile-session-directory)
+        (roots '()))
+    (when (file-directory-p dir)
+      (dolist (file (directory-files dir t "\\.eld\\'"))
+        (let ((data (ignore-errors (projectile-session--read-file file))))
+          ;; require a string root: a corrupt/hand-edited file with a
+          ;; non-string `:root' would otherwise crash the `sort' below and
+          ;; (via the startup handler's guard) silently disable all restore
+          (when-let* ((root (plist-get data :root))
+                      ((stringp root)))
+            (push root roots)))))
+    (sort roots #'string-lessp)))
 
 (defun projectile-session--frame-buffers ()
   "Return the distinct buffers shown in the selected frame's windows."
@@ -11049,12 +11090,61 @@ sessions were saved."
       (message "Saved %d project session%s" saved (if (= saved 1) "" "s")))
     saved))
 
+;;;###autoload
+(defun projectile-session-restore-all ()
+  "Reopen every saved project's session into its own tab.
+For each project with a session saved on disk (see
+`projectile-session--saved-roots'): when a tab for it is already open,
+leave it be rather than duplicating it; otherwise create a fresh project
+tab and restore the saved session into it.  A session whose files are all
+gone recreates nothing, so its just-created empty tab is closed again and
+it is not counted, keeping restore-all from littering the frame with empty
+tabs.  Tabs are re-resolved by root, never by a cons captured before a
+selection, since `tab-bar-select-tab' rebuilds cons cells as it switches.
+End on the first successfully restored project's tab (falling back to the
+starting tab when nothing was restored) rather than wherever the iteration
+left off.  When called interactively, report how many sessions were
+restored.  Return that count."
+  (interactive)
+  (let ((origin (projectile-session--current-tab-index))
+        (first-root nil)
+        (restored 0))
+    (dolist (root (projectile-session--saved-roots))
+      (unless (projectile-session--project-tab root)
+        (projectile-session--make-project-tab root)
+        (if (ignore-errors (projectile-session-restore root))
+            (progn
+              (setq restored (1+ restored))
+              (unless first-root (setq first-root root)))
+          ;; nothing recreated (the project's files are gone): drop the
+          ;; empty tab `--make-project-tab' just created and selected
+          (ignore-errors (tab-bar-close-tab)))))
+    ;; Land the user somewhere deterministic.  When we restored something,
+    ;; go to the first restored project; otherwise return to where we
+    ;; started (any tabs we made for stale sessions were closed again, so
+    ;; the starting index still points at the same tab).
+    (if first-root
+        (projectile-session--select-tab-by-root first-root)
+      (ignore-errors (tab-bar-select-tab origin)))
+    (when (called-interactively-p 'any)
+      (message "Restored %d project session%s" restored
+               (if (= restored 1) "" "s")))
+    restored))
+
 (defun projectile-session--autosave-on-kill ()
   "Save every open project's session when autosave is enabled.
 Wired onto `kill-emacs-hook'; the frame is going away, so the tab left
 selected by `projectile-session--save-all-tabs' does not matter."
   (when projectile-session-autosave
     (projectile-session--save-all-tabs)))
+
+(defun projectile-session--maybe-restore-on-startup ()
+  "Reopen all saved sessions at startup when configured to.
+Wired onto `emacs-startup-hook' while `projectile-session-mode' is on; the
+restore is gated on `projectile-session-restore-on-startup'.  Errors are
+swallowed so a restore problem can't abort the rest of Emacs startup."
+  (when projectile-session-restore-on-startup
+    (ignore-errors (projectile-session-restore-all))))
 
 ;;;###autoload
 (define-minor-mode projectile-session-mode
@@ -11094,6 +11184,13 @@ existing tabs untouched."
     (add-hook 'projectile-before-switch-project-hook
               #'projectile-session--maybe-autosave)
     (add-hook 'kill-emacs-hook #'projectile-session--autosave-on-kill)
+    ;; Restore-on-startup wiring.  The handler is gated on
+    ;; `projectile-session-restore-on-startup' and `emacs-startup-hook' fires
+    ;; once, right after init, so setting the mode plus the defcustom in init
+    ;; restores after startup; enabling the mode later simply never fires it.
+    ;; `add-hook' is idempotent for an `eq' function, so a double enable can't
+    ;; stack duplicates.
+    (add-hook 'emacs-startup-hook #'projectile-session--maybe-restore-on-startup)
     ;; Re-simplify a survivor's name when its same-named sibling tab is
     ;; closed.  `add-hook' is idempotent for an `eq' function, so a double
     ;; enable can't stack duplicates.
@@ -11109,6 +11206,8 @@ existing tabs untouched."
     (remove-hook 'projectile-before-switch-project-hook
                  #'projectile-session--maybe-autosave)
     (remove-hook 'kill-emacs-hook #'projectile-session--autosave-on-kill)
+    (remove-hook 'emacs-startup-hook
+                 #'projectile-session--maybe-restore-on-startup)
     (remove-hook 'tab-bar-tab-pre-close-functions
                  #'projectile-session--on-tab-close))))
 

--- a/test/projectile-session-test.el
+++ b/test/projectile-session-test.el
@@ -791,6 +791,254 @@
         (tab-bar-close-tab)
         (expect (length (tab-bar-tabs)) :to-equal (1- count))))))
 
+(describe "projectile-session--saved-roots"
+  (before-each
+    (setq projectile-session-test--dir (projectile-session-test--make-dir)))
+
+  (after-each
+    (when (and projectile-session-test--dir
+               (file-directory-p projectile-session-test--dir))
+      (delete-directory projectile-session-test--dir t)))
+
+  (it "collects saved roots in a stable order, skipping junk files"
+    (let ((tmp (make-temp-file "projectile-session-roots" nil ".txt")))
+      (let* ((projectile-session-directory projectile-session-test--dir)
+             (buf (find-file-noselect tmp)))
+        (unwind-protect
+            (progn
+              (delete-other-windows)
+              (switch-to-buffer buf)
+              ;; two real, current-version session files
+              (projectile-session-save "/proj/zeta/")
+              (projectile-session-save "/proj/alpha/")
+              ;; a file that isn't a readable session: must be skipped
+              (with-temp-file (expand-file-name "garbage.eld"
+                                                projectile-session-test--dir)
+                (insert "not ( a valid sexp"))
+              (expect (projectile-session--saved-roots)
+                      :to-equal '("/proj/alpha/" "/proj/zeta/")))
+          (when (buffer-live-p buf) (kill-buffer buf))
+          (delete-file tmp)))))
+
+  (it "returns nil when the session directory is absent"
+    (let ((projectile-session-directory
+           (expand-file-name "does-not-exist/" projectile-session-test--dir)))
+      (expect (projectile-session--saved-roots) :to-be nil)))
+
+  (it "skips a version-current file whose root is not a string"
+    (let ((projectile-session-directory projectile-session-test--dir))
+      ;; a corrupt/hand-edited file with a non-string :root must not crash the
+      ;; sort (which would silently disable all restore-on-startup)
+      (with-temp-file (expand-file-name "corrupt.eld" projectile-session-test--dir)
+        (prin1 (list :projectile-session-version projectile-session--format-version
+                     :root 42 :buffers nil :window-state nil)
+               (current-buffer)))
+      (expect (projectile-session--saved-roots) :to-be nil))))
+
+(describe "projectile-session-restore-all"
+  (before-each
+    (setq projectile-session-test--dir (projectile-session-test--make-dir))
+    (projectile-session-test--reset-tabs))
+
+  (after-each
+    (projectile-session-test--reset-tabs)
+    (when (and projectile-session-test--dir
+               (file-directory-p projectile-session-test--dir))
+      (delete-directory projectile-session-test--dir t)))
+
+  ;; Real-tab test: restore-all must reopen each saved session into its own
+  ;; tab, land the user on the first restored project, and put the right
+  ;; file back in each tab.  Building actual tabs (not mocked symbols) is
+  ;; what catches a cons-based selection going stale mid-loop.
+  (it "reopens each saved session into its own tab"
+    (let* ((projectile-session-directory projectile-session-test--dir)
+           (ta (make-temp-file "projectile-session-ra-a" nil ".txt"))
+           (tb (make-temp-file "projectile-session-ra-b" nil ".txt"))
+           (root-a "/proj/alpha/")
+           (root-b "/proj/beta/")
+           (ba (find-file-noselect ta))
+           (bb (find-file-noselect tb)))
+      (unwind-protect
+          (progn
+            ;; write a one-file session for each project
+            (delete-other-windows)
+            (switch-to-buffer ba)
+            (projectile-session-save root-a)
+            (switch-to-buffer bb)
+            (projectile-session-save root-b)
+            ;; tear everything down so restore genuinely recreates
+            (kill-buffer ba) (kill-buffer bb)
+            (projectile-session-test--reset-tabs)
+            (delete-other-windows)
+            (switch-to-buffer "*scratch*")
+            (expect (projectile-session-restore-all) :to-equal 2)
+            ;; a tab per project now exists
+            (expect (projectile-session--project-tab root-a) :to-be-truthy)
+            (expect (projectile-session--project-tab root-b) :to-be-truthy)
+            ;; landed on the first restored (sorted) project, alpha
+            (expect (projectile-session--tab-root
+                     (projectile-session--current-tab))
+                    :to-equal root-a)
+            ;; each tab holds its own file
+            (projectile-session--select-tab-by-root root-a)
+            (expect (mapcar (lambda (w) (buffer-file-name (window-buffer w)))
+                            (window-list nil 'nomini))
+                    :to-contain ta)
+            (projectile-session--select-tab-by-root root-b)
+            (expect (mapcar (lambda (w) (buffer-file-name (window-buffer w)))
+                            (window-list nil 'nomini))
+                    :to-contain tb))
+        (when (buffer-live-p ba) (kill-buffer ba))
+        (when (buffer-live-p bb) (kill-buffer bb))
+        (dolist (n (list (file-name-nondirectory ta)
+                         (file-name-nondirectory tb)))
+          (when (get-buffer n) (kill-buffer n)))
+        (delete-file ta)
+        (delete-file tb))))
+
+  (it "skips a project whose tab is already open, without duplicating it"
+    (let* ((projectile-session-directory projectile-session-test--dir)
+           (ta (make-temp-file "projectile-session-ra-open" nil ".txt"))
+           (root-a "/proj/open/")
+           (ba (find-file-noselect ta)))
+      (unwind-protect
+          (progn
+            (delete-other-windows)
+            (switch-to-buffer ba)
+            (projectile-session-save root-a)
+            (kill-buffer ba)
+            (projectile-session-test--reset-tabs)
+            ;; pre-open a tab for root-a; restore-all must leave it be
+            (projectile-session--make-project-tab root-a)
+            (expect (projectile-session-restore-all) :to-equal 0)
+            ;; exactly one tab is bound to root-a (no duplicate)
+            (expect (length (seq-filter
+                             (lambda (tab)
+                               (projectile-session--same-root-p
+                                (projectile-session--tab-root tab) root-a))
+                             (tab-bar-tabs)))
+                    :to-equal 1))
+        (when (buffer-live-p ba) (kill-buffer ba))
+        (when (get-buffer (file-name-nondirectory ta))
+          (kill-buffer (file-name-nondirectory ta)))
+        (delete-file ta))))
+
+  (it "closes the empty tab and skips a stale session whose files are gone"
+    (let* ((projectile-session-directory projectile-session-test--dir)
+           (ta (make-temp-file "projectile-session-ra-stale" nil ".txt"))
+           (root-a "/proj/stale/")
+           (ba (find-file-noselect ta)))
+      (unwind-protect
+          (progn
+            (delete-other-windows)
+            (switch-to-buffer ba)
+            (projectile-session-save root-a)
+            ;; the project's file is gone: nothing can be recreated
+            (kill-buffer ba)
+            (delete-file ta)
+            (projectile-session-test--reset-tabs)
+            (switch-to-buffer "*scratch*")
+            (let ((before (length (tab-bar-tabs))))
+              (expect (projectile-session-restore-all) :to-equal 0)
+              ;; no leftover empty tab, and none bound to the stale root
+              (expect (length (tab-bar-tabs)) :to-equal before)
+              (expect (projectile-session--project-tab root-a) :to-be nil)))
+        (when (buffer-live-p ba) (kill-buffer ba))
+        (when (get-buffer (file-name-nondirectory ta))
+          (kill-buffer (file-name-nondirectory ta)))
+        (when (file-exists-p ta) (delete-file ta)))))
+
+  (it "restores around a stale middle session and lands on the first live one"
+    (let* ((projectile-session-directory projectile-session-test--dir)
+           (ta (make-temp-file "projectile-session-ra-mid-a" nil ".txt"))
+           (tc (make-temp-file "projectile-session-ra-mid-c" nil ".txt"))
+           (tb (make-temp-file "projectile-session-ra-mid-b" nil ".txt"))
+           ;; sorted order is a < b < c; b will be the stale one in the middle
+           (root-a "/proj/aaa/")
+           (root-b "/proj/bbb/")
+           (root-c "/proj/ccc/")
+           (ba (find-file-noselect ta))
+           (bb (find-file-noselect tb))
+           (bc (find-file-noselect tc)))
+      (unwind-protect
+          (progn
+            (delete-other-windows)
+            (switch-to-buffer ba) (projectile-session-save root-a)
+            (switch-to-buffer bb) (projectile-session-save root-b)
+            (switch-to-buffer bc) (projectile-session-save root-c)
+            ;; b's file disappears; a and c stay restorable
+            (kill-buffer ba) (kill-buffer bb) (kill-buffer bc)
+            (delete-file tb)
+            (projectile-session-test--reset-tabs)
+            (switch-to-buffer "*scratch*")
+            (expect (projectile-session-restore-all) :to-equal 2)
+            ;; a and c reopened, the stale b left no tab
+            (expect (projectile-session--project-tab root-a) :to-be-truthy)
+            (expect (projectile-session--project-tab root-c) :to-be-truthy)
+            (expect (projectile-session--project-tab root-b) :to-be nil)
+            ;; landed on the first live project in sorted order, a
+            (expect (projectile-session--tab-root
+                     (projectile-session--current-tab))
+                    :to-equal root-a))
+        (dolist (b (list ba bb bc)) (when (buffer-live-p b) (kill-buffer b)))
+        (dolist (n (list (file-name-nondirectory ta)
+                         (file-name-nondirectory tc)))
+          (when (get-buffer n) (kill-buffer n)))
+        (when (file-exists-p ta) (delete-file ta))
+        (when (file-exists-p tc) (delete-file tc)))))
+
+  (it "reports the count when called interactively"
+    (spy-on 'projectile-session--saved-roots :and-return-value nil)
+    (spy-on 'message)
+    (call-interactively #'projectile-session-restore-all)
+    (expect 'message :to-have-been-called-with
+            "Restored %d project session%s" 0 "s")))
+
+(describe "projectile-session restore-on-startup"
+  (before-each
+    (projectile-session-test--reset-tabs))
+
+  (after-each
+    (when projectile-session-mode
+      (projectile-session-mode -1))
+    (projectile-session-test--reset-tabs))
+
+  (it "runs restore-all only when restore-on-startup is set"
+    (let ((projectile-session-restore-on-startup nil))
+      (spy-on 'projectile-session-restore-all)
+      (projectile-session--maybe-restore-on-startup)
+      (expect 'projectile-session-restore-all :not :to-have-been-called)
+      (setq projectile-session-restore-on-startup t)
+      (projectile-session--maybe-restore-on-startup)
+      (expect 'projectile-session-restore-all :to-have-been-called)))
+
+  (it "swallows an error out of the startup handler"
+    (let ((projectile-session-restore-on-startup t))
+      (spy-on 'projectile-session-restore-all
+              :and-call-fake (lambda () (error "boom")))
+      ;; must not propagate the error (would abort `emacs-startup-hook')
+      (expect (projectile-session--maybe-restore-on-startup) :not :to-throw)))
+
+  (it "adds and removes the startup hook with the mode"
+    (let ((projectile-switch-project-action 'projectile-find-file)
+          (emacs-startup-hook nil))
+      (spy-on 'projectile-project-root :and-return-value nil)
+      (projectile-session-mode 1)
+      (expect (memq 'projectile-session--maybe-restore-on-startup
+                    emacs-startup-hook)
+              :to-be-truthy)
+      ;; a double enable must not stack duplicates
+      (projectile-session-mode 1)
+      (expect (length (delq nil (mapcar
+                                 (lambda (h)
+                                   (eq h 'projectile-session--maybe-restore-on-startup))
+                                 emacs-startup-hook)))
+              :to-equal 1)
+      (projectile-session-mode -1)
+      (expect (memq 'projectile-session--maybe-restore-on-startup
+                    emacs-startup-hook)
+              :to-be nil))))
+
 (describe "projectile-session keybindings"
   (it "binds the w sub-prefix to the session commands"
     (expect (lookup-key projectile-command-map (kbd "w s"))
@@ -799,6 +1047,8 @@
             :to-equal #'projectile-session-save-all)
     (expect (lookup-key projectile-command-map (kbd "w r"))
             :to-equal #'projectile-session-restore)
+    (expect (lookup-key projectile-command-map (kbd "w R"))
+            :to-equal #'projectile-session-restore-all)
     (expect (lookup-key projectile-command-map (kbd "w f"))
             :to-equal #'projectile-session-forget)
     (expect (lookup-key projectile-command-map (kbd "w b"))


### PR DESCRIPTION
Builds on the per-project session work (#2065/#2066/#2067). `projectile-session-restore-all` reopens every project with a session on disk into its own tab, and `projectile-session-restore-on-startup` (default nil) runs it once on `emacs-startup-hook` so you get your projects back after Emacs starts.

It's idempotent, projects that already have a tab are left alone, and stale sessions whose files are gone are skipped with their empty tab closed so it doesn't litter the frame. Bound to `w R`, with the dispatch Session group, menu and usage.adoc kept in sync.
