### PR TITLE
Fix edge-case bugs found in the 3.1 review

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -1746,6 +1746,10 @@ The cache is created both in memory and on the hard drive."
           (puthash project-root new-cache projectile-projects-cache)
           (when (projectile-persistent-cache-p)
             (projectile-serialize new-cache (projectile-project-cache-file project-root)))
+          ;; Re-derive watches from the shrunken cache, otherwise the purged
+          ;; file's directory keeps being watched and a later create-event
+          ;; there re-adds the entries we just removed.
+          (projectile--maybe-watch-project project-root new-cache)
           (when projectile-verbose
             (message "%s removed from cache" file)))
       (user-error "%s is not in the cache" file))))
@@ -1764,7 +1768,10 @@ The cache is created both in memory and on the hard drive."
                                 project-cache)))
     (puthash project-root new-cache projectile-projects-cache)
     (when (projectile-persistent-cache-p)
-      (projectile-serialize new-cache (projectile-project-cache-file project-root)))))
+      (projectile-serialize new-cache (projectile-project-cache-file project-root)))
+    ;; Re-derive watches so the purged directory is no longer watched (and its
+    ;; files don't get re-added by a later create-event).
+    (projectile--maybe-watch-project project-root new-cache)))
 
 (defun projectile-file-cached-p (file project)
   "Check if FILE is already in PROJECT cache."
@@ -5453,7 +5460,10 @@ for the kind, and repeated invocations cycle through them in table order."
     (unless file
       (user-error "The current buffer is not visiting a file"))
     (let* ((project-root (projectile-acquire-root))
-           (rel-path (file-relative-name file project-root))
+           ;; Spell the file the same way as the root (symlink-resolved), so a
+           ;; project reached through a symlinked root doesn't yield a bogus
+           ;; `../'-prefixed relative name and a spurious "no related files".
+           (rel-path (projectile--project-relative-name (file-truename file) project-root))
            (ring (projectile--related-file-ring rel-path))
            (others (remove rel-path ring)))
       (unless others
@@ -8107,6 +8117,12 @@ Only the read-only search reviewer's ripgrep fast-path uses this; the
 pure-elisp async scan uses `projectile-replace--scan-timer' instead.
 Held so a re-scan, a quit, or killing the buffer can kill a scan that is
 still running, leaving no orphaned process.")
+(defvar-local projectile-replace--scan-generation 0
+  "Monotonic token identifying the current async scan of this buffer.
+Every (re-)scan and every cancel bumps it; a chunk timer carries the
+generation it was scheduled under and no-ops when it no longer matches.
+This way a timer that already fired and is waiting to run can't append
+to a newer scan's match list if it is superseded in the meantime.")
 (defvar-local projectile-replace--render-function #'projectile-replace--render
   "Function that redraws the current results buffer from its state.
 The scanning, navigation, filter and toggle machinery is shared
@@ -8274,6 +8290,9 @@ on re-scan, on quit, and from `kill-buffer-hook'."
     ;; drop our sentinel first so killing it doesn't run the finish handler
     (set-process-sentinel projectile-replace--scan-process #'ignore)
     (delete-process projectile-replace--scan-process))
+  ;; Bump the generation so a chunk timer that already fired and is queued
+  ;; behind us no-ops rather than resurrecting this scan.
+  (cl-incf projectile-replace--scan-generation)
   (setq projectile-replace--scan-timer nil
         projectile-replace--scan-process nil
         projectile-replace--scanning nil))
@@ -8289,24 +8308,31 @@ REGEXP; `projectile-replace-max-matches' and the `:truncated' note are
 honored the same way.  ON-DONE (or nil) is called in BUFFER once the scan
 finishes.  A scan already running in BUFFER should be canceled first (see
 `projectile-replace--cancel-scan')."
-  (with-current-buffer buffer
-    (setq projectile-replace--matches nil
-          projectile-replace--truncated nil
-          projectile-replace--filtered nil
-          projectile-replace--scanning t
-          projectile-replace--scan-timer nil))
-  (projectile-replace--scan-step
-   buffer candidates regexp projectile-replace-max-matches on-done))
+  (let ((generation
+         (with-current-buffer buffer
+           (setq projectile-replace--matches nil
+                 projectile-replace--truncated nil
+                 projectile-replace--filtered nil
+                 projectile-replace--scanning t
+                 projectile-replace--scan-timer nil)
+           (cl-incf projectile-replace--scan-generation))))
+    (projectile-replace--scan-step
+     buffer candidates regexp projectile-replace-max-matches on-done generation)))
 
-(defun projectile-replace--scan-step (buffer remaining regexp budget on-done)
+(defun projectile-replace--scan-step (buffer remaining regexp budget on-done generation)
   "Scan one chunk of REMAINING candidates for REGEXP into BUFFER.
-BUDGET is the remaining match allowance.  Delivers this chunk's matches
-into BUFFER and re-renders; while candidates and budget remain it
-schedules itself for the next chunk via a zero-delay timer, otherwise it
-finishes: clears the scanning state, does a final render and calls
-ON-DONE.  Guarded against a killed BUFFER (leaving no work behind) and
-against \\`C-g' during a chunk (which cancels the scan cleanly)."
-  (when (buffer-live-p buffer)
+BUDGET is the remaining match allowance.  GENERATION is the scan token
+this chunk belongs to; the step no-ops when it no longer matches BUFFER's
+current `projectile-replace--scan-generation' (i.e. the scan was
+superseded or canceled).  Delivers this chunk's matches into BUFFER and
+re-renders; while candidates and budget remain it schedules itself for
+the next chunk via a zero-delay timer, otherwise it finishes: clears the
+scanning state, does a final render and calls ON-DONE.  Guarded against a
+killed BUFFER (leaving no work behind) and against \\`C-g' during a chunk
+\(which cancels the scan cleanly)."
+  (when (and (buffer-live-p buffer)
+             (= generation
+                (buffer-local-value 'projectile-replace--scan-generation buffer)))
     (condition-case nil
         (let ((fold (buffer-local-value 'projectile-replace--case-fold buffer))
               (count 0)
@@ -8341,7 +8367,7 @@ against \\`C-g' during a chunk (which cancels the scan cleanly)."
                 (setq projectile-replace--scan-timer
                       (run-with-timer 0 nil
                                       #'projectile-replace--scan-step
-                                      buffer remaining regexp budget on-done))
+                                      buffer remaining regexp budget on-done generation))
                 (funcall projectile-replace--render-function))
             ;; finished (or budget-truncated): settle and hand off
             (with-current-buffer buffer
@@ -8482,7 +8508,7 @@ async scan streams matches in."
                      "\\[projectile-replace--export] export  "
                      "\\[projectile-replace--refresh] re-search  "
                      "\\[projectile-replace--visit] visit  "
-                     "\\[quit-window] quit\n"
+                     "\\[projectile-replace--quit] quit\n"
                      "\\[projectile-replace--toggle-case] case  "
                      "\\[projectile-replace--toggle-regexp] regexp/literal  "
                      "\\[projectile-replace--keep-matches]/\\[projectile-replace--flush-matches] keep/flush line  "
@@ -9429,7 +9455,7 @@ property so the shared navigation, visit and filter commands find it."
                      "\\[projectile-replace--refresh] re-search  "
                      "\\[projectile-search--to-replace] replace these  "
                      "\\[projectile-replace--export] export  "
-                     "\\[quit-window] quit\n"
+                     "\\[projectile-replace--quit] quit\n"
                      "\\[projectile-replace--toggle-case] case  "
                      "\\[projectile-replace--toggle-regexp] regexp/literal  "
                      "\\[projectile-replace--keep-matches]/\\[projectile-replace--flush-matches] keep/flush line  "
@@ -12477,10 +12503,15 @@ deserializer declines (e.g. the underlying file is gone)."
     (list :file (buffer-file-name buffer) :point (point))))
 
 (defun projectile-session--deserialize-file (record)
-  "Recreate the file buffer described by RECORD, or nil when the file is gone."
+  "Recreate the file buffer described by RECORD, or nil when the file is gone.
+The file is visited non-interactively - large-file warnings and unsafe
+file-local-variable prompts are suppressed - so restoring a session (in
+particular on startup) never blocks Emacs on a `yes-or-no-p'."
   (let ((file (plist-get record :file)))
     (when (and file (file-exists-p file))
-      (let ((buffer (find-file-noselect file)))
+      (let* ((large-file-warning-threshold nil)
+             (enable-local-variables :safe)
+             (buffer (find-file-noselect file)))
         (when (buffer-live-p buffer)
           (let ((point (plist-get record :point)))
             (when (integerp point)
@@ -12652,8 +12683,15 @@ session was restored."
          (recreated
           (let ((state (plist-get data :window-state)))
             (when state
-              (window-state-put (projectile-session--sanitize-window-state state)
-                                (frame-root-window) 'safe)))
+              ;; A hand-edited or corrupt :window-state that still passes the
+              ;; version check shouldn't abort the whole restore - fall through
+              ;; to the recreated buffers instead, matching the buffer-recreation
+              ;; guard above and the file-read robustness elsewhere here.
+              (condition-case err
+                  (window-state-put (projectile-session--sanitize-window-state state)
+                                    (frame-root-window) 'safe)
+                (error
+                 (message "projectile-session: could not restore window layout: %S" err)))))
           t)
          ;; Nothing could be recreated (every saved file is gone, say);
          ;; return nil so `restore-on-switch' falls back to populating the

--- a/test/projectile-core-test.el
+++ b/test/projectile-core-test.el
@@ -143,7 +143,16 @@
       ;; The in-memory cache should be updated
       (expect (gethash "/project/" projectile-projects-cache) :to-equal '("foo.el" "baz.el"))
       ;; projectile-serialize should be called with the updated list, not the stale one
-      (expect 'projectile-serialize :to-have-been-called-with '("foo.el" "baz.el") "/tmp/cache.eld"))))
+      (expect 'projectile-serialize :to-have-been-called-with '("foo.el" "baz.el") "/tmp/cache.eld")))
+  (it "re-derives file-notify watches from the updated cache"
+    (let ((projectile-projects-cache (make-hash-table :test 'equal))
+          (projectile-enable-caching t))
+      (puthash "/project/" '("foo.el" "bar.el") projectile-projects-cache)
+      (spy-on 'projectile-project-root :and-return-value "/project/")
+      (spy-on 'projectile--maybe-watch-project)
+      (projectile-purge-file-from-cache "bar.el")
+      (expect 'projectile--maybe-watch-project
+              :to-have-been-called-with "/project/" '("foo.el")))))
 
 (describe "projectile-purge-dir-from-cache"
   (it "removes files under the directory from the in-memory cache"
@@ -177,7 +186,16 @@
       (spy-on 'projectile-project-root :and-return-value "/project/")
       (spy-on 'projectile-serialize)
       (projectile-purge-dir-from-cache "src/")
-      (expect 'projectile-serialize :not :to-have-been-called))))
+      (expect 'projectile-serialize :not :to-have-been-called)))
+  (it "re-derives file-notify watches from the updated cache"
+    (let ((projectile-projects-cache (make-hash-table :test 'equal))
+          (projectile-enable-caching t))
+      (puthash "/project/" '("src/foo.el" "test/baz.el") projectile-projects-cache)
+      (spy-on 'projectile-project-root :and-return-value "/project/")
+      (spy-on 'projectile--maybe-watch-project)
+      (projectile-purge-dir-from-cache "src/")
+      (expect 'projectile--maybe-watch-project
+              :to-have-been-called-with "/project/" '("test/baz.el")))))
 
 (describe "projectile-sort-by-modification-time"
   (it "sorts files by modification time in descending order"

--- a/test/projectile-file-kinds-test.el
+++ b/test/projectile-file-kinds-test.el
@@ -273,6 +273,27 @@
             (projectile-toggle-related-file)
             (expect 'find-file :to-have-been-called-with
                     (expand-file-name "app/models/user.rb" root)))))))
+  (it "resolves the visited file's symlinks against the project root"
+    (projectile-test-with-sandbox
+      (projectile-test-with-files-using-custom-project
+          ("app/controllers/users_controller.rb"
+           "app/models/user.rb")
+          (:file-kinds projectile--rails-file-kinds)
+        (let* ((root (file-truename (expand-file-name "project/")))
+               ;; the current file reached through a symlinked project root, so
+               ;; `buffer-file-name' is un-resolved while the root is resolved
+               (link-file (expand-file-name
+                           "app/controllers/users_controller.rb"
+                           (file-name-as-directory (expand-file-name "linkproj")))))
+          (make-symbolic-link "project" "linkproj")
+          (spy-on 'find-file)
+          (cl-letf (((symbol-function 'buffer-file-name)
+                     (lambda (&optional _) link-file)))
+            (setq last-command nil this-command 'projectile-toggle-related-file)
+            ;; without truename'ing the file this raises "No related files"
+            (projectile-toggle-related-file)
+            (expect 'find-file :to-have-been-called-with
+                    (expand-file-name "app/models/user.rb" root)))))))
   (it "cycles through several related kinds on repeated invocation"
     (projectile-test-with-sandbox
       (projectile-test-with-files-using-custom-project

--- a/test/projectile-scan-async-test.el
+++ b/test/projectile-scan-async-test.el
@@ -341,7 +341,29 @@ project root.  BODY runs with `default-directory' at the root and
              (buf (projectile-scan-async-test--seed root)))
         (kill-buffer buf)
         ;; a chunk that fires after its buffer was killed is a silent no-op
-        (expect (projectile-replace--scan-step buf candidates "foo" 100 nil)
-                :not :to-throw)))))
+        (expect (projectile-replace--scan-step buf candidates "foo" 100 nil 0)
+                :not :to-throw))))
+
+  (it "ignores a chunk carrying a superseded scan generation"
+    (projectile-scan-async-test--with-project
+        (("a.txt" . "foo\nfoo\n"))
+      (let* ((root default-directory)
+             (candidates (projectile-scan-async-test--candidates root))
+             (buf (projectile-scan-async-test--seed root)))
+        (unwind-protect
+            (progn
+              (projectile-replace--gather-async candidates "foo" buf nil)
+              (projectile-scan-async-test--pump buf)
+              (with-current-buffer buf
+                (let ((current projectile-replace--scan-generation)
+                      (before (copy-sequence projectile-replace--matches)))
+                  ;; a step from an earlier generation must not touch the matches
+                  (projectile-replace--scan-step buf candidates "foo" 100 nil (1- current))
+                  (expect projectile-replace--matches :to-equal before)
+                  ;; sanity: the same step at the current generation does append
+                  (projectile-replace--scan-step buf candidates "foo" 100 nil current)
+                  (expect (length projectile-replace--matches)
+                          :to-be-greater-than (length before)))))
+          (kill-buffer buf))))))
 
 ;;; projectile-scan-async-test.el ends here

--- a/test/projectile-session-test.el
+++ b/test/projectile-session-test.el
@@ -285,6 +285,25 @@
                 (when (buffer-live-p buf) (kill-buffer buf)))))
         (delete-file tmp))))
 
+  (it "recreates a file buffer without interactive prompts"
+    (let ((tmp (make-temp-file "projectile-session-file" nil ".txt")))
+      (unwind-protect
+          (progn
+            (with-temp-file tmp (insert "x\n"))
+            (let (seen-lfwt seen-elv)
+              (spy-on 'find-file-noselect :and-call-fake
+                      (lambda (&rest _)
+                        (setq seen-lfwt large-file-warning-threshold
+                              seen-elv enable-local-variables)
+                        (get-buffer-create " *psession-fake*")))
+              (projectile-session--deserialize-file (list :file tmp))
+              ;; large-file warnings and unsafe file-locals must be suppressed,
+              ;; so restoring a session never blocks on a prompt
+              (expect seen-lfwt :to-be nil)
+              (expect seen-elv :to-be :safe)))
+        (when (get-buffer " *psession-fake*") (kill-buffer " *psession-fake*"))
+        (delete-file tmp))))
+
   (it "round-trips a dired buffer via its directory"
     (let* ((dir (make-temp-file "projectile-session-dired" t))
            (buf (dired-noselect dir)))
@@ -455,6 +474,22 @@
                 (when (get-buffer n) (kill-buffer n)))))
         (delete-file tmp1)
         (delete-file tmp2))))
+
+  (it "survives a corrupt window layout by falling back to the recreated buffers"
+    (let ((tmp (make-temp-file "projectile-session-corrupt" nil ".txt")))
+      (unwind-protect
+          (progn
+            (with-temp-file tmp (insert "x\n"))
+            ;; a data blob that passes the version check but carries a bogus
+            ;; :window-state must not abort the whole restore
+            (spy-on 'projectile-session--read :and-return-value
+                    (list :buffers (list (cons t (list :file tmp :point 1)))
+                          :window-state '(this is not a valid window state)))
+            ;; a throw here would fail the test; the fix demotes it to a message
+            (expect (projectile-session-restore "/proj/root/") :to-be t))
+        (when (get-buffer (file-name-nondirectory tmp))
+          (kill-buffer (file-name-nondirectory tmp)))
+        (delete-file tmp))))
 
   (it "does not error restoring a layout whose file is gone"
     (let ((tmp (make-temp-file "projectile-session-gone" nil ".txt")))


### PR DESCRIPTION
Six edge-case bugs from a review of the 3.1 work, each with a regression test.

`projectile-toggle-related-file` broke under a symlinked project root because it hand-rolled the relative path without `file-truename` (same class as the frecency fix in `196e45c`); it now goes through `projectile--project-relative-name`. The replace/search help advertised `C-x w q` for quit instead of the actual `q`. `projectile-purge-file/dir-from-cache` left watches on the purged path, so a later create event re-added the entries. Session restore could block startup on a large-file or unsafe-locals prompt, and a corrupt `:window-state` aborted the whole restore instead of keeping the recreated buffers. Finally, a stale async-scan chunk could bleed into a fresh scan, so scans now carry a generation token.

Nice-to-haves, doc drift and the version-metadata inconsistency are left for follow-ups.