### PR TITLE
Docs cleanup, phase 1: consistency and copy-edits

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -14,17 +14,14 @@ known as the `native indexing method`) and the other two (`hybrid` and
 `alien`) rely on external commands like `find`, `git`, etc to
 obtain the list of files in a project.
 
-The `alien` indexing method maximizes the speed of the `hybrid` indexing method.
-This means that Projectile will not do any processing or sorting of the files
-returned by the external commands and you're going to get the maximum
-performance possible.  This behaviour makes a lot of sense for most people, as
+The `alien` indexing method trades features for raw speed: Projectile does no
+processing or sorting of the files returned by the external commands, so you get
+the maximum performance possible.  This behaviour makes a lot of sense for most people, as
 they'd typically be putting ignores in their VCS config (e.g. `.gitignore`) and
 won't care about any additional ignores/unignores/sorting that Projectile might
 also provide.
 
 NOTE: By default the `alien` method is used on all operating systems except Windows.
- Prior to Projectile 2.0 `hybrid` used to be the default (but to make things
- confusing `hybrid` used to be known as `alien` back then).
 
 To force the
 use of native indexing in all operating systems:
@@ -48,11 +45,9 @@ To force the use of alien indexing in all operating systems:
 (setq projectile-indexing-method 'alien)
 ----
 
-This can speed up Projectile in Windows significantly (especially on
-big projects). The disadvantage of this method is that it's not well
-supported on Windows systems, as it requires setting up some Unix
-utilities there. If there's a problem, you can always use `native`
-indexing mode.
+Alien indexing is significantly faster, especially on big projects, but it
+relies on external Unix utilities. That's why it isn't the default on Windows;
+if you run into trouble there, fall back to the `native` indexing method.
 
 === Alien indexing
 
@@ -380,7 +375,7 @@ In Projectile 2.9 this was changed and now each project has its own cache file r
 the project's root directory.
 
 When `projectile-mode` is enabled Projectile will auto-update the project cache when files
-within are added or deleted from within Emacs. (this is achieved by file hooks) This behavior
+within are added or deleted from within Emacs (via file hooks). This behavior
 can be disabled like this:
 
 [source,elisp]
@@ -401,7 +396,7 @@ By default `projectile-files-cache-expire` is `nil`, meaning the cache never
 expires automatically.
 
 One last thing - the project cache will be auto-invalidated if you're using
-`.projectile` and it's last modification time is more recent than the time at
+`.projectile` and its last modification time is more recent than the time at
 which the cache file was last updated.
 
 === Automatic cache updates
@@ -570,13 +565,13 @@ package in the future.
 
 Projectile does many file existence checks since that is how it identifies a
 project root. Normally this is fine, however in some situations the file system
-speed is much slower than usual and can make emacs "freeze" for extended
+speed is much slower than usual and can make Emacs "freeze" for extended
 periods of time when opening files and browsing directories.
 
 The most common example would be interfacing with remote systems using
-TRAMP/ssh. By default all remote file existence checks are cached
+TRAMP/ssh. By default all remote file existence checks are cached.
 
-To disable remote file exists cache that use this snippet of code:
+To disable the remote file-exists cache, use this snippet of code:
 
 [source,elisp]
 ----
@@ -645,7 +640,7 @@ A few things that don't require configuration but are worth knowing:
   unexplained empty completion lists or `stringp, nil` crashes
   downstream.
 
-== Using Projectile Commands Outside of Projects Directories
+== Using Projectile commands outside of project directories
 
 Normally, you'd be using Projectile's commands from within some project directory.
 If, however, you invoke a command outside of a project, by default you'll be prompted
@@ -933,7 +928,7 @@ deleted, say) falls back to a placeholder buffer so the restore never
 errors. This is handled explicitly to keep working on Projectile's Emacs
 28.1 floor, which predates Emacs 30's `window-restore-killed-buffer-windows`.
 
-== Known Projects
+== Known projects
 
 Projectile stores the list of known projects in a file on disk.  You can
 customize its location:
@@ -973,7 +968,7 @@ whenever you visit a file in a project.  You can disable this:
 (setq projectile-track-known-projects-automatically nil)
 ----
 
-== Completion Options
+== Completion options
 
 Projectile reads with Emacs's built-in `completing-read`, so it works out of the
 box with whatever minibuffer UI you use - Vertico, Consult + Marginalia,
@@ -987,20 +982,16 @@ how they're presented.
 (setq projectile-completion-system 'default)
 ----
 
-NOTE: Earlier versions had dedicated `ido`, `ivy` and `helm` values (and an
-`auto` mode that detected `ido-mode`/`ivy-mode`/`helm-mode`). These were removed
-- those frameworks are used through `completing-read` nowadays, or through their
-own Projectile integration packages,
+NOTE: Earlier versions had dedicated `ido`, `ivy` and `helm` completion systems;
+these were removed in Projectile 3.0, and any of the old
+`projectile-completion-system` values now simply behaves like `default`. Those
+frameworks are used through `completing-read` these days, or through their own
+integration packages,
 https://github.com/bbatsov/helm-projectile[helm-projectile] and
-https://github.com/ericdanan/counsel-projectile[counsel-projectile]. Any of the
-old values now simply behaves like `default`.
-
-TIP: `ido` users should enable
-https://github.com/DarwinAwardWinner/ido-completing-read-plus[ido-completing-read+]
-(the package formerly known as `ido-ubiquitous`) via `ido-ubiquitous-mode`. That
-makes `ido` handle `completing-read` everywhere, so it drives Projectile's prompts
-just like the old `ido` completion system did. See the
-xref:upgrading_to_projectile_3.adoc#_ido_users[upgrade guide] for details.
+https://github.com/ericdanan/counsel-projectile[counsel-projectile]. `ido` users
+in particular should read the
+xref:upgrading_to_projectile_3.adoc#ido-users[upgrade guide], which covers
+`ido-completing-read+`.
 
 === Custom completion function
 
@@ -1021,7 +1012,7 @@ https://gist.github.com/rejeep/5933343[this one], which only shows the file name
 (not including path) and, if the selected file is not unique, follows up with a
 completion over names relative to the project root.
 
-== Project-specific Compilation Buffers
+== Project-specific compilation buffers
 
 This affects all commands built on top of `projectile--run-project-cmd` like:
 
@@ -1224,7 +1215,7 @@ Projectile adds a menu to the Emacs menu bar by default.  To disable it:
 (setq projectile-show-menu nil)
 ----
 
-== Project-type-specific Configuration
+== Project-type-specific configuration
 
 === CMake
 

--- a/doc/modules/ROOT/pages/contributing.adoc
+++ b/doc/modules/ROOT/pages/contributing.adoc
@@ -56,7 +56,7 @@ Good documentation is just as important as good code.
 Consider improving and extending this manual and the
 https://github.com/bbatsov/projectile/wiki[community wiki].
 
-=== Working on the Docs
+=== Working on the docs
 
 The manual is generated from the AsciiDoc files in the https://github.com/bbatsov/projectile/tree/master/doc[doc] folder of Projectile's GitHub repo and is published to https://docs.projectile.mx.
 https://antora.org[Antora] is used to convert the manual into HTML.
@@ -80,7 +80,7 @@ $ npm install
 Check out https://docs.antora.org/antora/latest/install/install-antora/[the detailed installation instructions]
 if you run into any problems.
 
-==== Building the Site
+==== Building the site
 
 You can build the documentation locally from the https://github.com/bbatsov/docs.projectile.mx[docs.projectile.mx] repo.
 

--- a/doc/modules/ROOT/pages/extensions.adoc
+++ b/doc/modules/ROOT/pages/extensions.adoc
@@ -10,7 +10,7 @@ There are a number of packages that built on top of the basic functionality prov
 * https://github.com/Alexander-Miller/treemacs/blob/master/src/extra/treemacs-projectile.el[treemacs-projectile] provides integration between treemacs and Projectile.
 * https://github.com/anshulverma/projectile-speedbar[projectile-speedbar] provides integration between speedbar and Projectile.
 
-NOTE: MELPA lists https://melpa.org/#/?q=projectile[20 more Projectile extensions], but I'm too lazy to list them all here.
+NOTE: MELPA lists https://melpa.org/#/?q=projectile[many more Projectile extensions] beyond the highlights above.
 
 There are also some packages that will use Projectile if present. Here are a few examples:
 

--- a/doc/modules/ROOT/pages/projectile_vs_project.adoc
+++ b/doc/modules/ROOT/pages/projectile_vs_project.adoc
@@ -8,7 +8,7 @@ Projectile over the built-in library. This section of the documentation will try
 
 When `project.el` was originally introduced it's feature-set was quite spartan, but it has added some new features in every Emacs release and circa 2026 it should cover the needs of most casual users. I'm guessing that Projectile inspired many features in `project.el`, and Projectile itself was inspired by tools like IntelliJ IDEA.
 
-== TLDR;
+== TL;DR
 
 If the functionality in `project.el` is good enough for you then you should probably use `project.el`.
 
@@ -88,9 +88,9 @@ NOTE: As of early 2026. (Projectile 2.10 and `project.el` in Emacs 31)
 | Somewhat complicated (standard for Emacs)
 |===
 
-== Notable Differences
+== Notable differences
 
-=== Minor Mode vs Global Keymap
+=== Minor mode vs global keymap
 
 Projectile makes heavy use of `projectile-mode`, which provides some additional features (e.g. project status in the modeline).
 You can use Projectile without it, but I guess few people do so. Most of Projectile's functionality will work fine even if the mode is not active.
@@ -98,7 +98,7 @@ You can use Projectile without it, but I guess few people do so. Most of Project
 `project.el` on the other hand, just adds its own keymap under the global keymap (using the prefix `C-x p`). You can do the same for Projectile,
 of course, if you want to.
 
-=== Project Indexing Strategies
+=== Project indexing strategies
 
 Projectile has multiple project indexing strategies to cover a wide variety of use cases. `project.el` has only one, which is more or less the same
 as Projectile's `alien` strategy. Admittedly, that's probably the most commonly used strategy.
@@ -108,7 +108,7 @@ as Projectile's `alien` strategy. Admittedly, that's probably the most commonly 
 Projectile has its own project marker/configuration file. It's a remnant of the early days of the project where I wanted to build a tool that didn't
 rely on the third-party applications and its significance today is not that big. (it will be completely ignored unless you're using `native` or `hybrid` indexing)
 
-=== Backend Protocol
+=== Backend protocol
 
 `project.el` defines a small protocol via `cl-defgeneric` (`project-root`, `project-files`, `project-buffers`, etc.) and ships two backends: a transient one for ad-hoc directories and a VC-aware one. New backends are added with `cl-defmethod`.
 
@@ -429,7 +429,7 @@ Side-by-side mapping of the most common entry points. Useful both when picking b
 | —
 |===
 
-== Projectile's Pros
+== Projectile's pros
 
 * Projectile targets Emacs 28.1+
 * Projectile has different project indexing strategies, which offer you a lot of flexibility in different situations
@@ -444,7 +444,7 @@ Side-by-side mapping of the most common entry points. Useful both when picking b
 * Projectile has more extensive documentation
   ** You can compare it with https://www.gnu.org/software/emacs/manual/html_node/emacs/Projects.html[project.el's documentation] and decide for yourself
 
-== Projectile's Cons
+== Projectile's cons
 
 * Third-party dependency, developed outside of Emacs. This is both a pro and con depending on one's perspective, but I know that many people prefer built-in packages, so I've put it under "cons".
   ** Built-in packages in theory should be maintained better (or at least for longer), as they have the Emacs team behind them.

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -1,6 +1,6 @@
 = Projects
 
-== Supported Project Types
+== Supported project types
 
 One of the main goals of Projectile is to operate on a wide range of project types
 without the need for any configuration. To achieve this it contains a lot of
@@ -19,7 +19,7 @@ TIP: If you'd like to override the default project detection functions you shoul
 check out `projectile-project-root-functions`. We'll discuss how to tweak in more
 details later in the documentation.
 
-=== Version Control Systems
+=== Version control systems
 
 Projectile considers most version-controlled repos to be
 a project. Out of the box Projectile supports:
@@ -86,9 +86,9 @@ are the configuration files of various build tools. Out of the box the following
 | `Taskfile.yml`
 | Go-task/Task project file
 
-| PHP
+| PHP (Symfony)
 | `composer.json`
-| PHP project file
+| Symfony project file
 
 | Erlang & Elixir
 | `rebar.config`
@@ -254,10 +254,6 @@ are the configuration files of various build tools. Out of the box the following
 | `cscope.out`
 | cscope
 
-| Composer
-| `composer.json`
-| Composer project file
-
 | Zig
 | `build.zig.zon`
 | Zig project file
@@ -268,9 +264,9 @@ are the configuration files of various build tools. Out of the box the following
 |===
 
 There's also Projectile's own `.projectile` which serves both as a project marker
-and a configuration file. We'll talk more about later in this section.
+and a configuration file. We'll cover it in more detail later on this page.
 
-== Adding Custom Project Types
+== Adding custom project types
 
 If a project you are working on is recognized incorrectly or you want
 to add your own type of projects you can add following to your Emacs
@@ -402,7 +398,7 @@ Below is a listing of all the available options for `projectile-register-project
 |===
 
 [discrete]
-==== Returning Projectile Commands from a function
+==== Returning Projectile commands from a function
 
 You can also pass a symbolic reference to a function into your project type definition if you wish to define the compile command dynamically:
 
@@ -711,7 +707,7 @@ only when the key can't be derived from a simple prefix/suffix - for
 instance when it lives in a directory name (as with Rails views and Django
 apps) or needs inflection.
 
-=== Editing Existing Project Types
+=== Editing existing project types
 
 You can also edit specific options of already existing project types:
 
@@ -729,7 +725,7 @@ You can also edit specific options of already existing project types:
 
 This will change the value of the `related-files-fn` option, remove the `test-prefix` option and `:precedence 'high` sets the sbt project type to be chosen in preference to other potentially clashing project types (a value `'low` would do the opposite).
 
-=== Removing a Project Type
+=== Removing a project type
 
 If a built-in project type mis-detects your projects (e.g. a language
 manifest that also appears in subdirectories of a larger repo), you can
@@ -830,7 +826,7 @@ automatically:
 (setq projectile-create-missing-test-files t)
 ----
 
-== Customizing Project Detection
+== Customizing project detection
 
 Project detection is pretty simple - Projectile just runs a list of
 project detection functions
@@ -1217,9 +1213,7 @@ TIP: You can also quickly visit or create the `dir-locals-file` with
 kbd:[s-p E] (kbd:[M-x] `projectile-edit-dir-locals` kbd:[RET]). 3rd party packages may use functions `projectile-add-dir-local-variable`
 and `projectile-delete-dir-local-variable` to store their settings.
 
-Here are a few examples of how to use this feature with Projectile.
-
-== Configuring Projectile's Behavior
+== Configuring Projectile's behavior
 
 Projectile exposes many variables (via `defcustom`) which allow users
 to customize its behavior.  Directory variables can be used to set
@@ -1268,7 +1262,7 @@ you e.g. test a command-line program with `projectile-run-project`.
 (setq projectile-compile-use-comint-mode t)
 ----
 
-== Project Buffers
+== Project buffers
 
 Projectile offers a bunch of operations that are operating on the open buffers
 for some project (e.g. `projectile-kill-buffers`). One tricky part here are
@@ -1367,7 +1361,7 @@ name instead, via `projectile-uniquify-dirname-transform`:
 Outside of a project the directory is left untouched, so this is safe to set
 globally. This mirrors `project.el`'s `project-uniquify-dirname-transform`.
 
-== Configure a Project's Lifecycle Commands and Other Attributes
+== Configure a project's lifecycle commands and other attributes
 
 There are a few variables that are intended to be customized via `.dir-locals.el`.
 
@@ -1417,7 +1411,7 @@ you've run in the project. `projectile-repeat-last-command` still re-runs the
 most recent command of any type.
 
 [#project-tasks]
-== Project Tasks
+== Project tasks
 
 Besides the standard lifecycle commands (compile, test, run, etc.), Projectile
 supports an arbitrary number of *named tasks* per project via

--- a/doc/modules/ROOT/pages/upgrading_to_projectile_3.adoc
+++ b/doc/modules/ROOT/pages/upgrading_to_projectile_3.adoc
@@ -117,7 +117,7 @@ The search commands now share one entry point, `projectile-search`
 (kbd:[s-p s s]), backed by a pluggable backend. `projectile-search-backend`
 picks the backend (`auto` by default, favouring `ripgrep` then `grep`); you can
 also register your own with `projectile-register-search-backend`. See the
-xref:configuration.adoc#_searching[Searching] section for details.
+xref:configuration.adoc#searching[Searching] section for details.
 
 `projectile-grep`, `projectile-ripgrep` and `projectile-ag` still exist as thin
 wrappers that force a specific backend.

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -2,6 +2,43 @@
 
 NOTE: Everything in this section assumes you've enabled `projectile-mode`.
 
+== Basic usage
+
+Just open some file in a version-controlled (e.g. `git`) or a project
+(e.g. `maven`) directory that's recognized by Projectile and you're
+ready for action. Projectile happens to recognize out of the box every common
+VCS and many popular project types for various programming languages.
+You can learn more about Projectile's notion of a project xref:projects.adoc[here].
+
+NOTE: The extent of the support for every VCS differs and Git is the best supported
+ one. Projectile supports some advanced features like working with Git submodules
+ and using `git-grep` instead of GNU grep.
+
+You need to know only a handful of Projectile commands to start benefiting from it.
+
+NOTE: The examples below (and throughout this manual) use the `s-p` prefix.
+ Projectile ships no default prefix key, so you need to bind one yourself as
+ shown in <<basic-configuration>>.
+
+* Find file in current project (kbd:[s-p f])
+* Switch project (kbd:[s-p p]) (you can also switch between open projects with kbd:[s-p q], or jump back to the previously active project with `projectile-switch-to-most-recent-project`)
+* Grep (search for text/regexp) in project (kbd:[s-p s g])
+* Replace in project (kbd:[s-p r])
+* Find references in project (kbd:[s-p ?] or kbd:[s-p s x])
+* Invoke any Projectile command via the Projectile dispatch menu (kbd:[s-p m])
+* Toggle between implementation and test (kbd:[s-p t])
+* Find another file with the same base name but a different extension, e.g. `foo.h` <-> `foo.c` (kbd:[s-p a])
+* Find a project file of a given kind, or jump between related files of a project type (e.g. a Rails model and its controller) (kbd:[s-p j] / kbd:[s-p J])
+* Run a shell command in the root of the project (kbd:[s-p !] for a sync command and kbd:[s-p &] for an async command)
+* Run various pre-defined project commands like:
+** build/compile project (kbd:[s-p c c])
+** test project (kbd:[s-p c t])
+** install project (kbd:[s-p c i])
+** package project (kbd:[s-p c p])
+** run project (kbd:[s-p c r])
+
+There are many more commands, covered in the sections below, but the basics can get you pretty far.
+
 == Basic setup
 
 In this section we'll cover the bare minimum of setup you might want to
@@ -11,7 +48,7 @@ bit you'll get more out of it.
 Check out the xref:configuration.adoc["Configuration"] section of the manual
 for a lot more information about configuring Projectile.
 
-=== Basic Configuration
+=== Basic configuration
 
 Here's how a typical Projectile configuration would look:
 
@@ -49,7 +86,7 @@ Here's how a typical Projectile configuration would look:
 
 The example above builds upon the simpler setup demonstrated in the "Installation" section.
 
-=== Automated Project Discovery
+=== Automated project discovery
 
 To add a project to Projectile's list of known projects, open a file
 in the project. If you have a projects directory, you can tell
@@ -106,16 +143,16 @@ that held several checkouts) use `projectile-forget-projects-under`. It prompts
 for a directory and removes the known projects that live directly under it; with
 a prefix argument it also removes projects nested deeper in the tree.
 
-=== Minibuffer Completion
+=== Minibuffer completion
 
 Projectile reads through Emacs's built-in `completing-read`, so it works with
 whatever minibuffer UI you use. It works fine with the stock completion, but
 you're encouraged to pair it with a modern package like `vertico` (+ `consult`,
 `marginalia`, `orderless`) or `fido-mode`/`fido-vertical-mode`. See the
-xref:configuration.adoc#_completion_options[Completion Options] section for
+xref:configuration.adoc#completion-options[Completion Options] section for
 details, including how to plug in a custom completion function.
 
-=== Installing External Tools
+=== Installing external tools
 
 NOTE: Windows users can ignore this section unless they are using Emacs via WSL or `cygwin`.
 
@@ -145,40 +182,7 @@ https://github.com/BurntSushi/ripgrep[rg] (`ripgrep`)
 
 TIP: You should also install the Emacs packages `ag`, `ripgrep` or `rg` if you want to make use of Projectile's commands `projectile-ag` and `projectile-ripgrep`.
 
-== Basic Usage
-
-Just open some file in a version-controlled (e.g. `git`) or a project
-(e.g. `maven`) directory that's recognized by Projectile and you're
-ready for action. Projectile happens to recognize out of the box every common
-VCS and many popular project types for various programming languages.
-You can learn more about Projectile's notion of a project xref:projects.adoc[here].
-
-NOTE: The extent of the support for every VCS differs and Git is the best supported
- one. Projectile supports some advanced features like working with Git submodules
- and using `git-grep` instead of GNU grep.
-
-You need to know only a handful of Projectile commands to start benefiting from it.
-
-* Find file in current project (kbd:[s-p f])
-* Switch project (kbd:[s-p p]) (you can also switch between open projects with kbd:[s-p q], or jump back to the previously active project with `projectile-switch-to-most-recent-project`)
-* Grep (search for text/regexp) in project (kbd:[s-p s g])
-* Replace in project (kbd:[s-p r])
-* Find references in project (kbd:[s-p ?] or kbd:[s-p s x])
-* Invoke any Projectile command via the Projectile dispatch menu (kbd:[s-p m])
-* Toggle between implementation and test (kbd:[s-p t])
-* Find another file with the same base name but a different extension, e.g. `foo.h` <-> `foo.c` (kbd:[s-p a])
-* Find a project file of a given kind, or jump between related files of a project type (e.g. a Rails model and its controller) (kbd:[s-p j] / kbd:[s-p J])
-* Run a shell command in the root of the project (kbd:[s-p !] for a sync command and kbd:[s-p &] for an async command)
-* Run various pre-defined project commands like:
-** build/compile project (kbd:[s-p c c])
-** test project (kbd:[s-p c t])
-** install project (kbd:[s-p c i])
-** package project (kbd:[s-p c p])
-** run project (kbd:[s-p c r])
-
-The next section lists many more commands, but the basics can get you pretty far.
-
-== Interactive Commands
+== Interactive commands
 
 NOTE: Projectile doesn't have a default key prefix for its commands, but all the examples
  in the manual assume you've opted for kbd:[s-p] (`super`-p).
@@ -225,7 +229,7 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | Switch to a project directory and show it in another frame.
 
 | kbd:[s-p T]
-| Display a list of all test files(specs, features, etc) in the project.
+| Display a list of all test files (specs, features, etc.) in the project.
 
 | kbd:[s-p l]
 | Display a list of all files in a directory (that's not necessarily a project)
@@ -282,7 +286,7 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | Runs `multi-occur` on all project buffers currently open.
 
 | kbd:[s-p r]
-| Runs interactive query-replace on all files in the projects.
+| Runs interactive query-replace on all files in the project.
 
 | kbd:[s-p R]
 | Reviewable replace: gather all matches in a results buffer where you can preview and toggle them before applying (see below).
@@ -650,7 +654,7 @@ scan (ripgrep's regex syntax is not Emacs regexp syntax), and the whole
 replace reviewer always uses the elisp scan (its write-back needs the
 exact buffer positions the elisp scan records).
 
-== Customizing Projectile's Keybindings
+== Customizing Projectile's keybindings
 
 It is possible to add additional commands to
 `projectile-command-map` referenced by the prefix key in
@@ -684,7 +688,7 @@ NOTE: The `Super` keybindings are not usable in Windows, as Windows
  makes heavy use of such keybindings itself. Emacs Prelude already adds those
  extra keybindings.
 
-== Dispatch Menu
+== Dispatch menu
 
 Projectile ships `projectile-dispatch`, a `transient` menu that mirrors
 `projectile-command-map`, for those of you who'd rather pick a command from a
@@ -755,11 +759,11 @@ it about Projectile's project discovery logic.
 TIP: Projectile provides its own alternative to `xref-find-references` that's named
 `projectile-find-references` (kbd:[s-p ?] or kbd:[s-p s x]). It's a backend-agnostic
 *textual* search: it greps the project for the symbol, scoped to the project root and
-honouring Projectile's ignore configuration (`.projectile' and the globally-ignored
+honouring Projectile's ignore configuration (`.projectile` and the globally-ignored
 files/directories), just like `projectile-grep` and friends. Use it when you don't have
 a language server or tags table set up; otherwise `xref-find-references` gives you
 semantic results (and is scoped to the Projectile project too, thanks to the
-`project.el' integration above).
+`project.el` integration above).
 
 You can disable the `project.el` integration like this:
 


### PR DESCRIPTION
First of a multi-phase docs cleanup. Polish only - nothing moved or split.

Headings are normalized to sentence case everywhere, the Usage page now opens with *Basic usage* instead of ~140 lines of setup (with an up-front note that the examples assume you've bound the `s-p` prefix, since Projectile ships none), and three internal cross-links that pointed at underscore anchors while Antora generates hyphenated ones are fixed - those had been dead on the site. Plus the usual copy-edits: the backwards "alien maximizes the speed of hybrid" sentence, the orphaned Windows indexing paragraph, the duplicate `composer.json` project-type row (the real type is `php-symfony`), and assorted typos.

Phases 2 (de-duplication across the projects/configuration boundary) and 3 (splitting the mega-pages, getting-started tutorial, nav grouping) follow separately.