### PR TITLE
Accelerate literal search-review with a ripgrep fast-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   * Matches are gathered into a read-only `*projectile-search*` buffer, grouped by file, one `LINE:COL: CONTEXT` line per match with the matched span highlighted; there is no preview, no per-match toggle and no apply.
   * The buffer reuses the replace reviewer's navigation, case/regexp toggles (`c`/`x`), line and file filters (`k`/`d`/`K`/`D`), re-search (`g`) and grep-mode export (`e`).
   * `r` bridges the current search to the replace reviewer, carrying over the term, literal-ness and case setting and prompting only for the replacement.
+  * A literal `projectile-search-review` accelerates its scan with ripgrep when `rg` is installed, streaming matches in near-instantly on large projects.
+    * Controlled by `projectile-search-use-ripgrep` (default on); set it to nil to always use the pure-elisp scan.
+    * The ripgrep fast-path follows ripgrep's ignore rules plus Projectile's ignore globs, which can differ slightly from the elisp path's file set (e.g. hidden files, symlinks); regexp search and the whole replace reviewer always use the portable elisp scan.
   * The commands are available from `projectile-dispatch` and the Projectile menu.
 * [#1924](https://github.com/bbatsov/projectile/issues/1924): Add reviewable project-wide replace commands that let you preview matches and choose which to apply, instead of the blocking, file-by-file `query-replace` walk of `projectile-replace`.
   * `projectile-replace-review` (`R`) does a literal replace; `projectile-replace-regexp-review` does an Emacs-regexp replace whose replacement can reference capture groups.

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -631,6 +631,25 @@ replacement. It re-runs the search from scratch, so any filtering you did
 in the search buffer is not carried into the replacement. Very large
 searches are capped at `projectile-replace-max-matches`.
 
+When `projectile-search-use-ripgrep` is non-nil (the default) and the
+`rg` (ripgrep) executable is installed, a *literal* `projectile-search-review`
+scan runs through ripgrep instead of the pure-Emacs-Lisp scan, which
+returns near-instantly even on a large project; the matches stream into
+the same read-only buffer and every reviewer command works unchanged. The
+ripgrep fast-path follows ripgrep's own ignore rules (`.gitignore`,
+`.ignore`, hidden-file handling, and so on) plus Projectile's ignore globs
+(`.projectile` and the globally-ignored files and directories, passed to
+`rg` via `--glob`), which can differ slightly from the pure-elisp path's
+file set (for example in how hidden files or symlinks are treated).
+Matches in files that aren't valid UTF-8 are also skipped by the ripgrep
+path but found by the elisp path. This
+is an accepted trade-off for speed; set `projectile-search-use-ripgrep` to
+nil to force the elisp scan, whose result set matches Projectile's ignore
+configuration exactly. The regexp search command always uses the elisp
+scan (ripgrep's regex syntax is not Emacs regexp syntax), and the whole
+replace reviewer always uses the elisp scan (its write-back needs the
+exact buffer positions the elisp scan records).
+
 == Customizing Projectile's Keybindings
 
 It is possible to add additional commands to

--- a/projectile.el
+++ b/projectile.el
@@ -7980,6 +7980,33 @@ async only changes when and how matches are delivered."
   :type 'boolean
   :package-version '(projectile . "3.2.0"))
 
+(defcustom projectile-search-use-ripgrep t
+  "Whether `projectile-search-review' accelerates literal search with ripgrep.
+When non-nil (the default) a literal `projectile-search-review' scan
+uses ripgrep (`rg') to find matches when the `rg' executable is
+available, which returns near-instantly even on a large project;
+otherwise, and always for the regexp search command and for every part
+of the replace reviewer, the portable pure-Emacs-Lisp scan is used.
+
+The ripgrep fast-path's result set follows ripgrep's own ignore rules
+\(`.gitignore', `.ignore', hidden-file handling, and so on) plus
+Projectile's ignore globs (`.projectile' and the globally-ignored files
+and directories, passed to `rg' via `--glob'), and skips matches in files
+that aren't valid UTF-8, so it can differ slightly from the pure-elisp
+path's `projectile-dir-files' set (for example in how
+hidden files or symlinks are treated).  This is an accepted trade-off for
+speed; set this to nil to force the elisp scan, whose result set matches
+Projectile's ignore configuration exactly.
+
+The regexp search command always uses the elisp scan (ripgrep's regex
+syntax is not Emacs regexp syntax), and the whole replace reviewer always
+uses the elisp scan (its write-back needs the exact buffer positions the
+elisp scan records).  In batch mode (`noninteractive') the elisp scan is
+used so scripted runs stay deterministic."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "3.2.0"))
+
 (defvar projectile-replace--scan-chunk-size 24
   "Number of candidate files scanned per async chunk before yielding.
 Each chunk scans this many files, delivers the matches into the results
@@ -8074,6 +8101,12 @@ a partial match set).  Cleared when the scan finishes or is canceled.")
   "The in-flight async scan timer for this results buffer, or nil.
 Held so a re-scan, a quit, or killing the buffer can cancel a scan that
 is still running.")
+(defvar-local projectile-replace--scan-process nil
+  "The in-flight ripgrep subprocess filling this results buffer, or nil.
+Only the read-only search reviewer's ripgrep fast-path uses this; the
+pure-elisp async scan uses `projectile-replace--scan-timer' instead.
+Held so a re-scan, a quit, or killing the buffer can kill a scan that is
+still running, leaving no orphaned process.")
 (defvar-local projectile-replace--render-function #'projectile-replace--render
   "Function that redraws the current results buffer from its state.
 The scanning, navigation, filter and toggle machinery is shared
@@ -8237,7 +8270,12 @@ no timer is left dangling.  Safe to call when nothing is scanning; used
 on re-scan, on quit, and from `kill-buffer-hook'."
   (when projectile-replace--scan-timer
     (cancel-timer projectile-replace--scan-timer))
+  (when (process-live-p projectile-replace--scan-process)
+    ;; drop our sentinel first so killing it doesn't run the finish handler
+    (set-process-sentinel projectile-replace--scan-process #'ignore)
+    (delete-process projectile-replace--scan-process))
   (setq projectile-replace--scan-timer nil
+        projectile-replace--scan-process nil
         projectile-replace--scanning nil))
 
 (defun projectile-replace--gather-async (candidates regexp buffer on-done)
@@ -8953,7 +8991,218 @@ scan to fill it."
           projectile-replace--truncated nil
           projectile-replace--filtered nil
           projectile-replace--scanning nil
-          projectile-replace--scan-timer nil)))
+          projectile-replace--scan-timer nil
+          projectile-replace--scan-process nil)))
+
+;;; Ripgrep fast-path for the read-only literal search reviewer
+;;
+;; An optional accelerator for `projectile-search-review': when the search is
+;; literal, `rg' is installed and `projectile-search-use-ripgrep' is on, the
+;; candidate scan runs `rg --json' as a subprocess and parses its NDJSON match
+;; stream into the very same `projectile-replace--match' structs the elisp scan
+;; produces, streaming them into the results buffer.  Only the fields the
+;; search reviewer renders are filled (file, line, character column, matched
+;; string, context line); the write-back-only fields (`beg'/`end'/`match-data'/
+;; `groups') stay nil because the search->replace bridge re-gathers via elisp.
+;; This path is deliberately narrow: the regexp search command keeps the elisp
+;; scan (rg's Rust regex is not Emacs regexp) and the whole replace reviewer
+;; keeps the elisp scan (its apply needs exact buffer positions).  The elisp
+;; scan stays the default and the fallback; rg is purely additive.
+
+(defun projectile-search--rg-executable ()
+  "Return the ripgrep executable name if available, else nil."
+  (and (executable-find "rg") "rg"))
+
+(defun projectile-search--rg-fastpath-p (literal)
+  "Return non-nil when the search reviewer should use the ripgrep fast-path.
+True for a LITERAL search when `projectile-search-use-ripgrep' is set,
+`rg' is available, and we are interactive; batch (`noninteractive') keeps
+the deterministic elisp scan."
+  (and projectile-search-use-ripgrep
+       literal
+       (not noninteractive)
+       (projectile-search--rg-executable)
+       t))
+
+(defun projectile-search--rg-command (term case-fold globs)
+  "Build the `rg --json' command line searching for literal TERM.
+CASE-FOLD selects case-insensitive matching; GLOBS is a list of ignore
+patterns (from `projectile--project-ignore-globs') passed as `--glob'
+exclusions so Projectile's ignores narrow ripgrep's own ignore rules.
+The search path is the relative `./', so the caller must run the process
+with `default-directory' bound to the project root."
+  (append
+   (list (projectile-search--rg-executable)
+         "--json" "--fixed-strings" "--line-number" "--column"
+         "--color" "never"
+         (if case-fold "--ignore-case" "--case-sensitive"))
+   ;; Projectile's `project-ignores' globs mark a root-anchored pattern with a
+   ;; leading `./' (e.g. a `.projectile' `-/vendor' line); ripgrep spells a
+   ;; root-anchored glob with a leading `/', so translate `./PAT' to `/PAT'.
+   ;; rg honors that only when searching a path relative to the root, which is
+   ;; why the search path below is `./' and the caller binds default-directory.
+   (mapcan (lambda (g)
+             (list "--glob"
+                   (concat "!" (if (string-prefix-p "./" g)
+                                   (substring g 1)
+                                 g))))
+           globs)
+   ;; `--' terminates options so a TERM starting with `-' is not misread.
+   (list "--" term "./")))
+
+(defun projectile-search--rg-json-get (obj &rest keys)
+  "Walk KEYS through nested hash-table OBJ, returning the leaf or nil.
+OBJ is a `json-parse-string' object (a hash-table with string keys)."
+  (dolist (k keys obj)
+    (setq obj (and (hash-table-p obj) (gethash k obj)))))
+
+(defun projectile-search--rg-byte->char-column (line byte)
+  "Return the 0-based character column for BYTE offset into LINE.
+BYTE is a UTF-8 byte offset into the line text (as ripgrep reports
+submatch offsets); LINE is the already-decoded line string.  The prefix
+is re-encoded to UTF-8 and its BYTE-long head decoded back, so multibyte
+characters before the match count as one column each, not one per byte."
+  (if (or (null byte) (<= byte 0))
+      0
+    (let* ((bytes (encode-coding-string line 'utf-8))
+           (n (min byte (length bytes))))
+      (length (decode-coding-string (substring bytes 0 n) 'utf-8)))))
+
+(defun projectile-search--rg-parse-line (line root)
+  "Parse one ripgrep NDJSON LINE into a list of match structs under ROOT.
+Returns nil for non-\"match\" records (begin/end/summary/context) and for
+records without decodable path or line text.  A line with several
+submatches yields one struct per submatch, in order."
+  (condition-case nil
+      (let ((obj (json-parse-string line)))
+        (when (equal (gethash "type" obj) "match")
+          (let* ((data (gethash "data" obj))
+                 (path (projectile-search--rg-json-get data "path" "text"))
+                 (line-no (projectile-search--rg-json-get data "line_number"))
+                 (text (projectile-search--rg-json-get data "lines" "text"))
+                 (subs (gethash "submatches" data))
+                 (context (and (stringp text)
+                               (replace-regexp-in-string "\r?\n\\'" "" text)))
+                 (result nil))
+            (when (and (stringp path) (integerp line-no) (stringp text) subs)
+              (let ((file (expand-file-name path root)))
+                (dotimes (i (length subs))
+                  (let* ((sub (aref subs i))
+                         (start (gethash "start" sub))
+                         (mstr (projectile-search--rg-json-get
+                                sub "match" "text")))
+                    (when (stringp mstr)
+                      (push (projectile-replace--match-create
+                             :file file :buffer nil :tick nil
+                             :line line-no
+                             :column (projectile-search--rg-byte->char-column
+                                      text start)
+                             :beg nil :end nil
+                             :string mstr :match-data nil :groups nil
+                             :context context :enabled t)
+                            result))))))
+            (nreverse result))))
+    (error nil)))
+
+(defun projectile-search--rg-ingest (buffer lines root)
+  "Parse rg NDJSON LINES into BUFFER's match list, render, honor the cap.
+Appends up to `projectile-replace-max-matches' matches in arrival order;
+when the cap is reached the surplus is dropped and the truncated flag is
+set.  Returns non-nil when the cap has been reached, so the caller can
+finish the scan."
+  (with-current-buffer buffer
+    (if projectile-replace--truncated
+        t
+      (let ((new nil))
+        (dolist (l lines)
+          (unless (string-empty-p l)
+            (setq new (nconc new (projectile-search--rg-parse-line l root)))))
+        (let ((room (- projectile-replace-max-matches
+                       (length projectile-replace--matches))))
+          (when (> (length new) room)
+            (setq new (take (max 0 room) new)
+                  projectile-replace--truncated t))
+          (when new
+            (setq projectile-replace--matches
+                  (append projectile-replace--matches new)))
+          (funcall projectile-replace--render-function)
+          projectile-replace--truncated)))))
+
+(defun projectile-search--rg-finish (buffer on-done)
+  "Settle BUFFER after its ripgrep scan ends and call ON-DONE.
+Kills the scan process if still live (dropping its sentinel first),
+clears the scanning state, does a final render and calls ON-DONE.  Safe
+against a killed BUFFER."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (when (process-live-p projectile-replace--scan-process)
+        (set-process-sentinel projectile-replace--scan-process #'ignore)
+        (delete-process projectile-replace--scan-process))
+      (setq projectile-replace--scanning nil
+            projectile-replace--scan-process nil
+            projectile-replace--scan-timer nil)
+      (funcall projectile-replace--render-function)
+      (when on-done (funcall on-done buffer)))))
+
+(defun projectile-search--gather-rg (buffer term on-done)
+  "Scan for literal TERM into BUFFER via `rg --json', then call ON-DONE.
+Resets BUFFER's match list and scanning state, launches `rg' as a
+subprocess reading ROOT, CASE-FOLD and the ignore globs from BUFFER's
+buffer-locals, and streams parsed matches into the buffer as ripgrep
+emits them, re-rendering per output chunk.  `projectile-replace-max-matches'
+is honored (the process is killed when the cap is hit) and the scan is
+cancelable and kill-safe exactly like the elisp async engine: the process
+is registered in `projectile-replace--scan-process' so
+`projectile-replace--cancel-scan' (re-search, quit, kill-buffer) can kill
+it, leaving no orphan.  ON-DONE (or nil) is called in BUFFER when the scan
+finishes."
+  (let* ((root (buffer-local-value 'projectile-replace--root buffer))
+         (case-fold (buffer-local-value 'projectile-replace--case-fold buffer))
+         (globs (projectile--project-ignore-globs root))
+         (command (projectile-search--rg-command term case-fold globs))
+         (pending ""))
+    (with-current-buffer buffer
+      (setq projectile-replace--matches nil
+            projectile-replace--truncated nil
+            projectile-replace--filtered nil
+            projectile-replace--scanning t
+            projectile-replace--scan-timer nil
+            projectile-replace--scan-process nil))
+    (let* (;; run rg IN the project root so the relative `./' search path and
+           ;; the `/'-anchored ignore globs resolve against it
+           (default-directory root)
+           (proc
+           (make-process
+            :name "projectile-search-rg"
+            :buffer nil
+            :command command
+            :connection-type 'pipe
+            :noquery t
+            :coding 'utf-8-unix
+            :filter
+            (lambda (_proc output)
+              (when (buffer-live-p buffer)
+                (with-current-buffer buffer
+                  (unless projectile-replace--truncated
+                    (setq pending (concat pending output))
+                    (let ((parts (split-string pending "\n")))
+                      ;; the last element is the (possibly empty) partial line
+                      (setq pending (car (last parts)))
+                      (when (projectile-search--rg-ingest
+                             buffer (butlast parts) root)
+                        (projectile-search--rg-finish buffer on-done)))))))
+            :sentinel
+            (lambda (proc _event)
+              (when (and (buffer-live-p buffer)
+                         (memq (process-status proc) '(exit signal)))
+                (with-current-buffer buffer
+                  (when (eq proc projectile-replace--scan-process)
+                    (unless projectile-replace--truncated
+                      (projectile-search--rg-ingest buffer (list pending) root))
+                    (projectile-search--rg-finish buffer on-done))))))))
+      (with-current-buffer buffer
+        (setq projectile-replace--scan-process proc))
+      proc)))
 
 (defun projectile-replace--start (buffer candidates regexp on-done)
   "Fill BUFFER's match list by scanning CANDIDATES for REGEXP.
@@ -8961,11 +9210,23 @@ Cancels any in-flight scan in BUFFER first, then scans with the async
 chunked driver when `projectile-replace--async-p' holds and otherwise
 synchronously (always in batch), so the final match list is identical
 either way -- only delivery differs.  BUFFER is re-rendered when done and
-ON-DONE (or nil) is called in it."
+ON-DONE (or nil) is called in it.
+
+As an optional accelerator, a read-only search-reviewer BUFFER doing a
+literal search takes the ripgrep fast-path (`projectile-search--gather-rg')
+when `projectile-search--rg-fastpath-p' holds; the replace reviewer and
+the regexp search always take the elisp path below."
   (with-current-buffer buffer
     (projectile-replace--cancel-scan))
-  (if (projectile-replace--async-p)
-      (projectile-replace--gather-async candidates regexp buffer on-done)
+  (cond
+   ((with-current-buffer buffer
+      (and (derived-mode-p 'projectile-search-mode)
+           (projectile-search--rg-fastpath-p projectile-replace--literal)))
+    (projectile-search--gather-rg
+     buffer (buffer-local-value 'projectile-replace--term buffer) on-done))
+   ((projectile-replace--async-p)
+    (projectile-replace--gather-async candidates regexp buffer on-done))
+   (t
     (with-current-buffer buffer
       (let* ((case-fold-search projectile-replace--case-fold)
              (result (projectile-replace--gather candidates regexp)))
@@ -8974,7 +9235,7 @@ ON-DONE (or nil) is called in it."
               projectile-replace--scanning nil
               projectile-replace--scan-timer nil))
       (funcall projectile-replace--render-function)
-      (when on-done (funcall on-done buffer)))))
+      (when on-done (funcall on-done buffer))))))
 
 (defun projectile-replace--open-finish (buffer)
   "Announce truncation once the scan filling BUFFER has finished."
@@ -8998,7 +9259,13 @@ REPLACEMENT, LITERAL and CASE-FOLD seed the buffer state."
   ;; instance of the buffer (re-seeding resets its buffer-locals)
   (when-let* ((existing (get-buffer buf-name)))
     (with-current-buffer existing (projectile-replace--cancel-scan)))
-  (if (projectile-replace--async-p)
+  (if (or (projectile-replace--async-p)
+          ;; the read-only search reviewer's ripgrep fast-path is inherently
+          ;; async, so it opens the streaming buffer even when the elisp async
+          ;; engine is off (`projectile-replace-async' nil); `--start' then
+          ;; dispatches it to ripgrep
+          (and (eq mode #'projectile-search-mode)
+               (projectile-search--rg-fastpath-p literal)))
       (let ((buf (get-buffer-create buf-name)))
         (projectile-replace--seed buf mode root term regexp replacement
                                   literal case-fold)

--- a/test/projectile-search-review-test.el
+++ b/test/projectile-search-review-test.el
@@ -319,4 +319,318 @@ REGEXP-P selects `projectile-search-regexp-review'."
           (expect projectile-replace--search :to-equal "\\_<foo\\_>")
           (expect (length projectile-replace--matches) :to-equal 2))))))
 
+;;; Ripgrep fast-path
+
+(defun projectile-search-review-test--wait (buf)
+  "Pump events until BUF's ripgrep scan finishes (or a timeout elapses)."
+  (with-current-buffer buf
+    (let ((limit (+ (float-time) 10)))
+      (while (and projectile-replace--scanning (< (float-time) limit))
+        (accept-process-output projectile-replace--scan-process 0.05)))))
+
+(describe "projectile-search--rg byte->char column conversion"
+  (it "counts a multibyte prefix as characters, not bytes"
+    ;; "café " is 5 characters but 6 UTF-8 bytes (é is 2 bytes); ripgrep
+    ;; reports the match at byte 6, which must map to character column 5.
+    (expect (projectile-search--rg-byte->char-column "café foo" 6) :to-equal 5)
+    (expect (projectile-search--rg-byte->char-column "abc" 2) :to-equal 2)
+    (expect (projectile-search--rg-byte->char-column "x" 0) :to-equal 0)
+    (expect (projectile-search--rg-byte->char-column "x" nil) :to-equal 0)))
+
+(describe "projectile-search--rg-parse-line"
+  (it "builds a struct with a character column from a multibyte match line"
+    (let* ((json (concat "{\"type\":\"match\",\"data\":{"
+                         "\"path\":{\"text\":\"lib/mb.txt\"},"
+                         "\"lines\":{\"text\":\"café foo bar\\n\"},"
+                         "\"line_number\":3,\"absolute_offset\":0,"
+                         "\"submatches\":[{\"match\":{\"text\":\"foo\"},"
+                         "\"start\":6,\"end\":9}]}}"))
+           (ms (projectile-search--rg-parse-line json "/proj/"))
+           (m (car ms)))
+      (expect (length ms) :to-equal 1)
+      (expect (projectile-replace--match-file m) :to-equal "/proj/lib/mb.txt")
+      (expect (projectile-replace--match-line m) :to-equal 3)
+      ;; byte offset 6 -> character column 5
+      (expect (projectile-replace--match-column m) :to-equal 5)
+      (expect (projectile-replace--match-string m) :to-equal "foo")
+      ;; the trailing newline is stripped from the context line
+      (expect (projectile-replace--match-context m) :to-equal "café foo bar")
+      ;; write-back-only fields stay nil (search never uses them)
+      (expect (projectile-replace--match-beg m) :to-be nil)
+      (expect (projectile-replace--match-end m) :to-be nil)
+      (expect (projectile-replace--match-match-data m) :to-be nil)))
+
+  (it "yields one struct per submatch, in order"
+    (let* ((json (concat "{\"type\":\"match\",\"data\":{"
+                         "\"path\":{\"text\":\"a.txt\"},"
+                         "\"lines\":{\"text\":\"foo baz foo\\n\"},"
+                         "\"line_number\":1,"
+                         "\"submatches\":[{\"match\":{\"text\":\"foo\"},"
+                         "\"start\":0,\"end\":3},"
+                         "{\"match\":{\"text\":\"foo\"},\"start\":8,\"end\":11}]}}"))
+           (ms (projectile-search--rg-parse-line json "/proj/")))
+      (expect (length ms) :to-equal 2)
+      (expect (mapcar #'projectile-replace--match-column ms) :to-equal '(0 8))))
+
+  (it "returns nil for non-match records"
+    (expect (projectile-search--rg-parse-line
+             "{\"type\":\"begin\",\"data\":{\"path\":{\"text\":\"a.txt\"}}}" "/p/")
+            :to-be nil)
+    (expect (projectile-search--rg-parse-line
+             "{\"type\":\"summary\",\"data\":{}}" "/p/")
+            :to-be nil))
+
+  (it "swallows a malformed JSON line rather than erroring"
+    (expect (projectile-search--rg-parse-line "not json at all" "/p/")
+            :to-be nil))
+
+  (it "skips a match whose line or path is non-UTF-8 (bytes, not text)"
+    ;; rg emits {\"bytes\": <base64>} instead of {\"text\": ...} for content
+    ;; that isn't valid UTF-8; the fast-path drops those cleanly (they surface
+    ;; via the portable elisp path instead)
+    (expect (projectile-search--rg-parse-line
+             (concat "{\"type\":\"match\",\"data\":{"
+                     "\"path\":{\"text\":\"a.txt\"},"
+                     "\"lines\":{\"bytes\":\"Zm9vCg==\"},"
+                     "\"line_number\":1,"
+                     "\"submatches\":[{\"match\":{\"text\":\"foo\"},"
+                     "\"start\":0,\"end\":3}]}}")
+             "/p/")
+            :to-be nil)
+    (expect (projectile-search--rg-parse-line
+             (concat "{\"type\":\"match\",\"data\":{"
+                     "\"path\":{\"bytes\":\"Zm9v\"},"
+                     "\"lines\":{\"text\":\"foo\\n\"},"
+                     "\"line_number\":1,"
+                     "\"submatches\":[{\"match\":{\"text\":\"foo\"},"
+                     "\"start\":0,\"end\":3}]}}")
+             "/p/")
+            :to-be nil)))
+
+(describe "projectile-search--rg-command"
+  (it "builds a fixed-strings, ignore-aware command with the term after --"
+    (let ((cmd (projectile-search--rg-command
+                "foo-bar" t '("node_modules/" "*.elc" "./vendor/"))))
+      (expect (member "--fixed-strings" cmd) :to-be-truthy)
+      (expect (member "--ignore-case" cmd) :to-be-truthy)
+      (expect (member "--case-sensitive" cmd) :to-be nil)
+      ;; a basename glob becomes a negated --glob verbatim
+      (expect (member "!node_modules/" cmd) :to-be-truthy)
+      (expect (member "!*.elc" cmd) :to-be-truthy)
+      ;; a root-anchored `./' glob is translated to ripgrep's `/'-anchored form
+      (expect (member "!/vendor/" cmd) :to-be-truthy)
+      (expect (member "!./vendor/" cmd) :to-be nil)
+      ;; the term is right after the -- terminator, then the relative `./' root
+      (let ((tail (cdr (member "--" cmd))))
+        (expect (car tail) :to-equal "foo-bar")
+        (expect (cadr tail) :to-equal "./"))))
+
+  (it "uses --case-sensitive when case-fold is nil"
+    (let ((cmd (projectile-search--rg-command "foo" nil nil)))
+      (expect (member "--case-sensitive" cmd) :to-be-truthy)
+      (expect (member "--ignore-case" cmd) :to-be nil))))
+
+(describe "projectile-search--rg-ingest streaming and cap"
+  (it "honors projectile-replace-max-matches and marks the list truncated"
+    (projectile-search-review-test--with-project
+        (("a.txt" . "foo\n"))
+      (let ((buf (get-buffer-create projectile-search-buffer-name))
+            (line (lambda (n)
+                    (format (concat "{\"type\":\"match\",\"data\":{"
+                                    "\"path\":{\"text\":\"a.txt\"},"
+                                    "\"lines\":{\"text\":\"foo\\n\"},"
+                                    "\"line_number\":%d,"
+                                    "\"submatches\":[{\"match\":{\"text\":\"foo\"},"
+                                    "\"start\":0,\"end\":3}]}}")
+                            n))))
+        (projectile-replace--seed buf #'projectile-search-mode
+                                  default-directory "foo" "foo" nil t t)
+        (with-current-buffer buf (setq projectile-replace--scanning t))
+        (let ((projectile-replace-max-matches 2))
+          (let ((capped (projectile-search--rg-ingest
+                         buf (list (funcall line 1)
+                                   (funcall line 2)
+                                   (funcall line 3))
+                         default-directory)))
+            (expect capped :to-be-truthy))
+          (with-current-buffer buf
+            (expect (length projectile-replace--matches) :to-equal 2)
+            (expect projectile-replace--truncated :to-be-truthy)))))))
+
+(describe "projectile-search-review ripgrep process lifecycle"
+  (it "cancel-scan kills the running process, leaving no orphan"
+    (assume (executable-find "sleep") "needs a sleep executable")
+    (projectile-search-review-test--with-project
+        (("a.txt" . "foo\n"))
+      ;; stub the command so we get a controllable long-running process
+      ;; without depending on ripgrep being installed
+      (cl-letf (((symbol-function 'projectile-search--rg-command)
+                 (lambda (&rest _) (list "sleep" "30"))))
+        (let ((buf (get-buffer-create projectile-search-buffer-name)))
+          (projectile-replace--seed buf #'projectile-search-mode
+                                    default-directory "foo" "foo" nil t t)
+          (projectile-search--gather-rg buf "foo" nil)
+          (let ((proc (buffer-local-value 'projectile-replace--scan-process buf)))
+            (expect (process-live-p proc) :to-be-truthy)
+            (expect (memq proc (process-list)) :to-be-truthy)
+            (with-current-buffer buf (projectile-replace--cancel-scan))
+            (expect (process-live-p proc) :to-be nil)
+            (expect (memq proc (process-list)) :to-be nil)
+            (expect (buffer-local-value 'projectile-replace--scan-process buf)
+                    :to-be nil))))))
+
+  (it "killing the results buffer kills the running process"
+    (assume (executable-find "sleep") "needs a sleep executable")
+    (projectile-search-review-test--with-project
+        (("a.txt" . "foo\n"))
+      (cl-letf (((symbol-function 'projectile-search--rg-command)
+                 (lambda (&rest _) (list "sleep" "30"))))
+        (let ((buf (get-buffer-create projectile-search-buffer-name)))
+          (projectile-replace--seed buf #'projectile-search-mode
+                                    default-directory "foo" "foo" nil t t)
+          (projectile-search--gather-rg buf "foo" nil)
+          (let ((proc (buffer-local-value 'projectile-replace--scan-process buf)))
+            (expect (process-live-p proc) :to-be-truthy)
+            (kill-buffer buf)
+            (expect (process-live-p proc) :to-be nil)
+            (expect (memq proc (process-list)) :to-be nil)))))))
+
+(describe "projectile-search-review ripgrep dispatch"
+  (before-each
+    ;; make the fast-path see ripgrep as available without depending on a
+    ;; real rg in CI; the gathers are spied so nothing actually runs
+    (spy-on 'executable-find :and-call-fake
+            (lambda (command &rest _) (and (equal command "rg") "rg"))))
+
+  (it "fastpath-p holds only for literal, enabled, interactive, rg present"
+    (let ((noninteractive nil) (projectile-search-use-ripgrep t))
+      (expect (projectile-search--rg-fastpath-p t) :to-be-truthy)
+      ;; a regexp search never takes the fast-path
+      (expect (projectile-search--rg-fastpath-p nil) :to-be nil))
+    (let ((noninteractive nil) (projectile-search-use-ripgrep nil))
+      (expect (projectile-search--rg-fastpath-p t) :to-be nil))
+    ;; batch keeps the deterministic elisp scan
+    (let ((noninteractive t) (projectile-search-use-ripgrep t))
+      (expect (projectile-search--rg-fastpath-p t) :to-be nil)))
+
+  (it "routes a literal search-mode buffer to the ripgrep gather"
+    (projectile-search-review-test--with-project
+        (("a.txt" . "foo\n"))
+      (let ((buf (get-buffer-create projectile-search-buffer-name)))
+        (projectile-replace--seed buf #'projectile-search-mode
+                                  default-directory "foo" "foo" nil t t)
+        (spy-on 'projectile-search--gather-rg)
+        (spy-on 'projectile-replace--gather-async)
+        (let ((noninteractive nil) (projectile-search-use-ripgrep t))
+          (projectile-replace--start buf nil "foo" nil))
+        (expect 'projectile-search--gather-rg :to-have-been-called)
+        (expect 'projectile-replace--gather-async :not :to-have-been-called))))
+
+  (it "routes a regexp search-mode buffer to the elisp path (no rg)"
+    (projectile-search-review-test--with-project
+        (("a.txt" . "foo\n"))
+      (let ((buf (get-buffer-create projectile-search-buffer-name)))
+        (projectile-replace--seed buf #'projectile-search-mode
+                                  default-directory "foo" "foo" nil nil t)
+        (spy-on 'projectile-search--gather-rg)
+        (spy-on 'projectile-replace--gather-async)
+        (let ((noninteractive nil) (projectile-search-use-ripgrep t))
+          (projectile-replace--start buf nil "foo" nil))
+        (expect 'projectile-search--gather-rg :not :to-have-been-called)
+        (expect 'projectile-replace--gather-async :to-have-been-called))))
+
+  (it "never routes a replace-mode buffer to ripgrep, even for a literal"
+    (projectile-search-review-test--with-project
+        (("a.txt" . "foo\n"))
+      (let ((buf (get-buffer-create projectile-replace-buffer-name)))
+        (projectile-replace--seed buf #'projectile-replace-mode
+                                  default-directory "foo" "foo" "" t t)
+        (spy-on 'projectile-search--gather-rg)
+        (spy-on 'projectile-replace--gather-async)
+        (let ((noninteractive nil) (projectile-search-use-ripgrep t))
+          (projectile-replace--start buf nil "foo" nil))
+        (expect 'projectile-search--gather-rg :not :to-have-been-called)
+        (expect 'projectile-replace--gather-async :to-have-been-called))))
+
+  (it "projectile-search-use-ripgrep nil forces the elisp path"
+    (projectile-search-review-test--with-project
+        (("a.txt" . "foo\n"))
+      (let ((buf (get-buffer-create projectile-search-buffer-name)))
+        (projectile-replace--seed buf #'projectile-search-mode
+                                  default-directory "foo" "foo" nil t t)
+        (spy-on 'projectile-search--gather-rg)
+        (spy-on 'projectile-replace--gather-async)
+        (let ((noninteractive nil) (projectile-search-use-ripgrep nil))
+          (projectile-replace--start buf nil "foo" nil))
+        (expect 'projectile-search--gather-rg :not :to-have-been-called)
+        (expect 'projectile-replace--gather-async :to-have-been-called)))))
+
+(describe "projectile-search-review ripgrep end-to-end"
+  (it "finds matches with a correct character column on a multibyte line"
+    (assume (executable-find "rg") "ripgrep is not installed")
+    (projectile-search-review-test--with-project
+        (("mb.txt" . "café foo bar\n")
+         ("plain.txt" . "foo\n"))
+      (let ((buf (get-buffer-create projectile-search-buffer-name))
+            (root default-directory))
+        (projectile-replace--seed buf #'projectile-search-mode
+                                  root "foo" "foo" nil t t)
+        (projectile-search--gather-rg buf "foo" nil)
+        (projectile-search-review-test--wait buf)
+        (with-current-buffer buf
+          (expect projectile-replace--scanning :to-be nil)
+          (expect (projectile-search-review-test--files buf)
+                  :to-equal '("mb.txt" "plain.txt"))
+          (let ((mb (cl-find-if
+                     (lambda (m) (string-suffix-p
+                                  "mb.txt" (projectile-replace--match-file m)))
+                     projectile-replace--matches)))
+            (expect mb :not :to-be nil)
+            (expect (projectile-replace--match-line mb) :to-equal 1)
+            ;; character column 5 ("café " is 5 chars), NOT the byte offset 6
+            (expect (projectile-replace--match-column mb) :to-equal 5)
+            (expect (projectile-replace--match-string mb) :to-equal "foo")
+            (expect (projectile-replace--match-context mb)
+                    :to-equal "café foo bar"))))))
+
+  (it "honors projectile-replace-max-matches over a real ripgrep stream"
+    (assume (executable-find "rg") "ripgrep is not installed")
+    (projectile-search-review-test--with-project
+        (("a.txt" . "foo\nfoo\nfoo\n"))
+      (let ((buf (get-buffer-create projectile-search-buffer-name))
+            (root default-directory)
+            (projectile-replace-max-matches 1))
+        (projectile-replace--seed buf #'projectile-search-mode
+                                  root "foo" "foo" nil t t)
+        (projectile-search--gather-rg buf "foo" nil)
+        (projectile-search-review-test--wait buf)
+        (with-current-buffer buf
+          (expect projectile-replace--scanning :to-be nil)
+          (expect (length projectile-replace--matches) :to-equal 1)
+          (expect projectile-replace--truncated :to-be-truthy)))))
+
+  (it "excludes a path-rooted .projectile ignore from the ripgrep results"
+    (assume (executable-find "rg") "ripgrep is not installed")
+    (projectile-search-review-test--with-project
+        ((".projectile" . "-/vendor\n")
+         ("keep.txt" . "foo\n")
+         ("vendor/hidden.txt" . "foo\n"))
+      (let ((buf (get-buffer-create projectile-search-buffer-name))
+            (root default-directory))
+        (projectile-replace--seed buf #'projectile-search-mode
+                                  root "foo" "foo" nil t t)
+        (projectile-search--gather-rg buf "foo" nil)
+        (projectile-search-review-test--wait buf)
+        (with-current-buffer buf
+          ;; the `-/vendor' dirconfig ignore must be honored by the rg path,
+          ;; just as it is by the elisp path
+          (expect (projectile-search-review-test--files buf)
+                  :to-equal '("keep.txt"))
+          (expect (cl-some (lambda (m)
+                             (string-match-p
+                              "vendor"
+                              (projectile-replace--match-file m)))
+                           projectile-replace--matches)
+                  :to-be nil))))))
+
 ;;; projectile-search-review-test.el ends here


### PR DESCRIPTION
Makes a literal search in the read-only search reviewer near-instant on large projects. With `projectile-search-use-ripgrep` (default t) and `rg` installed, `projectile-search-review` streams matches from `rg --json --fixed-strings` into the same results buffer. Regexp search and the whole replace reviewer keep using the elisp scan: rg's regex isn't Emacs regex, and the write-back needs exact positions that rg's byte offsets don't cleanly give us. The process is wired into the existing scan machinery, so cancel, re-search, quit, kill-buffer and the match cap all kill it.

One caveat, documented: rg still follows its own ignore rules and skips non-UTF-8 files, so its result set can differ slightly from the elisp path. Set the defcustom to nil if you want exact parity.
