### PR TITLE
Add grep-mode export to the reviewable replace UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     * `x` toggles between literal and Emacs-regexp matching, refusing an invalid regexp rather than erroring.
     * `k`/`d` keep or flush the matches whose line matches a regexp; `K`/`D` do the same by file name; re-searching with `g` restores anything filtered away.
   * A status line at the top shows the term, replacement, match and file counts, the mode flags, and a note when the list has been filtered.
+  * `e` exports the shown matches to a `grep-mode` buffer so wgrep or Emacs 31's `grep-edit-mode` can turn them editable and write back; wgrep stays an optional integration and `!` remains the no-dependency apply path.
   * The commands are available from `projectile-dispatch` and the Projectile menu, and the match cap is customizable via `projectile-replace-max-matches`.
 * Add `projectile-session-mode`, a global minor mode that gives each project its own `tab-bar` tab.
   * Switching to a project selects its existing tab (restoring that project's window layout) when one is open, or otherwise opens a fresh tab named after the project and populated via `projectile-session-default-action`.

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -508,6 +508,9 @@ supports these keys:
 | kbd:[!] (or kbd:[C-c C-c])
 | Apply all enabled matches.
 
+| kbd:[e]
+| Export the enabled matches to a `grep-mode` buffer for wgrep / `grep-edit-mode`.
+
 | kbd:[q]
 | Quit the results buffer.
 |===
@@ -536,6 +539,16 @@ step (and saves them), and writes closed files back to disk preserving their
 coding system. A buffer that was modified after the search is skipped rather
 than risk a bad edit; re-run the search (kbd:[g]) to pick up its current
 state. Very large searches are capped at `projectile-replace-max-matches`.
+
+kbd:[!] applies the enabled matches with no external dependency. If you'd
+rather edit the results as text, kbd:[e] exports the enabled matches (the
+same set kbd:[!] would act on) to a `+*projectile-replace-grep*+` buffer in `grep-mode`,
+with standard `RELPATH:LINE:CONTEXT` lines navigable with `next-error` and
+kbd:[RET]. This is the bridge to https://github.com/mhayashi1120/Emacs-wgrep[wgrep]
+(kbd:[C-c C-p] to make it editable, then kbd:[C-c C-c] to write back) or
+Emacs 31's `grep-edit-mode`. wgrep is an optional integration, not a
+dependency; after exporting, Projectile tells you which workflow is
+available based on what you have installed.
 
 == Customizing Projectile's Keybindings
 

--- a/projectile.el
+++ b/projectile.el
@@ -8273,6 +8273,7 @@ property, so match navigation skips it."
                      "\\[projectile-replace--toggle-file] toggle file  "
                      "\\[projectile-replace--set-replacement] set replacement  "
                      "\\[projectile-replace--apply] apply  "
+                     "\\[projectile-replace--export] export  "
                      "\\[projectile-replace--refresh] re-search  "
                      "\\[projectile-replace--visit] visit  "
                      "\\[quit-window] quit\n"
@@ -8641,6 +8642,77 @@ unsaved changes is edited but left for the user to save."
                         ""))))
     (projectile-replace--refresh)))
 
+;;; Exporting to a grep-mode buffer for wgrep / grep-edit-mode
+
+(defvar projectile-replace-grep-buffer-name "*projectile-replace-grep*"
+  "Name of the `grep-mode' buffer produced by `projectile-replace--export'.")
+
+(defun projectile-replace--grep-line (m root)
+  "Format match M as a RELPATH:LINE:CONTEXT grep hit relative to ROOT."
+  (format "%s:%d:%s"
+          (file-relative-name (projectile-replace--match-file m) root)
+          (projectile-replace--match-line m)
+          (projectile-replace--match-context m)))
+
+(defun projectile-replace--export-guidance ()
+  "Message how to make the exported grep buffer editable.
+The wording adapts to what's installed: wgrep, Emacs 31's
+`grep-edit-mode', or neither.  Returns the message string."
+  (let ((msg (projectile-prepend-project-name
+              (cond
+               ((fboundp 'wgrep-change-to-wgrep-mode)
+                "exported to grep buffer; press C-c C-p to edit with wgrep, then C-c C-c to write back")
+               ((fboundp 'grep-edit-mode)
+                "exported to grep buffer; run M-x grep-edit-mode to edit, then C-c C-c to write back")
+               (t
+                "exported to a read-only grep buffer for navigation; install wgrep from MELPA to edit and write back")))))
+    (message "%s" msg)
+    msg))
+
+(defun projectile-replace--export ()
+  "Export the enabled matches to a `grep-mode' buffer for editing with wgrep.
+Renders the matches Projectile's own apply command would act on (the
+enabled matches from the reviewed and filtered list; ones toggled off are
+excluded, just as they are by apply) as standard RELPATH:LINE:CONTEXT grep
+hits in a `*projectile-replace-grep*' buffer whose `default-directory' is
+the project root, so the relative paths resolve.  The buffer is a real
+`grep-mode' buffer navigable with `next-error' and RET, so wgrep
+(`wgrep-change-to-wgrep-mode', bound to \\`C-c C-p') or Emacs 31's
+`grep-edit-mode' can turn it editable and write your edits back to the
+files.  This is the bridge for people who prefer the grep/wgrep workflow;
+Projectile's own apply command
+(\\<projectile-replace-mode-map>\\[projectile-replace--apply]) is the no-dependency path and needs no external package."
+  (interactive)
+  (require 'grep)
+  (let ((matches (cl-remove-if-not #'projectile-replace--match-enabled
+                                   projectile-replace--matches))
+        (root projectile-replace--root)
+        (buf (get-buffer-create projectile-replace-grep-buffer-name)))
+    (when (null matches)
+      (user-error "No enabled matches to export"))
+    (with-current-buffer buf
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (setq default-directory root)
+        (insert (format "-*- mode: grep; default-directory: %S -*-\n\n" root))
+        ;; No colon before a value here: the search term could be `10:30' and
+        ;; would otherwise parse as a phantom `file:line:' grep hit.
+        (insert (format "Projectile replace  (%d match%s)\n\n"
+                        (length matches)
+                        (if (= (length matches) 1) "" "es")))
+        (dolist (m matches)
+          (insert (projectile-replace--grep-line m root) "\n"))
+        (insert "\nProjectile replace export finished\n"))
+      (grep-mode)
+      ;; keep the root as default-directory so the relative hits resolve
+      (setq default-directory root)
+      ;; let wgrep hook up its keys if the user has it; strictly optional
+      (when (fboundp 'wgrep-setup) (wgrep-setup))
+      (goto-char (point-min)))
+    (pop-to-buffer buf)
+    (projectile-replace--export-guidance)
+    buf))
+
 (defvar projectile-replace-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "RET") #'projectile-replace--visit)
@@ -8658,6 +8730,7 @@ unsaved changes is edited but left for the user to save."
     (define-key map (kbd "d") #'projectile-replace--flush-matches)
     (define-key map (kbd "K") #'projectile-replace--keep-files)
     (define-key map (kbd "D") #'projectile-replace--flush-files)
+    (define-key map (kbd "e") #'projectile-replace--export)
     (define-key map (kbd "!") #'projectile-replace--apply)
     (define-key map (kbd "C-c C-c") #'projectile-replace--apply)
     (define-key map (kbd "g") #'projectile-replace--refresh)
@@ -8676,6 +8749,11 @@ narrow the shown matches by keeping or flushing them against a regexp
 matched on the context line (\\[projectile-replace--keep-matches] / \\[projectile-replace--flush-matches]) or the file name
 (\\[projectile-replace--keep-files] / \\[projectile-replace--flush-files]).  Re-searching (\\[projectile-replace--refresh]) rebuilds the list from scratch,
 undoing any filtering.
+
+Applying with \\[projectile-replace--apply] needs no external package.  If you prefer the
+grep/wgrep workflow, \\[projectile-replace--export] exports the shown matches to a `grep-mode'
+buffer that wgrep or Emacs 31's `grep-edit-mode' can turn editable and
+write back to the files.
 
 \\{projectile-replace-mode-map}"
   (setq-local truncate-lines t)

--- a/test/projectile-replace-review-test.el
+++ b/test/projectile-replace-review-test.el
@@ -554,4 +554,119 @@ REGEXP-P selects `projectile-replace-regexp-review'."
         (expect (projectile-replace-review-test--header buf)
                 :to-match "filtered")))))
 
+(defun projectile-replace-review-test--export (buf)
+  "Export results buffer BUF to a grep buffer and return that grep buffer."
+  (with-current-buffer buf
+    (cl-letf (((symbol-function 'pop-to-buffer) #'ignore))
+      (projectile-replace--export))))
+
+(describe "projectile-replace-review export to grep-mode"
+  (it "renders the shown matches as a navigable grep-mode buffer"
+    (projectile-replace-review-test--with-project
+        (("a.txt" . "foo one foo\n")
+         ("lib/b.txt" . "start foo end\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let* ((buf (projectile-replace-review-test--run "foo" "bar"))
+             (gbuf (projectile-replace-review-test--export buf)))
+        (unwind-protect
+            (with-current-buffer gbuf
+              ;; it is a real grep-mode buffer rooted at the project
+              (expect major-mode :to-equal 'grep-mode)
+              (expect (file-truename default-directory)
+                      :to-equal (file-truename
+                                 (buffer-local-value
+                                  'projectile-replace--root buf)))
+              ;; every shown match appears as a RELPATH:LINE: grep hit
+              (let ((text (buffer-string)))
+                (expect text :to-match "^a\\.txt:1:foo one foo$")
+                (expect text :to-match "^lib/b\\.txt:1:start foo end$"))
+              ;; the lines are recognized as grep hits, not inert text
+              (goto-char (point-min))
+              (compilation-next-error 1)
+              (expect (get-text-property (point) 'compilation-message)
+                      :not :to-be nil)
+              (expect (buffer-substring-no-properties
+                       (line-beginning-position) (line-end-position))
+                      :to-match "\\`a\\.txt:1:"))
+          (kill-buffer gbuf)))))
+
+  (it "exports only the filtered (shown) matches, not the removed ones"
+    (projectile-replace-review-test--with-project
+        (("keep.txt" . "keep foo\n")
+         ("drop.txt" . "drop foo\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (with-current-buffer buf (projectile-replace--flush-files "drop"))
+        (let ((gbuf (projectile-replace-review-test--export buf)))
+          (unwind-protect
+              (with-current-buffer gbuf
+                (let ((text (buffer-string)))
+                  (expect text :to-match "^keep\\.txt:1:")
+                  (expect text :not :to-match "drop\\.txt")))
+            (kill-buffer gbuf))))))
+
+  (it "errors when there are no matches to export"
+    (projectile-replace-review-test--with-project
+        (("z.txt" . "foo\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (with-current-buffer buf
+          (setq projectile-replace--matches nil)
+          (expect (projectile-replace--export) :to-throw 'user-error)))))
+
+  (it "excludes matches toggled off, matching what apply would do"
+    (projectile-replace-review-test--with-project
+        (("e.txt" . "foo\nfoo\nfoo\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        (with-current-buffer buf
+          ;; disable the first (line 1) match
+          (setf (projectile-replace--match-enabled
+                 (car projectile-replace--matches))
+                nil))
+        (let ((gbuf (projectile-replace-review-test--export buf)))
+          (unwind-protect
+              (with-current-buffer gbuf
+                (let ((text (buffer-string)))
+                  ;; the disabled line-1 match is gone; the enabled ones remain
+                  (expect text :not :to-match "^e\\.txt:1:")
+                  (expect text :to-match "^e\\.txt:2:")
+                  (expect text :to-match "^e\\.txt:3:")))
+            (kill-buffer gbuf))))))
+
+  (it "does not create a phantom grep hit for a numeric term like 10:30"
+    (projectile-replace-review-test--with-project
+        (("t.txt" . "before 10:30 after\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      (let ((buf (projectile-replace-review-test--run "10:30" "NOON")))
+        (let ((gbuf (projectile-replace-review-test--export buf)))
+          (unwind-protect
+              (with-current-buffer gbuf
+                ;; the header carries no colon, so the term can't parse as a
+                ;; bogus `file:line:' hit; the first real hit is t.txt
+                (expect (buffer-string) :not :to-match "Projectile replace:")
+                (goto-char (point-min))
+                (compilation-next-error 1)
+                (expect (buffer-substring-no-properties
+                         (line-beginning-position) (line-end-position))
+                        :to-match "\\`t\\.txt:1:"))
+            (kill-buffer gbuf)))))))
+
+(describe "projectile-replace export guidance"
+  (it "points at wgrep when wgrep-change-to-wgrep-mode is available"
+    (cl-letf (((symbol-function 'wgrep-change-to-wgrep-mode) #'ignore))
+      (expect (projectile-replace--export-guidance) :to-match "C-c C-p")))
+
+  (it "points at grep-edit-mode when only that is available"
+    (cl-letf (((symbol-function 'wgrep-change-to-wgrep-mode) nil)
+              ((symbol-function 'grep-edit-mode) #'ignore))
+      (expect (projectile-replace--export-guidance) :to-match "grep-edit-mode")))
+
+  (it "falls back to a read-only note pointing at MELPA otherwise"
+    (cl-letf (((symbol-function 'wgrep-change-to-wgrep-mode) nil)
+              ((symbol-function 'grep-edit-mode) nil))
+      (let ((msg (projectile-replace--export-guidance)))
+        (expect msg :to-match "read-only")
+        (expect msg :to-match "MELPA")))))
+
 ;;; projectile-replace-review-test.el ends here


### PR DESCRIPTION
Last piece of the reviewable find-and-replace UI (after #2069/#2070): `e` exports the enabled matches into a `*projectile-replace-grep*` buffer. It's a real `grep-mode` buffer with standard `RELPATH:LINE:CONTEXT` lines rooted at the project, so `next-error`/`RET` work and wgrep or Emacs 31's `grep-edit-mode` can make it editable and write your edits back.

Integration is soft on purpose: no new `Package-Requires`, no `require` of wgrep, every `wgrep-*`/`grep-edit-mode` reference behind `fboundp`, and a guidance message that adapts to what you have installed. Projectile's own `!` stays the dependency-free path.
