### PR TITLE
Docs cleanup, phase 2: de-duplication and cross-linking

### DIFF
--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -229,6 +229,10 @@ doesn't catch you off guard.  Switch to `hybrid` (or `native`) if you
 need those rules applied; set
 `projectile-warn-when-dirconfig-is-ignored` to nil to silence.
 
+TIP: For the details of each ignore mechanism (`.projectile`, the indexing
+tools, and the global ignore/unignore variables), see
+xref:projects.adoc#ignoring-files[Ignoring files].
+
 == Sorting
 
 You can choose how Projectile sorts files by customizing `projectile-sort-order`.

--- a/doc/modules/ROOT/pages/faq.adoc
+++ b/doc/modules/ROOT/pages/faq.adoc
@@ -15,7 +15,7 @@ project and happens to be part of Emacs.
 have been asking since how do the two packages compare.
 
 Internally they have a lot of differences (e.g. different approach to project discovery and indexing), but from the user standpoint they are probably quite similar
-these days (circa 2021). Historically, Projectile had a lot more features, but many
+these days. Historically, Projectile had a lot more features, but many
 of them found their way into `project.el` over the years. If all you need is
 a way to quickly jump between project files or search/replace inside a project, you can't go wrong with both.
 
@@ -32,10 +32,10 @@ NOTE: You can find a more detailed comparison xref:projectile_vs_project.adoc[he
 
 == Does Projectile provide any integration with `project.el`?
 
-Starting with Projectile 2.7, Projectile will plug automatically its
-project discovery functions in `project.el`. You can find more
-information on the subject in the xref:usage.adoc["Usage"] section of
-the documentation.
+Starting with Projectile 2.7, Projectile automatically plugs its project
+discovery functions into `project.el`. See the
+xref:usage.adoc#using-projectile-with-project-el[Using Projectile with
+project.el] section for details.
 
 == Does Projectile work with TRAMP?
 

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -995,6 +995,11 @@ effect immediately even when several buffers share the same directory.
 
 == Ignoring files
 
+Projectile can exclude files and directories from a project in several ways,
+described below. Which of them apply depends on the indexing method in use - see
+the xref:configuration.adoc#indexing-method-comparison[indexing method
+comparison] for the full matrix of what each method honors.
+
 === Ignoring files using `.projectile` (a.k.a. dirconfig)
 
 WARNING: The contents of `.projectile` are ignored when using the


### PR DESCRIPTION
Second phase of the documentation cleanup. On close reading, the docs are better cross-linked than the editorial audit suggested, so this phase is intentionally small and surgical rather than a big content shuffle.

- The FAQ's "Does Projectile provide integration with project.el?" answer now links to the specific *Using Projectile with project.el* section instead of gesturing at the whole Usage page, and a stale "circa 2021" date is dropped from the comparison answer.
- The *Ignoring files* section on the Projects page gets a short framing intro that links to the indexing-method comparison matrix (the one place that authoritatively says which indexing method honors which ignore rule), with a reciprocal link added back from the matrix. That gives the "how do I ignore X and will it actually apply?" journey a single reference point.

Deliberately left alone: the project.el material spread across the FAQ, the migration guide and the comparison page is already curated-summary-plus-pointer (the migration guide links out three times), not real duplication; and the search-reviewer key table stays separate from the replace-reviewer one because the read-only reviewer has a genuinely smaller key set, so a dedicated table beats a cross-lookup.

The substantive structural work (splitting the two mega-pages, a getting-started tutorial, nav grouping, a defcustom index) is Phase 3, which I'll scope with you first since it changes page boundaries and URLs.

AsciiDoc parses clean; all three new cross-link anchors verified.