### PR TITLE
Add case, regexp/literal, and filtering controls to the replace reviewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   * Matches are gathered in Emacs Lisp, so the regexp command honors full Emacs regexp syntax and the preview reflects exactly what will be edited, including unsaved changes in open buffers.
   * The `*projectile-replace*` results buffer shows a per-file, per-match preview where each match can be toggled on or off; `!` (or `C-c C-c`) applies just the enabled ones, in any order.
   * Applying edits each file from the bottom up, edits open buffers in place under a single undo step, writes closed files back preserving their coding system, and skips buffers modified since the search rather than corrupting them.
+  * The results buffer can reshape the search in place, each action re-scanning and re-rendering the previews:
+    * `c` toggles case sensitivity (seeded from `case-fold-search`).
+    * `x` toggles between literal and Emacs-regexp matching, refusing an invalid regexp rather than erroring.
+    * `k`/`d` keep or flush the matches whose line matches a regexp; `K`/`D` do the same by file name; re-searching with `g` restores anything filtered away.
+  * A status line at the top shows the term, replacement, match and file counts, the mode flags, and a note when the list has been filtered.
   * The commands are available from `projectile-dispatch` and the Projectile menu, and the match cap is customizable via `projectile-replace-max-matches`.
 * Add `projectile-session-mode`, a global minor mode that gives each project its own `tab-bar` tab.
   * Switching to a project selects its existing tab (restoring that project's window layout) when one is open, or otherwise opens a fresh tab named after the project and populated via `projectile-session-default-action`.

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -490,8 +490,20 @@ supports these keys:
 | kbd:[r]
 | Re-read the replacement string and refresh the previews.
 
+| kbd:[c]
+| Toggle case sensitivity and re-scan.
+
+| kbd:[x]
+| Toggle between literal and regexp matching and re-scan.
+
+| kbd:[k] / kbd:[d]
+| Keep / flush the matches whose line matches a regexp you type.
+
+| kbd:[K] / kbd:[D]
+| Keep / flush the matches whose file matches a regexp you type.
+
 | kbd:[g]
-| Re-run the search.
+| Re-run the search (also undoes any filtering).
 
 | kbd:[!] (or kbd:[C-c C-c])
 | Apply all enabled matches.
@@ -499,6 +511,24 @@ supports these keys:
 | kbd:[q]
 | Quit the results buffer.
 |===
+
+A status line at the top of the buffer shows the term, the replacement, the
+match and file counts, the active mode flags (`[literal]`/`[regexp]` and
+`[case-sensitive]`/`[ignore-case]`), and a `filtered` note once you've pruned
+the list.
+
+You can reshape the search without leaving the buffer. kbd:[c] toggles case
+sensitivity (seeded from `case-fold-search`) and kbd:[x] toggles literal
+versus Emacs-regexp matching, each re-scanning and re-rendering the previews
+in place; switching to regexp mode with a term that isn't a valid regexp is
+refused with a message rather than erroring. Because a toggle re-scans from
+scratch, it rebuilds the match list and every match comes back enabled, so
+any per-match include/exclude toggles you had set are reset (use the filter
+keys instead to prune while keeping the survivors' state). The filter keys
+narrow the shown matches, either by the match's line (kbd:[k] keep, kbd:[d]
+flush) or by its project-relative file name (kbd:[K] keep, kbd:[D] flush).
+Filtering only hides matches from the current list; re-running the search
+(kbd:[g]) gathers from scratch and brings them back.
 
 Applying edits a file's matches from the bottom up so earlier edits don't
 disturb later ones, edits already-open buffers in place under a single undo

--- a/projectile.el
+++ b/projectile.el
@@ -7988,6 +7988,12 @@ shown and a note is displayed."
   :group 'projectile
   :package-version '(projectile . "3.2.0"))
 
+(defface projectile-replace-header
+  '((t :inherit font-lock-keyword-face :weight bold))
+  "Face for the status header line of the replace results buffer."
+  :group 'projectile
+  :package-version '(projectile . "3.2.0"))
+
 (defvar projectile-replace-buffer-name "*projectile-replace*"
   "Name of the buffer used by `projectile-replace-review'.")
 
@@ -8019,10 +8025,17 @@ shown and a note is displayed."
   "Pending replacement string for the current results buffer.")
 (defvar-local projectile-replace--literal nil
   "Non-nil when the current results buffer is a literal (not regexp) replace.")
+(defvar-local projectile-replace--case-fold nil
+  "Non-nil when the current search ignores case.
+Initialized from `case-fold-search' at the first search and bound
+around every (re-)gather so it drives which matches are collected.")
 (defvar-local projectile-replace--matches nil
   "List of `projectile-replace--match' structs shown in the results buffer.")
 (defvar-local projectile-replace--truncated nil
   "Non-nil when the match list was capped at `projectile-replace-max-matches'.")
+(defvar-local projectile-replace--filtered nil
+  "Non-nil when the shown match list was pruned by a filter command.
+Re-searching (\\<projectile-replace-mode-map>\\[projectile-replace--refresh]) gathers from scratch and clears this.")
 
 (defun projectile-replace--expand (replacement groups literal)
   "Expand REPLACEMENT for a match whose group strings are GROUPS.
@@ -8118,15 +8131,22 @@ A file visited in a live buffer is scanned from that buffer's current
 text (so the preview matches what will be edited, even when the buffer
 has unsaved changes); otherwise it is read from disk into a temp buffer.
 Binary-looking and unreadable files are skipped."
-  (let ((buffer (get-file-buffer file)))
+  ;; Capture the intended `case-fold-search' (bound dynamically around the
+  ;; gather) before entering a live buffer, then re-establish it there: some
+  ;; major modes make `case-fold-search' buffer-local, which would otherwise
+  ;; shadow the dynamic binding and make the case toggle a no-op for that file.
+  (let ((buffer (get-file-buffer file))
+        (fold case-fold-search))
     (if buffer
         (with-current-buffer buffer
-          (projectile-replace--scan-region file buffer regexp budget))
+          (let ((case-fold-search fold))
+            (projectile-replace--scan-region file buffer regexp budget)))
       (condition-case nil
           (with-temp-buffer
             (insert-file-contents file)
             (unless (projectile-replace--binary-p)
-              (projectile-replace--scan-region file nil regexp budget)))
+              (let ((case-fold-search fold))
+                (projectile-replace--scan-region file nil regexp budget))))
         (error nil)))))
 
 (defun projectile-replace--gather (candidates regexp)
@@ -8145,15 +8165,17 @@ and `:truncated' (non-nil when the cap was hit)."
         (setq truncated t)))
     (list :matches all :truncated truncated)))
 
-(defun projectile-replace--candidates (term literal directory)
+(defun projectile-replace--candidates (term literal case-fold directory)
   "Return the files under DIRECTORY worth scanning for TERM.
-For a LITERAL search this narrows to files containing TERM (via
-`projectile-files-with-string') intersected with the project's
-ignore-aware file list; for a regexp search it is the whole
-ignore-aware file list, since grep tools can't honor Emacs regexps."
+For a case-sensitive LITERAL search this narrows to files containing
+TERM (via `projectile-files-with-string') intersected with the
+project's ignore-aware file list.  For a regexp search, or a
+case-insensitive literal search (where the case-sensitive grep tools
+would miss case-variant occurrences), it is the whole ignore-aware file
+list, since those searches can't be narrowed by an external grep."
   (let ((project-files (mapcar (lambda (f) (expand-file-name f directory))
                                (projectile-dir-files directory))))
-    (if literal
+    (if (and literal (not case-fold))
         (seq-filter (lambda (f) (member f project-files))
                     (projectile-files-with-string term directory))
       (seq-remove (lambda (f) (or (file-directory-p f) (not (file-exists-p f))))
@@ -8201,6 +8223,37 @@ struct under the `projectile-replace-match' text property."
          (line (concat indicator locator before highlight after "\n")))
     (propertize line 'projectile-replace-match m)))
 
+(defun projectile-replace--header-string ()
+  "Return the propertized status header for the results buffer.
+Shows the term, the replacement (or \"(none)\"), the match and file
+counts, the mode flags (regexp/literal and case), and a note when the
+list has been filtered.  The header carries no `projectile-replace-match'
+property, so match navigation skips it."
+  (let* ((matches projectile-replace--matches)
+         (nmatches (length matches))
+         (seen (make-hash-table :test 'equal))
+         (repl (if (and projectile-replace--replacement
+                        (not (string-empty-p projectile-replace--replacement)))
+                   (format "%S" projectile-replace--replacement)
+                 "(none)"))
+         nfiles flags)
+    (dolist (m matches)
+      (puthash (projectile-replace--match-file m) t seen))
+    (setq nfiles (hash-table-count seen)
+          flags (concat
+                 (if projectile-replace--literal "[literal]" "[regexp]")
+                 " "
+                 (if projectile-replace--case-fold
+                     "[ignore-case]" "[case-sensitive]")
+                 (if projectile-replace--filtered "  filtered" "")))
+    (propertize
+     (format "Replace %S with %s\n%d match%s in %d file%s  %s\n"
+             projectile-replace--term repl
+             nmatches (if (= nmatches 1) "" "es")
+             nfiles (if (= nfiles 1) "" "s")
+             flags)
+     'face 'projectile-replace-header)))
+
 (defun projectile-replace--render ()
   "Redraw the current results buffer from its buffer-local state."
   (let ((inhibit-read-only t)
@@ -8213,12 +8266,7 @@ struct under the `projectile-replace-match' text property."
     (dolist (m matches)
       (cl-incf (gethash (projectile-replace--match-file m) counts 0)))
     (erase-buffer)
-    (insert (propertize
-             (format "Replace (%s) %S with %S\n"
-                     (if literal "literal" "regexp")
-                     projectile-replace--term
-                     (or replacement ""))
-             'face 'bold))
+    (insert (projectile-replace--header-string))
     (insert (substitute-command-keys
              (concat "\\<projectile-replace-mode-map>"
                      "\\[projectile-replace--toggle] toggle  "
@@ -8227,7 +8275,11 @@ struct under the `projectile-replace-match' text property."
                      "\\[projectile-replace--apply] apply  "
                      "\\[projectile-replace--refresh] re-search  "
                      "\\[projectile-replace--visit] visit  "
-                     "\\[quit-window] quit\n\n")))
+                     "\\[quit-window] quit\n"
+                     "\\[projectile-replace--toggle-case] case  "
+                     "\\[projectile-replace--toggle-regexp] regexp/literal  "
+                     "\\[projectile-replace--keep-matches]/\\[projectile-replace--flush-matches] keep/flush line  "
+                     "\\[projectile-replace--keep-files]/\\[projectile-replace--flush-files] keep/flush file\n\n")))
     (if (null matches)
         (insert "No matches.\n")
       (dolist (m matches)
@@ -8355,16 +8407,117 @@ otherwise they are all enabled."
                      projectile-replace--replacement))
   (projectile-replace--render-preserve))
 
-(defun projectile-replace--refresh ()
-  "Re-run the search and redraw the results buffer."
-  (interactive)
-  (let* ((candidates (projectile-replace--candidates
+(defun projectile-replace--regather ()
+  "Re-run the search from scratch into the buffer-local match list.
+`case-fold-search' is bound to `projectile-replace--case-fold' so the
+scan honors the current case setting, and any active filter is cleared
+because the list is rebuilt from every match in the project.  Because the
+match list is rebuilt, every match comes back enabled: re-scanning (via
+`g', the case toggle, or the regexp toggle) resets any per-match include
+or exclude toggles you had set.  Use the filter commands instead to prune
+the list while preserving the survivors' state."
+  (let* ((case-fold-search projectile-replace--case-fold)
+         (candidates (projectile-replace--candidates
                       projectile-replace--term projectile-replace--literal
-                      projectile-replace--root))
+                      projectile-replace--case-fold projectile-replace--root))
          (result (projectile-replace--gather candidates projectile-replace--search)))
     (setq projectile-replace--matches (plist-get result :matches)
-          projectile-replace--truncated (plist-get result :truncated))
-    (projectile-replace--render)))
+          projectile-replace--truncated (plist-get result :truncated)
+          projectile-replace--filtered nil)))
+
+(defun projectile-replace--refresh ()
+  "Re-run the search and redraw the results buffer.
+This gathers from scratch, so any filtering is undone and matches
+removed by a filter command reappear."
+  (interactive)
+  (projectile-replace--regather)
+  (projectile-replace--render))
+
+(defun projectile-replace--toggle-case ()
+  "Toggle case sensitivity of the search, re-scan, and re-render."
+  (interactive)
+  (setq projectile-replace--case-fold (not projectile-replace--case-fold))
+  (projectile-replace--regather)
+  (projectile-replace--render)
+  (message "%s"
+           (projectile-prepend-project-name
+            (if projectile-replace--case-fold
+                "search now ignores case" "search now case-sensitive"))))
+
+(defun projectile-replace--valid-regexp-p (regexp)
+  "Return non-nil when REGEXP is a valid Emacs regexp."
+  (condition-case nil
+      (progn (string-match-p regexp "") t)
+    (error nil)))
+
+(defun projectile-replace--toggle-regexp ()
+  "Toggle between literal and regexp search, re-scan, and re-render.
+Switching to regexp mode with a term that is not a valid regexp is
+refused with a message so the buffer stays usable rather than erroring."
+  (interactive)
+  (let ((new-literal (not projectile-replace--literal)))
+    (if (and (not new-literal)
+             (not (projectile-replace--valid-regexp-p projectile-replace--term)))
+        (message "%s"
+                 (projectile-prepend-project-name
+                  (format "%S is not a valid regexp; staying literal"
+                          projectile-replace--term)))
+      (setq projectile-replace--literal new-literal
+            projectile-replace--search (if new-literal
+                                           (regexp-quote projectile-replace--term)
+                                         projectile-replace--term))
+      (projectile-replace--regather)
+      (projectile-replace--render)
+      (message "%s"
+               (projectile-prepend-project-name
+                (if new-literal "literal search" "regexp search"))))))
+
+(defun projectile-replace--filter-by (predicate)
+  "Keep only matches satisfying PREDICATE, mark the list filtered, re-render.
+The removed matches are recoverable by re-searching (\\<projectile-replace-mode-map>\\[projectile-replace--refresh]), which
+gathers from scratch."
+  (setq projectile-replace--matches
+        (cl-remove-if-not predicate projectile-replace--matches)
+        projectile-replace--filtered t)
+  (projectile-replace--render))
+
+(defun projectile-replace--line-matches-p (m regexp)
+  "Return non-nil when match M's context line matches REGEXP.
+Honors the buffer's case setting."
+  (let ((case-fold-search projectile-replace--case-fold))
+    (string-match-p regexp (projectile-replace--match-context m))))
+
+(defun projectile-replace--file-matches-p (m regexp)
+  "Return non-nil when match M's project-relative file matches REGEXP.
+Honors the buffer's case setting."
+  (let ((case-fold-search projectile-replace--case-fold))
+    (string-match-p regexp
+                    (file-relative-name (projectile-replace--match-file m)
+                                        projectile-replace--root))))
+
+(defun projectile-replace--keep-matches (regexp)
+  "Keep only matches whose context line matches REGEXP."
+  (interactive (list (read-regexp "Keep matches whose line matches regexp")))
+  (projectile-replace--filter-by
+   (lambda (m) (projectile-replace--line-matches-p m regexp))))
+
+(defun projectile-replace--flush-matches (regexp)
+  "Remove matches whose context line matches REGEXP."
+  (interactive (list (read-regexp "Flush matches whose line matches regexp")))
+  (projectile-replace--filter-by
+   (lambda (m) (not (projectile-replace--line-matches-p m regexp)))))
+
+(defun projectile-replace--keep-files (regexp)
+  "Keep only matches whose project-relative file matches REGEXP."
+  (interactive (list (read-regexp "Keep matches whose file matches regexp")))
+  (projectile-replace--filter-by
+   (lambda (m) (projectile-replace--file-matches-p m regexp))))
+
+(defun projectile-replace--flush-files (regexp)
+  "Remove matches whose project-relative file matches REGEXP."
+  (interactive (list (read-regexp "Flush matches whose file matches regexp")))
+  (projectile-replace--filter-by
+   (lambda (m) (not (projectile-replace--file-matches-p m regexp)))))
 
 ;;; Applying the enabled matches
 
@@ -8499,6 +8652,12 @@ unsaved changes is edited but left for the user to save."
     (define-key map (kbd "SPC") #'projectile-replace--toggle)
     (define-key map (kbd "f") #'projectile-replace--toggle-file)
     (define-key map (kbd "r") #'projectile-replace--set-replacement)
+    (define-key map (kbd "c") #'projectile-replace--toggle-case)
+    (define-key map (kbd "x") #'projectile-replace--toggle-regexp)
+    (define-key map (kbd "k") #'projectile-replace--keep-matches)
+    (define-key map (kbd "d") #'projectile-replace--flush-matches)
+    (define-key map (kbd "K") #'projectile-replace--keep-files)
+    (define-key map (kbd "D") #'projectile-replace--flush-files)
     (define-key map (kbd "!") #'projectile-replace--apply)
     (define-key map (kbd "C-c C-c") #'projectile-replace--apply)
     (define-key map (kbd "g") #'projectile-replace--refresh)
@@ -8508,6 +8667,15 @@ unsaved changes is edited but left for the user to save."
 
 (define-derived-mode projectile-replace-mode special-mode "Projectile-Replace"
   "Major mode for reviewing and applying a project-wide replacement.
+
+Each match starts enabled and can be toggled on or off; only the
+enabled matches are applied.  Besides toggling and applying, the search
+itself can be reshaped without leaving the buffer: toggle case
+sensitivity (\\<projectile-replace-mode-map>\\[projectile-replace--toggle-case]) or literal/regexp matching (\\[projectile-replace--toggle-regexp]) to re-scan, and
+narrow the shown matches by keeping or flushing them against a regexp
+matched on the context line (\\[projectile-replace--keep-matches] / \\[projectile-replace--flush-matches]) or the file name
+(\\[projectile-replace--keep-files] / \\[projectile-replace--flush-files]).  Re-searching (\\[projectile-replace--refresh]) rebuilds the list from scratch,
+undoing any filtering.
 
 \\{projectile-replace-mode-map}"
   (setq-local truncate-lines t)
@@ -8526,7 +8694,8 @@ Emacs regexp and the replacement may reference capture groups."
                        (projectile-prepend-project-name
                         (format "Replace %s with: " term))))
          (regexp (if literal (regexp-quote term) term))
-         (candidates (projectile-replace--candidates term literal root))
+         (case-fold case-fold-search)
+         (candidates (projectile-replace--candidates term literal case-fold root))
          (result (projectile-replace--gather candidates regexp))
          (matches (plist-get result :matches))
          (truncated (plist-get result :truncated)))
@@ -8541,8 +8710,10 @@ Emacs regexp and the replacement may reference capture groups."
                 projectile-replace--search regexp
                 projectile-replace--replacement replacement
                 projectile-replace--literal literal
+                projectile-replace--case-fold case-fold
                 projectile-replace--matches matches
-                projectile-replace--truncated truncated)
+                projectile-replace--truncated truncated
+                projectile-replace--filtered nil)
           (projectile-replace--render))
         (when truncated
           (message "projectile-replace: showing the first %d matches"

--- a/test/projectile-replace-review-test.el
+++ b/test/projectile-replace-review-test.el
@@ -112,6 +112,14 @@ REGEXP-P selects `projectile-replace-regexp-review'."
   (with-current-buffer buf
     (projectile-replace--apply)))
 
+(defun projectile-replace-review-test--header (buf)
+  "Return the two-line status header of results buffer BUF."
+  (with-current-buffer buf
+    (buffer-substring-no-properties (point-min)
+                                    (save-excursion
+                                      (goto-char (point-min))
+                                      (line-end-position 2)))))
+
 (describe "projectile-replace-review (literal)"
   (it "finds every literal match and applies them to a file on disk"
     (projectile-replace-review-test--with-project
@@ -324,5 +332,226 @@ REGEXP-P selects `projectile-replace-regexp-review'."
           (expect (buffer-modified-p) :to-be-truthy))
         (expect (projectile-replace-review-test--disk "u.txt")
                 :to-equal "foo mid\n")))))
+
+(describe "projectile-replace-review case-sensitivity toggle"
+  (it "flips which matches are found and re-renders"
+    (projectile-replace-review-test--with-project
+        (("case.txt" . "Foo foo FOO\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (with-current-buffer buf
+          ;; `case-fold-search' is t in the sandbox, so all three case
+          ;; variants match to start with
+          (expect projectile-replace--case-fold :to-be-truthy)
+          (expect (length projectile-replace--matches) :to-equal 3)
+          (projectile-replace--toggle-case)
+          (expect projectile-replace--case-fold :to-be nil)
+          (expect (length projectile-replace--matches) :to-equal 1)
+          (expect (projectile-replace--match-string
+                   (car projectile-replace--matches))
+                  :to-equal "foo")
+          ;; toggling back restores the case-insensitive match set
+          (projectile-replace--toggle-case)
+          (expect (length projectile-replace--matches) :to-equal 3)))))
+
+  (it "applies only the case-sensitive survivors after a toggle"
+    (projectile-replace-review-test--with-project
+        (("s.txt" . "Foo foo\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (with-current-buffer buf
+          (projectile-replace--toggle-case))
+        (projectile-replace-review-test--apply buf)
+        ;; only the lowercase `foo' is replaced; `Foo' is left alone
+        (expect (projectile-replace-review-test--disk "s.txt")
+                :to-equal "Foo bar\n"))))
+
+  (it "still excludes ignored files on the case-insensitive fallback path"
+    ;; the case-insensitive literal search scans the full file list rather
+    ;; than the grep narrowing, so it must still honor .projectile ignores
+    (projectile-replace-review-test--with-project
+        ((".projectile" . "-secret\n")
+         ("keep.txt" . "FOO\n")
+         ("secret/hide.txt" . "FOO\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      ;; case-insensitive (sandbox default) literal search for `foo' finds
+      ;; `FOO' in keep.txt but never in the ignored secret/ tree
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (with-current-buffer buf
+          (expect (length projectile-replace--matches) :to-equal 1)
+          (expect (cl-some (lambda (m)
+                             (string-match-p
+                              "secret"
+                              (projectile-replace--match-file m)))
+                           projectile-replace--matches)
+                  :to-be nil))
+        (projectile-replace-review-test--apply buf)
+        (expect (projectile-replace-review-test--disk "keep.txt")
+                :to-equal "bar\n")
+        (expect (projectile-replace-review-test--disk "secret/hide.txt")
+                :to-equal "FOO\n"))))
+
+  (it "re-enables all matches when re-scanning (documented reset)"
+    (projectile-replace-review-test--with-project
+        (("e.txt" . "foo foo foo\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (with-current-buffer buf
+          ;; disable one match, then toggle case: re-scan rebuilds the list,
+          ;; so every match comes back enabled (the documented behavior)
+          (setf (projectile-replace--match-enabled
+                 (car projectile-replace--matches))
+                nil)
+          (projectile-replace--toggle-case)
+          (projectile-replace--toggle-case)
+          (expect (cl-every #'projectile-replace--match-enabled
+                            projectile-replace--matches)
+                  :to-be-truthy))))))
+
+(describe "projectile-replace-review regexp/literal toggle"
+  (it "re-scans and changes the count for a term with metacharacters"
+    (projectile-replace-review-test--with-project
+        (("meta.txt" . "a.b axb a.b\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "a.b" "Z")))
+        (with-current-buffer buf
+          (expect projectile-replace--literal :to-be-truthy)
+          ;; literal: only the two real `a.b' occurrences
+          (expect (length projectile-replace--matches) :to-equal 2)
+          (projectile-replace--toggle-regexp)
+          (expect projectile-replace--literal :to-be nil)
+          (expect projectile-replace--search :to-equal "a.b")
+          ;; regexp: the `.' now also matches the `x' in `axb'
+          (expect (length projectile-replace--matches) :to-equal 3)))))
+
+  (it "refuses an invalid regexp and stays literal without erroring"
+    (projectile-replace-review-test--with-project
+        (("br.txt" . "foo[bar\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo[" "X")))
+        (with-current-buffer buf
+          (expect projectile-replace--literal :to-be-truthy)
+          (expect (length projectile-replace--matches) :to-equal 1)
+          ;; `foo[' is not a valid regexp; the toggle must not error
+          (projectile-replace--toggle-regexp)
+          (expect projectile-replace--literal :to-be-truthy)
+          (expect (length projectile-replace--matches) :to-equal 1))))))
+
+(describe "projectile-replace-review match filtering"
+  (it "keeps only matches whose line matches and applies just those"
+    (projectile-replace-review-test--with-project
+        (("f.txt" . "keep foo here\ndrop foo there\nkeep foo again\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (with-current-buffer buf
+          (expect (length projectile-replace--matches) :to-equal 3)
+          (projectile-replace--keep-matches "keep")
+          (expect (length projectile-replace--matches) :to-equal 2)
+          (expect projectile-replace--filtered :to-be-truthy))
+        (projectile-replace-review-test--apply buf)
+        (expect (projectile-replace-review-test--disk "f.txt")
+                :to-equal "keep bar here\ndrop foo there\nkeep bar again\n"))))
+
+  (it "flushes matches whose line matches and applies the survivors"
+    (projectile-replace-review-test--with-project
+        (("f.txt" . "keep foo here\ndrop foo there\nkeep foo again\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (with-current-buffer buf
+          (projectile-replace--flush-matches "drop")
+          (expect (length projectile-replace--matches) :to-equal 2))
+        (projectile-replace-review-test--apply buf)
+        (expect (projectile-replace-review-test--disk "f.txt")
+                :to-equal "keep bar here\ndrop foo there\nkeep bar again\n"))))
+
+  (it "restores a filtered-away match on re-search"
+    (projectile-replace-review-test--with-project
+        (("f.txt" . "keep foo here\ndrop foo there\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (with-current-buffer buf
+          (expect (length projectile-replace--matches) :to-equal 2)
+          (projectile-replace--flush-matches "drop")
+          (expect (length projectile-replace--matches) :to-equal 1)
+          (expect projectile-replace--filtered :to-be-truthy)
+          ;; re-search gathers from scratch, bringing the flushed match back
+          (projectile-replace--refresh)
+          (expect (length projectile-replace--matches) :to-equal 2)
+          (expect projectile-replace--filtered :to-be nil))))))
+
+(describe "projectile-replace-review file filtering"
+  (it "keeps only matches whose file matches the regexp"
+    (projectile-replace-review-test--with-project
+        (("keep.txt" . "foo\n")
+         ("lib/skip.txt" . "foo\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (with-current-buffer buf
+          (expect (length projectile-replace--matches) :to-equal 2)
+          (projectile-replace--keep-files "keep")
+          (expect (length projectile-replace--matches) :to-equal 1)
+          (expect (file-name-nondirectory
+                   (projectile-replace--match-file
+                    (car projectile-replace--matches)))
+                  :to-equal "keep.txt"))
+        (projectile-replace-review-test--apply buf)
+        (expect (projectile-replace-review-test--disk "keep.txt")
+                :to-equal "bar\n")
+        (expect (projectile-replace-review-test--disk "lib/skip.txt")
+                :to-equal "foo\n"))))
+
+  (it "flushes matches whose project-relative path matches the regexp"
+    (projectile-replace-review-test--with-project
+        (("keep.txt" . "foo\n")
+         ("lib/skip.txt" . "foo\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (with-current-buffer buf
+          ;; matches the directory component of the relative path
+          (projectile-replace--flush-files "lib/")
+          (expect (length projectile-replace--matches) :to-equal 1)
+          (expect (file-name-nondirectory
+                   (projectile-replace--match-file
+                    (car projectile-replace--matches)))
+                  :to-equal "keep.txt"))
+        (projectile-replace-review-test--apply buf)
+        (expect (projectile-replace-review-test--disk "lib/skip.txt")
+                :to-equal "foo\n")))))
+
+(describe "projectile-replace-review status header"
+  (it "reflects the mode flags and updates when they toggle"
+    (projectile-replace-review-test--with-project
+        (("h.txt" . "foo\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (let ((header (projectile-replace-review-test--header buf)))
+          (expect header :to-match "Replace \"foo\" with \"bar\"")
+          (expect header :to-match "\\[literal\\]")
+          (expect header :to-match "\\[ignore-case\\]"))
+        (with-current-buffer buf (projectile-replace--toggle-case))
+        (expect (projectile-replace-review-test--header buf)
+                :to-match "\\[case-sensitive\\]")
+        (with-current-buffer buf (projectile-replace--toggle-regexp))
+        (expect (projectile-replace-review-test--header buf)
+                :to-match "\\[regexp\\]"))))
+
+  (it "shows (none) when there is no replacement yet"
+    (projectile-replace-review-test--with-project
+        (("h.txt" . "foo\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "")))
+        (expect (projectile-replace-review-test--header buf)
+                :to-match "with (none)"))))
+
+  (it "notes when the list has been filtered"
+    (projectile-replace-review-test--with-project
+        (("h.txt" . "keep foo\ndrop foo\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (expect (projectile-replace-review-test--header buf)
+                :not :to-match "filtered")
+        (with-current-buffer buf (projectile-replace--flush-matches "drop"))
+        (expect (projectile-replace-review-test--header buf)
+                :to-match "filtered")))))
 
 ;;; projectile-replace-review-test.el ends here


### PR DESCRIPTION
Follow-up to #2069, adding interactive controls to the replace results buffer: `c` toggles case sensitivity, `x` toggles literal vs Emacs regexp (an invalid regexp is refused with a message), and `k`/`d`/`K`/`D` keep or flush matches by line or by file, color-rg style. A two-line status header shows the term, replacement, counts and the current flags.

Two things worth knowing: filtering only hides matches from the current list, so re-running the search with `g` brings them back and also resets the per-match toggles. And case-insensitive literal search scans the full ignore-aware file list rather than the case-sensitive grep narrowing, so it finds case variants while still honoring `.projectile` ignores. The write-back path is unchanged.
