### PR TITLE
Add a reviewable read-only project search UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### New features
 
+* Add reviewable read-only search commands, a search-only sibling of the reviewable replace UI.
+  * `projectile-search-review` (`s R`) searches for a literal string; `projectile-search-regexp-review` (`s X`) searches for an Emacs regexp, honoring full Emacs regexp syntax.
+  * Matches are gathered into a read-only `*projectile-search*` buffer, grouped by file, one `LINE:COL: CONTEXT` line per match with the matched span highlighted; there is no preview, no per-match toggle and no apply.
+  * The buffer reuses the replace reviewer's navigation, case/regexp toggles (`c`/`x`), line and file filters (`k`/`d`/`K`/`D`), re-search (`g`) and grep-mode export (`e`).
+  * `r` bridges the current search to the replace reviewer, carrying over the term, literal-ness and case setting and prompting only for the replacement.
+  * The commands are available from `projectile-dispatch` and the Projectile menu.
 * [#1924](https://github.com/bbatsov/projectile/issues/1924): Add reviewable project-wide replace commands that let you preview matches and choose which to apply, instead of the blocking, file-by-file `query-replace` walk of `projectile-replace`.
   * `projectile-replace-review` (`R`) does a literal replace; `projectile-replace-regexp-review` does an Emacs-regexp replace whose replacement can reference capture groups.
   * Matches are gathered in Emacs Lisp, so the regexp command honors full Emacs regexp syntax and the preview reflects exactly what will be edited, including unsaved changes in open buffers.

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -248,6 +248,12 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p s x]
 | Find references to the symbol at point within the project. Uses internally the `xref` library.
 
+| kbd:[s-p s R]
+| Reviewable search: gather all matches for a literal string into a read-only results buffer you can navigate, filter and reshape (see below).
+
+| kbd:[s-p s X]
+| Reviewable search for an Emacs regexp (the regexp sibling of kbd:[s-p s R]).
+
 | kbd:[s-p v]
 | Run `vc-dir` on the root directory of the project.
 
@@ -542,13 +548,77 @@ state. Very large searches are capped at `projectile-replace-max-matches`.
 
 kbd:[!] applies the enabled matches with no external dependency. If you'd
 rather edit the results as text, kbd:[e] exports the enabled matches (the
-same set kbd:[!] would act on) to a `+*projectile-replace-grep*+` buffer in `grep-mode`,
+same set kbd:[!] would act on) to a `+*projectile-grep*+` buffer in `grep-mode`,
 with standard `RELPATH:LINE:CONTEXT` lines navigable with `next-error` and
 kbd:[RET]. This is the bridge to https://github.com/mhayashi1120/Emacs-wgrep[wgrep]
 (kbd:[C-c C-p] to make it editable, then kbd:[C-c C-c] to write back) or
 Emacs 31's `grep-edit-mode`. wgrep is an optional integration, not a
 dependency; after exporting, Projectile tells you which workflow is
 available based on what you have installed.
+
+=== Reviewing search matches
+
+When you want to look through every match for a term across the project
+without changing anything, the search reviewer is the read-only sibling of
+the replace reviewer:
+
+* `projectile-search-review` (kbd:[s-p s R]) for a literal search.
+* `projectile-search-regexp-review` (kbd:[s-p s X]) for an Emacs regexp
+  search (full Emacs regexp syntax, e.g. symbol boundaries like `\_<foo\_>`).
+
+Both prompt only for the search term (defaulting to the symbol or region at
+point) and gather every match into a read-only `+*projectile-search*+`
+buffer, grouped by file, one `LINE:COL: CONTEXT` line per match with the
+matched span highlighted. There is no replacement, no per-match toggle and
+no apply: the buffer never edits your files.
+
+The results buffer supports these keys:
+
+|===
+| Key | Action
+
+| kbd:[RET]
+| Visit the match under point in another window.
+
+| kbd:[n] / kbd:[p]
+| Move to the next / previous match.
+
+| kbd:[M-n] / kbd:[M-p]
+| Move to the next / previous file.
+
+| kbd:[c]
+| Toggle case sensitivity and re-scan.
+
+| kbd:[x]
+| Toggle between literal and regexp matching and re-scan.
+
+| kbd:[k] / kbd:[d]
+| Keep / flush the matches whose line matches a regexp you type.
+
+| kbd:[K] / kbd:[D]
+| Keep / flush the matches whose file matches a regexp you type.
+
+| kbd:[g]
+| Re-run the search (also undoes any filtering).
+
+| kbd:[r]
+| Hand the current search to the replace reviewer, prompting only for the replacement.
+
+| kbd:[e]
+| Export the shown matches to a `grep-mode` buffer for wgrep / `grep-edit-mode`.
+
+| kbd:[q]
+| Quit the results buffer.
+|===
+
+The status line, the case/regexp toggles, the filter keys and the grep
+export behave exactly as in the replace reviewer above; only the preview,
+per-match toggle and apply are absent. kbd:[r] is the search-to-replace
+bridge: it carries over the same term, literal-ness and case setting and
+opens the `+*projectile-replace*+` reviewer, prompting only for the
+replacement. It re-runs the search from scratch, so any filtering you did
+in the search buffer is not carried into the replacement. Very large
+searches are capped at `projectile-replace-max-matches`.
 
 == Customizing Projectile's Keybindings
 

--- a/projectile.el
+++ b/projectile.el
@@ -8036,6 +8036,13 @@ around every (re-)gather so it drives which matches are collected.")
 (defvar-local projectile-replace--filtered nil
   "Non-nil when the shown match list was pruned by a filter command.
 Re-searching (\\<projectile-replace-mode-map>\\[projectile-replace--refresh]) gathers from scratch and clears this.")
+(defvar-local projectile-replace--render-function #'projectile-replace--render
+  "Function that redraws the current results buffer from its state.
+The scanning, navigation, filter and toggle machinery is shared
+between the replace reviewer and the read-only search reviewer
+(`projectile-search-mode'); this buffer-local seam lets those shared
+commands redraw with the current mode's renderer.  It defaults to the
+replace renderer and search mode rebinds it to its own.")
 
 (defun projectile-replace--expand (replacement groups literal)
   "Expand REPLACEMENT for a match whose group strings are GROUPS.
@@ -8432,14 +8439,14 @@ This gathers from scratch, so any filtering is undone and matches
 removed by a filter command reappear."
   (interactive)
   (projectile-replace--regather)
-  (projectile-replace--render))
+  (funcall projectile-replace--render-function))
 
 (defun projectile-replace--toggle-case ()
   "Toggle case sensitivity of the search, re-scan, and re-render."
   (interactive)
   (setq projectile-replace--case-fold (not projectile-replace--case-fold))
   (projectile-replace--regather)
-  (projectile-replace--render)
+  (funcall projectile-replace--render-function)
   (message "%s"
            (projectile-prepend-project-name
             (if projectile-replace--case-fold
@@ -8468,7 +8475,7 @@ refused with a message so the buffer stays usable rather than erroring."
                                            (regexp-quote projectile-replace--term)
                                          projectile-replace--term))
       (projectile-replace--regather)
-      (projectile-replace--render)
+      (funcall projectile-replace--render-function)
       (message "%s"
                (projectile-prepend-project-name
                 (if new-literal "literal search" "regexp search"))))))
@@ -8480,7 +8487,7 @@ gathers from scratch."
   (setq projectile-replace--matches
         (cl-remove-if-not predicate projectile-replace--matches)
         projectile-replace--filtered t)
-  (projectile-replace--render))
+  (funcall projectile-replace--render-function))
 
 (defun projectile-replace--line-matches-p (m regexp)
   "Return non-nil when match M's context line matches REGEXP.
@@ -8644,8 +8651,9 @@ unsaved changes is edited but left for the user to save."
 
 ;;; Exporting to a grep-mode buffer for wgrep / grep-edit-mode
 
-(defvar projectile-replace-grep-buffer-name "*projectile-replace-grep*"
-  "Name of the `grep-mode' buffer produced by `projectile-replace--export'.")
+(defvar projectile--grep-export-buffer-name "*projectile-grep*"
+  "Name of the `grep-mode' buffer produced by `projectile-replace--export'.
+Shared by the replace and search reviewers, hence the neutral name.")
 
 (defun projectile-replace--grep-line (m root)
   "Format match M as a RELPATH:LINE:CONTEXT grep hit relative to ROOT."
@@ -8674,7 +8682,7 @@ The wording adapts to what's installed: wgrep, Emacs 31's
 Renders the matches Projectile's own apply command would act on (the
 enabled matches from the reviewed and filtered list; ones toggled off are
 excluded, just as they are by apply) as standard RELPATH:LINE:CONTEXT grep
-hits in a `*projectile-replace-grep*' buffer whose `default-directory' is
+hits in a `*projectile-grep*' buffer whose `default-directory' is
 the project root, so the relative paths resolve.  The buffer is a real
 `grep-mode' buffer navigable with `next-error' and RET, so wgrep
 (`wgrep-change-to-wgrep-mode', bound to \\`C-c C-p') or Emacs 31's
@@ -8687,7 +8695,10 @@ Projectile's own apply command
   (let ((matches (cl-remove-if-not #'projectile-replace--match-enabled
                                    projectile-replace--matches))
         (root projectile-replace--root)
-        (buf (get-buffer-create projectile-replace-grep-buffer-name)))
+        ;; label the export by which reviewer it came from (read here, before
+        ;; switching to the grep buffer, so `major-mode' is the source buffer's)
+        (kind (if (derived-mode-p 'projectile-search-mode) "search" "replace"))
+        (buf (get-buffer-create projectile--grep-export-buffer-name)))
     (when (null matches)
       (user-error "No enabled matches to export"))
     (with-current-buffer buf
@@ -8697,12 +8708,12 @@ Projectile's own apply command
         (insert (format "-*- mode: grep; default-directory: %S -*-\n\n" root))
         ;; No colon before a value here: the search term could be `10:30' and
         ;; would otherwise parse as a phantom `file:line:' grep hit.
-        (insert (format "Projectile replace  (%d match%s)\n\n"
-                        (length matches)
+        (insert (format "Projectile %s  (%d match%s)\n\n"
+                        kind (length matches)
                         (if (= (length matches) 1) "" "es")))
         (dolist (m matches)
           (insert (projectile-replace--grep-line m root) "\n"))
-        (insert "\nProjectile replace export finished\n"))
+        (insert (format "\nProjectile %s export finished\n" kind)))
       (grep-mode)
       ;; keep the root as default-directory so the relative hits resolve
       (setq default-directory root)
@@ -8759,6 +8770,30 @@ write back to the files.
   (setq-local truncate-lines t)
   (buffer-disable-undo))
 
+(defun projectile-replace--display (root term regexp replacement literal
+                                         case-fold matches truncated)
+  "Populate and show the `*projectile-replace*' results buffer.
+ROOT, TERM, REGEXP, REPLACEMENT, LITERAL and CASE-FOLD seed the buffer's
+state; MATCHES are the collected structs and TRUNCATED notes whether the
+match cap was hit."
+  (let ((buf (get-buffer-create projectile-replace-buffer-name)))
+    (with-current-buffer buf
+      (projectile-replace-mode)
+      (setq projectile-replace--root root
+            projectile-replace--term term
+            projectile-replace--search regexp
+            projectile-replace--replacement replacement
+            projectile-replace--literal literal
+            projectile-replace--case-fold case-fold
+            projectile-replace--matches matches
+            projectile-replace--truncated truncated
+            projectile-replace--filtered nil)
+      (projectile-replace--render))
+    (when truncated
+      (message "projectile-replace: showing the first %d matches"
+               projectile-replace-max-matches))
+    (pop-to-buffer buf)))
+
 (defun projectile-replace--review (literal)
   "Gather matches for a project-wide replacement and pop the results buffer.
 LITERAL non-nil runs a literal replace; otherwise the search term is an
@@ -8780,23 +8815,8 @@ Emacs regexp and the replacement may reference capture groups."
     (if (null matches)
         (message "%s" (projectile-prepend-project-name
                        (format "No matches for %s" term)))
-      (let ((buf (get-buffer-create projectile-replace-buffer-name)))
-        (with-current-buffer buf
-          (projectile-replace-mode)
-          (setq projectile-replace--root root
-                projectile-replace--term term
-                projectile-replace--search regexp
-                projectile-replace--replacement replacement
-                projectile-replace--literal literal
-                projectile-replace--case-fold case-fold
-                projectile-replace--matches matches
-                projectile-replace--truncated truncated
-                projectile-replace--filtered nil)
-          (projectile-replace--render))
-        (when truncated
-          (message "projectile-replace: showing the first %d matches"
-                   projectile-replace-max-matches))
-        (pop-to-buffer buf)))))
+      (projectile-replace--display root term regexp replacement literal
+                                   case-fold matches truncated))))
 
 ;;;###autoload
 (defun projectile-replace-review ()
@@ -8819,6 +8839,238 @@ This is a non-blocking, previewable alternative to
 `projectile-replace-regexp'."
   (interactive)
   (projectile-replace--review nil))
+
+;;; Reviewable read-only project-content search
+;;
+;; A search-only sibling of the reviewable replace UI above.  It reuses the
+;; same pure "find matches" machinery (`projectile-replace--candidates',
+;; `--gather', `--scan-file', the match struct and its accessors) and the
+;; same navigation, filter, case/regexp-toggle, visit and grep-export
+;; commands, but renders the matches into a read-only `*projectile-search*'
+;; buffer with no before->after preview, no per-match enable/disable toggle,
+;; and no apply.  It is a distinct major mode (`projectile-search-mode', a
+;; sibling of `projectile-replace-mode', not a shared base) so its keymap can
+;; simply omit every write-back key rather than disable it; the shared code
+;; lives under the `projectile-replace--' prefix (where it already was) and
+;; the two modes share the results-buffer buffer-locals.  A `replace these'
+;; bridge hands the current search off to the replace reviewer.
+
+(defvar projectile-search-buffer-name "*projectile-search*"
+  "Name of the buffer used by `projectile-search-review'.")
+
+(defun projectile-search--header-string ()
+  "Return the propertized status header for the search results buffer.
+Shows the term, the match and file counts, the mode flags
+\(regexp/literal and case), and a note when the list has been filtered.
+Carries no `projectile-replace-match' property, so match navigation
+skips it."
+  (let* ((matches projectile-replace--matches)
+         (nmatches (length matches))
+         (seen (make-hash-table :test 'equal))
+         nfiles flags)
+    (dolist (m matches)
+      (puthash (projectile-replace--match-file m) t seen))
+    (setq nfiles (hash-table-count seen)
+          flags (concat
+                 (if projectile-replace--literal "[literal]" "[regexp]")
+                 " "
+                 (if projectile-replace--case-fold
+                     "[ignore-case]" "[case-sensitive]")
+                 (if projectile-replace--filtered "  filtered" "")))
+    (propertize
+     (format "Search %S\n%d match%s in %d file%s  %s\n"
+             projectile-replace--term
+             nmatches (if (= nmatches 1) "" "es")
+             nfiles (if (= nfiles 1) "" "s")
+             flags)
+     'face 'projectile-replace-header)))
+
+(defun projectile-search--render-line (m)
+  "Return the propertized results line for match M.
+The line is `LINE:COL: CONTEXT' with the matched span highlighted; there
+is no replacement preview and no enable/disable indicator.  The whole
+line carries the match struct under the `projectile-replace-match' text
+property so the shared navigation, visit and filter commands find it."
+  (let* ((col (projectile-replace--match-column m))
+         (ctx (projectile-replace--match-context m))
+         (mstr (projectile-replace--match-string m))
+         (before (substring ctx 0 (min col (length ctx))))
+         (after (if (<= (+ col (length mstr)) (length ctx))
+                    (substring ctx (+ col (length mstr)))
+                  ""))
+         (highlight (propertize mstr 'face 'projectile-replace-match))
+         (locator (propertize (format "%d:%d: "
+                                      (projectile-replace--match-line m)
+                                      (1+ col))
+                              'face 'projectile-replace-line-number))
+         (line (concat locator before highlight after "\n")))
+    (propertize line 'projectile-replace-match m)))
+
+(defun projectile-search--render ()
+  "Redraw the current search results buffer from its buffer-local state."
+  (let ((inhibit-read-only t)
+        (root projectile-replace--root)
+        (matches projectile-replace--matches)
+        (counts (make-hash-table :test 'equal))
+        (prev-file nil))
+    (dolist (m matches)
+      (cl-incf (gethash (projectile-replace--match-file m) counts 0)))
+    (erase-buffer)
+    (insert (projectile-search--header-string))
+    (insert (substitute-command-keys
+             (concat "\\<projectile-search-mode-map>"
+                     "\\[projectile-replace--visit] visit  "
+                     "\\[projectile-replace--refresh] re-search  "
+                     "\\[projectile-search--to-replace] replace these  "
+                     "\\[projectile-replace--export] export  "
+                     "\\[quit-window] quit\n"
+                     "\\[projectile-replace--toggle-case] case  "
+                     "\\[projectile-replace--toggle-regexp] regexp/literal  "
+                     "\\[projectile-replace--keep-matches]/\\[projectile-replace--flush-matches] keep/flush line  "
+                     "\\[projectile-replace--keep-files]/\\[projectile-replace--flush-files] keep/flush file\n\n")))
+    (if (null matches)
+        (insert "No matches.\n")
+      (dolist (m matches)
+        (let ((file (projectile-replace--match-file m)))
+          (unless (equal prev-file file)
+            (when prev-file (insert "\n"))
+            (setq prev-file file)
+            (insert (projectile-replace--file-header
+                     file root (gethash file counts))))
+          (insert (projectile-search--render-line m)))))
+    (when projectile-replace--truncated
+      (insert (format "\n(showing the first %d matches)\n"
+                      projectile-replace-max-matches)))
+    (goto-char (point-min))))
+
+(defun projectile-search--to-replace ()
+  "Hand the current search to the reviewable replace UI.
+Carries over the same term, literal-ness and case setting and prompts
+only for the replacement.  The project is re-scanned from scratch (so
+any filtering is undone and every match comes back enabled), mirroring
+`projectile-replace-review'."
+  (interactive)
+  (let* ((root projectile-replace--root)
+         (term projectile-replace--term)
+         (literal projectile-replace--literal)
+         (case-fold projectile-replace--case-fold)
+         (regexp projectile-replace--search)
+         (replacement (read-string
+                       (projectile-prepend-project-name
+                        (format "Replace %s with: " term))))
+         (candidates (projectile-replace--candidates term literal case-fold root))
+         (result (projectile-replace--gather candidates regexp))
+         (matches (plist-get result :matches))
+         (truncated (plist-get result :truncated)))
+    (if (null matches)
+        (message "%s" (projectile-prepend-project-name
+                       (format "No matches for %s" term)))
+      (projectile-replace--display root term regexp replacement literal
+                                   case-fold matches truncated))))
+
+(defvar projectile-search-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "RET") #'projectile-replace--visit)
+    (define-key map (kbd "n") #'projectile-replace--goto-next-match)
+    (define-key map (kbd "p") #'projectile-replace--goto-prev-match)
+    (define-key map (kbd "M-n") #'projectile-replace--goto-next-file)
+    (define-key map (kbd "M-p") #'projectile-replace--goto-prev-file)
+    (define-key map (kbd "c") #'projectile-replace--toggle-case)
+    (define-key map (kbd "x") #'projectile-replace--toggle-regexp)
+    (define-key map (kbd "k") #'projectile-replace--keep-matches)
+    (define-key map (kbd "d") #'projectile-replace--flush-matches)
+    (define-key map (kbd "K") #'projectile-replace--keep-files)
+    (define-key map (kbd "D") #'projectile-replace--flush-files)
+    (define-key map (kbd "e") #'projectile-replace--export)
+    (define-key map (kbd "r") #'projectile-search--to-replace)
+    (define-key map (kbd "g") #'projectile-replace--refresh)
+    (define-key map (kbd "q") #'quit-window)
+    map)
+  "Keymap for `projectile-search-mode'.")
+
+(define-derived-mode projectile-search-mode special-mode "Projectile-Search"
+  "Major mode for reviewing project-wide search matches, read-only.
+
+A search-only sibling of `projectile-replace-mode': the buffer is a
+read-only listing of every match, grouped by file, with no replacement
+preview and no way to edit the files from here.  Navigate with
+\\<projectile-search-mode-map>\\[projectile-replace--goto-next-match] / \\[projectile-replace--goto-prev-match] (match) and \\[projectile-replace--goto-next-file] / \\[projectile-replace--goto-prev-file] (file), and \\[projectile-replace--visit]
+visits the match under point.  The search can be reshaped in place:
+\\[projectile-replace--toggle-case] toggles case sensitivity and \\[projectile-replace--toggle-regexp] toggles literal/regexp matching,
+each re-scanning; \\[projectile-replace--keep-matches] / \\[projectile-replace--flush-matches] keep or flush matches by line and
+\\[projectile-replace--keep-files] / \\[projectile-replace--flush-files] by file; \\[projectile-replace--refresh] re-runs the search, undoing any filtering.
+
+\\[projectile-search--to-replace] hands the current search off to the reviewable replace UI
+\(prompting only for the replacement), and \\[projectile-replace--export] exports the shown
+matches to a `grep-mode' buffer for wgrep or Emacs 31's `grep-edit-mode'.
+
+\\{projectile-search-mode-map}"
+  (setq-local truncate-lines t)
+  (setq-local projectile-replace--render-function #'projectile-search--render)
+  (buffer-disable-undo))
+
+(defun projectile-search--review (literal)
+  "Gather matches for a project-wide search and pop the read-only results buffer.
+LITERAL non-nil searches for a literal string; otherwise the term is an
+Emacs regexp.  There is no replacement prompt."
+  (let* ((root (projectile-acquire-root))
+         (term (read-string
+                (projectile-prepend-project-name
+                 (if literal "Search: " "Search regexp: "))
+                (projectile-symbol-or-selection-at-point)))
+         (regexp (if literal (regexp-quote term) term))
+         (case-fold case-fold-search)
+         (candidates (projectile-replace--candidates term literal case-fold root))
+         ;; SEAM: this is the single gather site.  Everything above computes
+         ;; the candidate file list; everything below renders whatever matches
+         ;; come back.  A future async scanning engine replaces just this call
+         ;; (feeding matches in incrementally) without touching the rendering.
+         (result (projectile-replace--gather candidates regexp))
+         (matches (plist-get result :matches))
+         (truncated (plist-get result :truncated)))
+    (if (null matches)
+        (message "%s" (projectile-prepend-project-name
+                       (format "No matches for %s" term)))
+      (let ((buf (get-buffer-create projectile-search-buffer-name)))
+        (with-current-buffer buf
+          (projectile-search-mode)
+          (setq projectile-replace--root root
+                projectile-replace--term term
+                projectile-replace--search regexp
+                projectile-replace--replacement nil
+                projectile-replace--literal literal
+                projectile-replace--case-fold case-fold
+                projectile-replace--matches matches
+                projectile-replace--truncated truncated
+                projectile-replace--filtered nil)
+          (projectile-search--render))
+        (when truncated
+          (message "projectile-search: showing the first %d matches"
+                   projectile-replace-max-matches))
+        (pop-to-buffer buf)))))
+
+;;;###autoload
+(defun projectile-search-review ()
+  "Search the project for a literal string and review the matches read-only.
+
+Prompts for a literal search string (defaulting to the symbol or region
+at point), gathers every match across the project into a read-only
+`*projectile-search*' buffer grouped by file, and lets you navigate,
+filter and reshape the search.  Use \\<projectile-search-mode-map>\\[projectile-search--to-replace] to turn it into a
+reviewable replacement.  This is the read-only sibling of
+`projectile-replace-review'."
+  (interactive)
+  (projectile-search--review t))
+
+;;;###autoload
+(defun projectile-search-regexp-review ()
+  "Search the project for an Emacs regexp and review the matches read-only.
+
+Like `projectile-search-review', but the search term is an Emacs regexp,
+so full Emacs regexp syntax (e.g. symbol boundaries like `\\_<foo\\_>')
+is honored."
+  (interactive)
+  (projectile-search--review nil))
 
 (defun projectile--buffer-matches-conditions (buffer conditions)
   "Return non-nil if BUFFER satisfies any condition in CONDITIONS.
@@ -10693,6 +10945,8 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "s r") #'projectile-ripgrep)
     (define-key map (kbd "s a") #'projectile-ag)
     (define-key map (kbd "s x") #'projectile-find-references)
+    (define-key map (kbd "s R") #'projectile-search-review)
+    (define-key map (kbd "s X") #'projectile-search-regexp-review)
     (define-key map (kbd "S") #'projectile-save-project-buffers)
     (define-key map (kbd "t") #'projectile-toggle-between-implementation-and-test)
     (define-key map (kbd "T") #'projectile-find-test-file)
@@ -10974,6 +11228,8 @@ window or frame (file/buffer/project commands)."
       ("sr" "ripgrep" projectile-dispatch-ripgrep)
       ("sa" "ag" projectile-dispatch-ag)
       ("sx" "references" projectile-find-references)
+      ("sR" "search (review)" projectile-search-review)
+      ("sX" "search regexp (review)" projectile-search-regexp-review)
       ("o" "multi-occur" projectile-multi-occur)
       ("r" "replace" projectile-replace)
       ("R" "replace (review)" projectile-replace-review)]]

--- a/test/projectile-search-review-test.el
+++ b/test/projectile-search-review-test.el
@@ -1,0 +1,322 @@
+;;; projectile-search-review-test.el --- Tests for the reviewable search UI -*- lexical-binding: t -*-
+
+;; Copyright © 2011-2026 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for `projectile-search-review' and
+;; `projectile-search-regexp-review', the read-only search reviewer.  Like
+;; the replace-review tests, these exercise real files on disk and real live
+;; buffers, since faithful matching against real content is the whole point.
+
+;;; Code:
+
+(require 'projectile-test-helpers)
+
+(defun projectile-search-review-test--kill-project-buffers (root)
+  "Kill all buffers visiting files under ROOT, discarding modifications."
+  (dolist (buffer (buffer-list))
+    (when-let* ((file (buffer-file-name buffer)))
+      (when (string-prefix-p root (file-truename file))
+        (with-current-buffer buffer
+          (set-buffer-modified-p nil))
+        (let (kill-buffer-query-functions)
+          (kill-buffer buffer)))))
+  (dolist (name (list projectile-search-buffer-name
+                      projectile-replace-buffer-name))
+    (when-let* ((buf (get-buffer name)))
+      (kill-buffer buf))))
+
+(defmacro projectile-search-review-test--with-project (files &rest body)
+  "Evaluate BODY in a sandbox project containing FILES.
+
+FILES is a literal alist of (NAME . CONTENT) file specs created relative
+to the project root.  A `.projectile' marker is created; include one in
+FILES to override its contents (e.g. to add ignore rules).  BODY runs
+with `default-directory' at the root and `projectile-project-root'
+stubbed accordingly.  Project buffers and the results buffers are killed
+afterwards."
+  (declare (indent 1) (debug (sexp &rest form)))
+  `(projectile-test-with-sandbox
+     (make-directory "project" t)
+     (with-temp-file "project/.projectile")
+     ,@(mapcar (lambda (spec)
+                 `(progn
+                    (when-let* ((dir (file-name-directory ,(car spec))))
+                      (make-directory (expand-file-name dir "project") t))
+                    (with-temp-file (expand-file-name ,(car spec) "project")
+                      (insert ,(cdr spec)))))
+               files)
+     (let ((default-directory (file-name-as-directory
+                               (file-truename (expand-file-name "project/"))))
+           (projectile-indexing-method 'native)
+           (projectile-projects-cache (make-hash-table :test 'equal))
+           (projectile-projects-cache-time (make-hash-table :test 'equal))
+           (projectile-enable-caching nil)
+           (case-fold-search t))
+       (spy-on 'projectile-project-root :and-return-value default-directory)
+       (unwind-protect
+           (progn ,@body)
+         (projectile-search-review-test--kill-project-buffers default-directory)))))
+
+(defun projectile-search-review-test--use-plain-grep ()
+  "Force `projectile-files-with-string' to shell out to plain grep."
+  (assume (projectile-unixy-system-p) "needs unixy text utilities")
+  (spy-on 'executable-find :and-call-fake
+          (lambda (command &rest _)
+            (member command '("grep" "cut" "uniq")))))
+
+(defun projectile-search-review-test--run (term &optional regexp-p)
+  "Drive the search review command for TERM and return the results buffer.
+REGEXP-P selects `projectile-search-regexp-review'."
+  (let ((inputs (list term)))
+    (spy-on 'read-string :and-call-fake (lambda (&rest _) (pop inputs)))
+    (cl-letf (((symbol-function 'pop-to-buffer) #'ignore))
+      (call-interactively (if regexp-p
+                              #'projectile-search-regexp-review
+                            #'projectile-search-review)))
+    (get-buffer projectile-search-buffer-name)))
+
+(defun projectile-search-review-test--files (buf)
+  "Return the sorted set of project-relative files with matches in BUF."
+  (with-current-buffer buf
+    (let ((root projectile-replace--root)
+          (files nil))
+      (dolist (m projectile-replace--matches)
+        (cl-pushnew (file-relative-name (projectile-replace--match-file m) root)
+                    files :test #'equal))
+      (sort files #'string<))))
+
+(describe "projectile-search-review (literal)"
+  (it "finds every literal match grouped by file, read-only, no apply keys"
+    (projectile-search-review-test--with-project
+        (("a.txt" . "foo one foo\n")
+         ("lib/b.txt" . "start foo end\n"))
+      (projectile-search-review-test--use-plain-grep)
+      (let ((buf (projectile-search-review-test--run "foo")))
+        (with-current-buffer buf
+          (expect major-mode :to-equal 'projectile-search-mode)
+          (expect (length projectile-replace--matches) :to-equal 3)
+          (expect (projectile-search-review-test--files buf)
+                  :to-equal '("a.txt" "lib/b.txt"))
+          ;; the buffer is genuinely read-only
+          (expect buffer-read-only :to-be-truthy)
+          ;; and exposes no write-back / enable-toggle commands
+          (expect (lookup-key projectile-search-mode-map (kbd "!")) :to-be nil)
+          (expect (lookup-key projectile-search-mode-map (kbd "t")) :to-be nil)
+          (expect (lookup-key projectile-search-mode-map (kbd "C-c C-c"))
+                  :not :to-equal 'projectile-replace--apply)
+          ;; the rendered body carries no [X]/[ ] enable indicators
+          (expect (buffer-string) :not :to-match "\\[[ X]\\]")))))
+
+  (it "renders each match as LINE:COL: with the matched span present"
+    (projectile-search-review-test--with-project
+        (("a.txt" . "alpha foo beta\n"))
+      (projectile-search-review-test--use-plain-grep)
+      (let ((buf (projectile-search-review-test--run "foo")))
+        (with-current-buffer buf
+          (expect (buffer-string) :to-match "1:7: alpha foo beta")))))
+
+  (it "reports no matches without popping a buffer"
+    (projectile-search-review-test--with-project
+        (("a.txt" . "nothing here\n"))
+      (projectile-search-review-test--use-plain-grep)
+      (spy-on 'message)
+      (let ((buf (projectile-search-review-test--run "absent")))
+        (expect buf :to-be nil)))))
+
+(describe "projectile-search-regexp-review"
+  (it "honors Emacs-only regexp constructs a shell regexp couldn't express"
+    (projectile-search-review-test--with-project
+        (("s.txt" . "foo foobar barfoo foo\n"))
+      (let ((buf (projectile-search-review-test--run "\\_<foo\\_>" 'regexp)))
+        (with-current-buffer buf
+          ;; only the two standalone `foo' symbols match
+          (expect (length projectile-replace--matches) :to-equal 2)
+          (expect projectile-replace--literal :to-be nil))))))
+
+(describe "projectile-search-review visit"
+  (it "RET resolves the right file and line/column"
+    (projectile-search-review-test--with-project
+        (("a.txt" . "line one\nsecond foo here\n")
+         ("lib/b.txt" . "foo at top\n"))
+      (projectile-search-review-test--use-plain-grep)
+      (let ((buf (projectile-search-review-test--run "foo")))
+        (with-current-buffer buf
+          ;; jump to the match in lib/b.txt
+          (goto-char (point-min))
+          (let ((found nil))
+            (while (and (not found) (not (eobp)))
+              (let ((m (projectile-replace--match-at-point)))
+                (when (and m (string-suffix-p
+                              "lib/b.txt"
+                              (projectile-replace--match-file m)))
+                  (setq found t)))
+              (unless found (forward-line 1)))
+            (expect found :to-be-truthy))
+          (let (visited)
+            (cl-letf (((symbol-function 'switch-to-buffer-other-window)
+                       (lambda (b &rest _) (set-buffer b) (setq visited b))))
+              (projectile-replace--visit))
+            ;; point now sits in lib/b.txt on the match
+            (with-current-buffer visited
+              (expect (string-suffix-p "lib/b.txt" (buffer-file-name))
+                      :to-be-truthy)
+              (expect (line-number-at-pos) :to-equal 1)
+              (expect (current-column) :to-equal 0))))))))
+
+(describe "projectile-search-review filtering"
+  (it "prunes matches by line and marks the list filtered"
+    (projectile-search-review-test--with-project
+        (("f.txt" . "keep foo here\ndrop foo there\nkeep foo again\n"))
+      (projectile-search-review-test--use-plain-grep)
+      (let ((buf (projectile-search-review-test--run "foo")))
+        (with-current-buffer buf
+          (expect (length projectile-replace--matches) :to-equal 3)
+          (projectile-replace--keep-matches "keep")
+          (expect (length projectile-replace--matches) :to-equal 2)
+          (expect projectile-replace--filtered :to-be-truthy)
+          ;; re-search brings the pruned match back
+          (projectile-replace--refresh)
+          (expect (length projectile-replace--matches) :to-equal 3)
+          (expect projectile-replace--filtered :to-be nil)))))
+
+  (it "prunes matches by file"
+    (projectile-search-review-test--with-project
+        (("keep.txt" . "foo\n")
+         ("lib/skip.txt" . "foo\n"))
+      (projectile-search-review-test--use-plain-grep)
+      (let ((buf (projectile-search-review-test--run "foo")))
+        (with-current-buffer buf
+          (expect (length projectile-replace--matches) :to-equal 2)
+          (projectile-replace--flush-files "lib/")
+          (expect (length projectile-replace--matches) :to-equal 1)
+          (expect (file-name-nondirectory
+                   (projectile-replace--match-file
+                    (car projectile-replace--matches)))
+                  :to-equal "keep.txt"))))))
+
+(describe "projectile-search-review case and regexp toggles"
+  (it "re-scans when case sensitivity flips"
+    (projectile-search-review-test--with-project
+        (("case.txt" . "Foo foo FOO\n"))
+      (projectile-search-review-test--use-plain-grep)
+      (let ((buf (projectile-search-review-test--run "foo")))
+        (with-current-buffer buf
+          (expect projectile-replace--case-fold :to-be-truthy)
+          (expect (length projectile-replace--matches) :to-equal 3)
+          (projectile-replace--toggle-case)
+          (expect projectile-replace--case-fold :to-be nil)
+          (expect (length projectile-replace--matches) :to-equal 1)
+          (expect (projectile-replace--match-string
+                   (car projectile-replace--matches))
+                  :to-equal "foo")))))
+
+  (it "re-scans when literal/regexp flips"
+    (projectile-search-review-test--with-project
+        (("meta.txt" . "a.b axb a.b\n"))
+      (projectile-search-review-test--use-plain-grep)
+      (let ((buf (projectile-search-review-test--run "a.b")))
+        (with-current-buffer buf
+          (expect projectile-replace--literal :to-be-truthy)
+          (expect (length projectile-replace--matches) :to-equal 2)
+          (projectile-replace--toggle-regexp)
+          (expect projectile-replace--literal :to-be nil)
+          ;; regexp: the `.' now also matches the `x' in `axb'
+          (expect (length projectile-replace--matches) :to-equal 3))))))
+
+(describe "projectile-search-review status header"
+  (it "shows the term, counts and mode flags"
+    (projectile-search-review-test--with-project
+        (("h.txt" . "foo\n"))
+      (projectile-search-review-test--use-plain-grep)
+      (let ((buf (projectile-search-review-test--run "foo")))
+        (with-current-buffer buf
+          (let ((header (buffer-substring-no-properties
+                         (point-min)
+                         (save-excursion (goto-char (point-min))
+                                         (line-end-position 2)))))
+            (expect header :to-match "Search \"foo\"")
+            (expect header :to-match "\\[literal\\]")
+            (expect header :to-match "\\[ignore-case\\]")
+            ;; a search header has no replacement segment
+            (expect header :not :to-match "with")))))))
+
+(defun projectile-search-review-test--export (buf)
+  "Export search results buffer BUF to a grep buffer and return it."
+  (with-current-buffer buf
+    (cl-letf (((symbol-function 'pop-to-buffer) #'ignore))
+      (projectile-replace--export))))
+
+(describe "projectile-search-review export to grep-mode"
+  (it "renders the shown matches as a navigable grep-mode buffer"
+    (projectile-search-review-test--with-project
+        (("a.txt" . "foo one foo\n")
+         ("lib/b.txt" . "start foo end\n"))
+      (projectile-search-review-test--use-plain-grep)
+      (let* ((buf (projectile-search-review-test--run "foo"))
+             (gbuf (projectile-search-review-test--export buf)))
+        (unwind-protect
+            (with-current-buffer gbuf
+              (expect major-mode :to-equal 'grep-mode)
+              (let ((text (buffer-string)))
+                ;; the export is labelled for the reviewer it came from
+                (expect text :to-match "Projectile search")
+                (expect text :not :to-match "Projectile replace")
+                (expect text :to-match "^a\\.txt:1:foo one foo$")
+                (expect text :to-match "^lib/b\\.txt:1:start foo end$")))
+          (kill-buffer gbuf))))))
+
+(describe "projectile-search-review to-replace bridge"
+  (it "opens the replace reviewer preloaded with the same term"
+    (projectile-search-review-test--with-project
+        (("a.txt" . "foo one foo\n"))
+      (projectile-search-review-test--use-plain-grep)
+      (let ((buf (projectile-search-review-test--run "foo")))
+        (with-current-buffer buf
+          ;; the bridge prompts only for the replacement
+          (spy-on 'read-string :and-return-value "bar")
+          (cl-letf (((symbol-function 'pop-to-buffer) #'ignore))
+            (projectile-search--to-replace)))
+        (let ((rbuf (get-buffer projectile-replace-buffer-name)))
+          (expect rbuf :not :to-be nil)
+          (with-current-buffer rbuf
+            (expect major-mode :to-equal 'projectile-replace-mode)
+            (expect projectile-replace--term :to-equal "foo")
+            (expect projectile-replace--literal :to-be-truthy)
+            (expect projectile-replace--replacement :to-equal "bar")
+            (expect (length projectile-replace--matches) :to-equal 2)
+            ;; the replace buffer really is applyable (has the enable indicator)
+            (expect (buffer-string) :to-match "\\[X\\]"))))))
+
+  (it "carries literal-ness through from a regexp search"
+    (projectile-search-review-test--with-project
+        (("s.txt" . "foo foobar foo\n"))
+      (let ((buf (projectile-search-review-test--run "\\_<foo\\_>" 'regexp)))
+        (with-current-buffer buf
+          (spy-on 'read-string :and-return-value "X")
+          (cl-letf (((symbol-function 'pop-to-buffer) #'ignore))
+            (projectile-search--to-replace)))
+        (with-current-buffer (get-buffer projectile-replace-buffer-name)
+          (expect projectile-replace--literal :to-be nil)
+          (expect projectile-replace--search :to-equal "\\_<foo\\_>")
+          (expect (length projectile-replace--matches) :to-equal 2))))))
+
+;;; projectile-search-review-test.el ends here


### PR DESCRIPTION
A read-only sibling of the replace reviewer: `projectile-search-review` (`s R`, literal) and `projectile-search-regexp-review` (`s X`) open a `*projectile-search*` buffer with the same grouping, navigation, filtering, case/regexp toggles, re-search and grep export, but no apply and no per-match toggles. `r` hands the current search (term, literal-ness, case) over to the replace reviewer, prompting only for the replacement.

It's dependency-free (no ag.el/rg.el) and shares the scanner, match struct and UI with the replace reviewer, so the only changes to shared code are a buffer-local render-function indirection and an extracted display helper. Replace behavior is identical. That single `--gather` call is the seam a later async engine drops into.
