### PR TITLE
Address the non-blocker findings from the 3.1 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@
   * Which buffers are recorded, and how, is extensible via `projectile-session-buffer-serializers`; file-visiting and `dired-mode` buffers work out of the box.
   * The session commands are bound under the `w` sub-prefix of the command map (`s-p w s`, `s-p w S`, `s-p w r`, `s-p w R`, `s-p w f`, `s-p w b`), and are also available from `projectile-dispatch` and the Projectile menu.
 
+### Changes
+
+* Add `projectile-frecency-max-projects` (default 100), which caps how many projects' frecency history is kept so the store can't grow without bound.
+* `projectile-replace-scan-chunk-size` is now a user-facing `defcustom` (was an internal variable).
+
 ## 3.1.0 (2026-07-04)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -2246,6 +2246,15 @@ When the limit is exceeded, the lowest-ranking entries are dropped."
   :type 'natnum
   :package-version '(projectile . "3.1.0"))
 
+(defcustom projectile-frecency-max-projects 100
+  "Maximum number of projects whose frecency history is kept.
+When the store holds more roots than this, the least recently active
+ones are dropped on save, so the history can't grow without bound as
+projects come and go."
+  :group 'projectile
+  :type 'natnum
+  :package-version '(projectile . "3.2.0"))
+
 (defvar projectile--frecency-table nil
   "Hash of project root to a hash of relative file name to (COUNT . TIME).
 TIME is the last visit in seconds since the epoch.  nil until loaded
@@ -2377,6 +2386,21 @@ both, the higher visit count and the later timestamp win."
           disk-files)))
      disk-table)))
 
+(defun projectile--frecency-cap-projects (data)
+  "Return DATA capped at `projectile-frecency-max-projects' roots.
+DATA is an alist of (ROOT . FILE-ENTRIES), each FILE-ENTRY a
+\(FILE COUNT TIME) list.  The most recently active roots (highest file
+timestamp) are kept and the rest dropped, so the store can't accumulate
+dead roots without bound."
+  (if (<= (length data) projectile-frecency-max-projects)
+      data
+    (let ((ranked
+           (sort (copy-sequence data)
+                 (lambda (a b)
+                   (> (apply #'max 0 (mapcar (lambda (fe) (or (nth 2 fe) 0)) (cdr a)))
+                      (apply #'max 0 (mapcar (lambda (fe) (or (nth 2 fe) 0)) (cdr b))))))))
+      (seq-take ranked projectile-frecency-max-projects))))
+
 (defun projectile--frecency-save ()
   "Persist the frecency data to `projectile-frecency-file'.
 Merges with the data on disk first, so concurrent Emacs sessions
@@ -2401,7 +2425,8 @@ the file isn't writable, so a later save can retry."
                         files)
                (push (cons root file-entries) data))))
          projectile--frecency-table)
-        (projectile-serialize data projectile-frecency-file))
+        (projectile-serialize (projectile--frecency-cap-projects data)
+                              projectile-frecency-file))
       (setq projectile--frecency-dirty nil))))
 
 ;;;###autoload

--- a/projectile.el
+++ b/projectile.el
@@ -5319,7 +5319,6 @@ a plist with the following optional properties:
   :key-fn  a function of the file's relative path returning its resource
            key string, or nil when the file is not of this kind.  When
            omitted the key is derived by `projectile--file-kind-default-key'.
-  :file-fn  reserved for a future inverse of :key-fn; currently unused.
 
 The returned function, given a relative path, finds the first kind the
 path belongs to and emits, for every *other* kind, an entry
@@ -12640,12 +12639,20 @@ so shared or circular structure in a record can't hang the write."
 (defun projectile-session--read-file (file)
   "Read and return the session data stored in FILE, or nil.
 Data that isn't a well-formed session plist of the current version is
-ignored, so an unreadable or stale file is skipped rather than erroring."
+ignored, so an unreadable or stale file is skipped rather than erroring.
+A real session file written by an incompatible format version is skipped
+with a message, so the user learns why nothing was restored."
   (let ((data (projectile-unserialize file)))
-    (and (consp data)
-         (equal (plist-get data :projectile-session-version)
-                projectile-session--format-version)
-         data)))
+    (cond
+     ((and (consp data)
+           (equal (plist-get data :projectile-session-version)
+                  projectile-session--format-version)
+           data))
+     ((and (consp data) (plist-member data :projectile-session-version))
+      (message "Ignoring session file %s: format version %s (expected %s)"
+               file (plist-get data :projectile-session-version)
+               projectile-session--format-version)
+      nil))))
 
 (defun projectile-session--read (root)
   "Read and return project ROOT's session data, or nil.

--- a/projectile.el
+++ b/projectile.el
@@ -329,7 +329,10 @@ takes effect the next time a project's file list is cached."
          ;; The watch machinery is defined further down in this file, so
          ;; guard against the initial `defcustom' evaluation at load time.
          (if value
-             (when (fboundp 'projectile--watch-all-cached-projects)
+             ;; Only arm watches when the mode is on; otherwise they'd have no
+             ;; mode-disable teardown to fire and would linger until Emacs exits.
+             (when (and (bound-and-true-p projectile-mode)
+                        (fboundp 'projectile--watch-all-cached-projects))
                (projectile--watch-all-cached-projects))
            (when (fboundp 'projectile--teardown-all-watches)
              (projectile--teardown-all-watches))))
@@ -2506,7 +2509,13 @@ PATH may be a file or directory and directory paths may end with a slash."
 A single `directory-files' call replaces one `file-exists-p' per
 candidate name - over TRAMP that turns N sequential remote round-trips
 into one.  Returns nil when DIRECTORY can't be listed (missing or
-permission denied) or contains no entries."
+permission denied) or contains no entries.
+
+Note: membership is by directory entry, not `file-exists-p', so a broken
+symlink named like a marker counts as present here (the old per-candidate
+`file-exists-p' followed the link and returned nil).  This is harmless in
+practice - a project marker that is a dangling symlink is a pathological
+setup."
   (when-let* ((entries (ignore-errors
                          (directory-files
                           directory nil directory-files-no-dot-files-regexp t))))
@@ -12070,6 +12079,9 @@ Otherwise behave as if called interactively.
     (remove-hook 'window-configuration-change-hook #'projectile-update-mode-line-on-window-change)
     (remove-hook 'kill-emacs-hook #'projectile--teardown-all-watches)
     (projectile--teardown-all-watches)
+    ;; Forget the last-seen project so re-enabling the mode fires
+    ;; `projectile-project-changed-functions' on the first re-entry.
+    (setq projectile--current-project nil)
     (advice-remove 'compilation-find-file #'compilation-find-file-projectile-find-compilation-buffer)
     (advice-remove 'delete-file #'delete-file-projectile-remove-from-cache))))
 

--- a/projectile.el
+++ b/projectile.el
@@ -7992,7 +7992,7 @@ to run the replacement."
 When a search would exceed this, only the first that many matches are
 shown and a note is displayed."
   :group 'projectile
-  :type 'integer
+  :type 'natnum
   :package-version '(projectile . "3.2.0"))
 
 (defcustom projectile-replace-async t
@@ -8042,12 +8042,15 @@ used so scripted runs stay deterministic."
   :type 'boolean
   :package-version '(projectile . "3.2.0"))
 
-(defvar projectile-replace--scan-chunk-size 24
+(defcustom projectile-replace-scan-chunk-size 24
   "Number of candidate files scanned per async chunk before yielding.
 Each chunk scans this many files, delivers the matches into the results
 buffer and re-renders, then yields to redisplay via a zero-delay timer
 before the next chunk.  Larger values scan faster but redisplay less
-often; smaller values keep Emacs more responsive.")
+often; smaller values keep Emacs more responsive."
+  :group 'projectile
+  :type 'natnum
+  :package-version '(projectile . "3.2.0"))
 
 (defface projectile-replace-file
   '((t :inherit font-lock-function-name-face :weight bold))
@@ -8325,7 +8328,7 @@ on re-scan, on quit, and from `kill-buffer-hook'."
 (defun projectile-replace--gather-async (candidates regexp buffer on-done)
   "Scan CANDIDATES for REGEXP into BUFFER incrementally, then call ON-DONE.
 Resets BUFFER's match list and scanning state, then processes CANDIDATES
-in `projectile-replace--scan-chunk-size' batches, each batch delivering
+in `projectile-replace-scan-chunk-size' batches, each batch delivering
 its matches and re-rendering before yielding to redisplay via a
 zero-delay timer.  Matches accumulate in file order, so the final list is
 identical to `projectile-replace--gather' over the same CANDIDATES and
@@ -8368,7 +8371,7 @@ killed BUFFER (leaving no work behind) and against \\`C-g' during a chunk
           ;; a file is scanned while budget remains; the first file reached
           ;; with the budget exhausted marks the list truncated and stops.
           (while (and remaining (not stop)
-                      (< count projectile-replace--scan-chunk-size))
+                      (< count projectile-replace-scan-chunk-size))
             (if (> budget 0)
                 (let ((ms (let ((case-fold-search fold))
                             (projectile-replace--scan-file
@@ -8414,12 +8417,13 @@ The write-back and export must never run against a partial match set."
 
 (defun projectile-replace--candidates (term literal case-fold directory)
   "Return the files under DIRECTORY worth scanning for TERM.
-For a case-sensitive LITERAL search this narrows to files containing
-TERM (via `projectile-files-with-string') intersected with the
-project's ignore-aware file list.  For a regexp search, or a
-case-insensitive literal search (where the case-sensitive grep tools
-would miss case-variant occurrences), it is the whole ignore-aware file
-list, since those searches can't be narrowed by an external grep."
+For a case-sensitive LITERAL search this narrows to files that contain
+TERM, via `projectile-files-with-string' - which matches
+case-insensitively, so the narrowed set is a safe superset that the scan
+then filters exactly - intersected with the project's ignore-aware file
+list.  For a regexp search, or a case-insensitive literal search, it
+returns the whole ignore-aware file list, since those can't be narrowed
+by an external grep this way."
   (let ((project-files (mapcar (lambda (f) (expand-file-name f directory))
                                (projectile-dir-files directory))))
     (if (and literal (not case-fold))
@@ -9222,6 +9226,11 @@ finishes."
     (let* (;; run rg IN the project root so the relative `./' search path and
            ;; the `/'-anchored ignore globs resolve against it
            (default-directory root)
+           ;; keep rg's stderr out of the JSON stream, so a diagnostic line
+           ;; (e.g. an unreadable directory) can't split a match across filter
+           ;; chunks and get silently dropped
+           (stderr-buffer (get-buffer-create " *projectile-search-rg-stderr*"))
+           (_ (with-current-buffer stderr-buffer (erase-buffer)))
            (proc
            (make-process
             :name "projectile-search-rg"
@@ -9229,6 +9238,7 @@ finishes."
             :command command
             :connection-type 'pipe
             :noquery t
+            :stderr stderr-buffer
             :coding 'utf-8-unix
             :filter
             (lambda (_proc output)

--- a/test/projectile-core-test.el
+++ b/test/projectile-core-test.el
@@ -114,7 +114,12 @@
     (projectile-mode 1)
     (expect (memq 'projectile-find-file-hook-function find-file-hook) :to-be-truthy)
     (projectile-mode -1)
-    (expect (memq 'projectile-find-file-hook-function find-file-hook) :not :to-be-truthy)))
+    (expect (memq 'projectile-find-file-hook-function find-file-hook) :not :to-be-truthy))
+  (it "forgets the last-seen project when disabled"
+    (spy-on 'projectile--teardown-all-watches)
+    (setq projectile--current-project "/some/project/")
+    (projectile-mode -1)
+    (expect projectile--current-project :to-be nil)))
 
 (describe "projectile-default-mode-line"
   (it "includes the project name and type when in a project"

--- a/test/projectile-frecency-test.el
+++ b/test/projectile-frecency-test.el
@@ -211,7 +211,33 @@
        (expect (gethash "mine.el" files) :to-equal '(1 . 1000))
        (expect (gethash "theirs.el" files) :to-equal '(3 . 2000))
        ;; max count, latest timestamp
-       (expect (gethash "shared.el" files) :to-equal '(7 . 1000))))))
+       (expect (gethash "shared.el" files) :to-equal '(7 . 1000)))))
+
+  (it "keeps the newer on-disk timestamp when merging an older local entry"
+    (projectile-test-with-frecency
+     (projectile-test--record-visit "/proj/" "shared.el" 1000)
+     ;; another session recorded the same file more recently
+     (with-temp-file projectile-frecency-file
+       (insert (prin1-to-string '(("/proj/" ("shared.el" 1 5000))))))
+     (projectile--frecency-save)
+     (setq projectile--frecency-table nil)
+     (expect (gethash "shared.el" (gethash "/proj/" (projectile--frecency-data)))
+             :to-equal '(1 . 5000))))
+
+  (it "caps the saved data at projectile-frecency-max-projects roots"
+    (projectile-test-with-frecency
+     (let ((projectile-frecency-max-projects 2))
+       (projectile-test--record-visit "/a/" "a.el" 1000)
+       (projectile-test--record-visit "/b/" "b.el" 2000)
+       (projectile-test--record-visit "/c/" "c.el" 3000)
+       (projectile--frecency-save)
+       (setq projectile--frecency-table nil)
+       (let ((data (projectile--frecency-data)))
+         (expect (hash-table-count data) :to-equal 2)
+         ;; the two most recently active roots survive, the oldest is dropped
+         (expect (gethash "/c/" data) :to-be-truthy)
+         (expect (gethash "/b/" data) :to-be-truthy)
+         (expect (gethash "/a/" data) :to-be nil))))))
 
 (describe "projectile-completing-read sort metadata"
   (it "exposes the sort function via completion metadata"

--- a/test/projectile-replace-review-test.el
+++ b/test/projectile-replace-review-test.el
@@ -288,6 +288,22 @@ REGEXP-P selects `projectile-replace-regexp-review'."
           (expect (projectile-replace-review-test--disk "o.txt")
                   :to-equal "foo tail\n")))))
 
+  (it "skips a live buffer's match when text is inserted before it after the scan"
+    (projectile-replace-review-test--with-project
+        (("p.txt" . "keep\nfoo tail\n"))
+      (projectile-replace-review-test--use-plain-grep)
+      ;; open before the scan so the match is tagged against the live buffer
+      (find-file-noselect (expand-file-name "p.txt"))
+      (let ((buf (projectile-replace-review-test--run "foo" "bar")))
+        ;; insert BEFORE the match, shifting the recorded position off `foo';
+        ;; `--positions-valid-p' must reject it and the match must be skipped
+        (with-current-buffer (get-file-buffer (expand-file-name "p.txt"))
+          (goto-char (point-min))
+          (insert "PREPENDED\n"))
+        (projectile-replace-review-test--apply buf)
+        (with-current-buffer (get-file-buffer (expand-file-name "p.txt"))
+          (expect (buffer-string) :to-equal "PREPENDED\nkeep\nfoo tail\n")))))
+
   (it "preserves CRLF line endings on the disk write-back path"
     (projectile-replace-review-test--with-project
         (("crlf.txt" . "foo\r\nbar\r\n"))

--- a/test/projectile-scan-async-test.el
+++ b/test/projectile-scan-async-test.el
@@ -116,7 +116,7 @@ project root.  BODY runs with `default-directory' at the root and
         (unwind-protect
             ;; a chunk larger than the candidate set finishes in one inline
             ;; pass (no timer), the simplest way to drive it to completion
-            (let ((projectile-replace--scan-chunk-size 10000))
+            (let ((projectile-replace-scan-chunk-size 10000))
               (projectile-replace--gather-async candidates "foo" buf nil)
               (with-current-buffer buf
                 (expect projectile-replace--scanning :to-be nil)
@@ -138,7 +138,7 @@ project root.  BODY runs with `default-directory' at the root and
              (sync (projectile-scan-async-test--sync-matches candidates))
              (buf (projectile-scan-async-test--seed root)))
         (unwind-protect
-            (let ((projectile-replace--scan-chunk-size 1))
+            (let ((projectile-replace-scan-chunk-size 1))
               (projectile-replace--gather-async candidates "foo" buf nil)
               ;; the first chunk ran inline; more files remain, so a scan is
               ;; in flight with a pending timer and partial matches
@@ -175,7 +175,7 @@ project root.  BODY runs with `default-directory' at the root and
         (unwind-protect
             ;; one file per chunk, so e.txt is scanned in a LATE chunk (from a
             ;; timer); the driver must re-establish case-fold there too
-            (let ((projectile-replace--scan-chunk-size 1))
+            (let ((projectile-replace-scan-chunk-size 1))
               (projectile-replace--gather-async candidates "foo" buf nil)
               (projectile-scan-async-test--pump buf)
               (with-current-buffer buf
@@ -198,7 +198,7 @@ project root.  BODY runs with `default-directory' at the root and
              (sync (projectile-scan-async-test--sync-matches candidates))
              (buf (projectile-scan-async-test--seed root)))
         (unwind-protect
-            (let ((projectile-replace--scan-chunk-size 3)) ; boundary at file 3
+            (let ((projectile-replace-scan-chunk-size 3)) ; boundary at file 3
               (projectile-replace--gather-async candidates "foo" buf nil)
               (projectile-scan-async-test--pump buf)
               (with-current-buffer buf
@@ -219,7 +219,7 @@ project root.  BODY runs with `default-directory' at the root and
              (buf (projectile-scan-async-test--seed root))
              (seen nil))
         (unwind-protect
-            (let ((projectile-replace--scan-chunk-size 1))
+            (let ((projectile-replace-scan-chunk-size 1))
               (projectile-replace--gather-async
                candidates "foo" buf
                (lambda (b) (setq seen (list b (buffer-local-value
@@ -240,7 +240,7 @@ project root.  BODY runs with `default-directory' at the root and
              (buf (projectile-scan-async-test--seed root)))
         (unwind-protect
             (let ((projectile-replace-max-matches 3)
-                  (projectile-replace--scan-chunk-size 1))
+                  (projectile-replace-scan-chunk-size 1))
               (projectile-replace--gather-async candidates "foo" buf nil)
               (projectile-scan-async-test--pump buf)
               (with-current-buffer buf
@@ -303,7 +303,7 @@ project root.  BODY runs with `default-directory' at the root and
              (candidates (projectile-scan-async-test--candidates root))
              (buf (projectile-scan-async-test--seed root)))
         (unwind-protect
-            (let ((projectile-replace--scan-chunk-size 1))
+            (let ((projectile-replace-scan-chunk-size 1))
               (projectile-replace--gather-async candidates "foo" buf nil)
               (let ((old (buffer-local-value 'projectile-replace--scan-timer buf)))
                 (expect old :not :to-be nil)
@@ -325,7 +325,7 @@ project root.  BODY runs with `default-directory' at the root and
       (let* ((root default-directory)
              (candidates (projectile-scan-async-test--candidates root))
              (buf (projectile-scan-async-test--seed root))
-             (projectile-replace--scan-chunk-size 1))
+             (projectile-replace-scan-chunk-size 1))
         (projectile-replace--gather-async candidates "foo" buf nil)
         (let ((old (buffer-local-value 'projectile-replace--scan-timer buf)))
           (expect old :not :to-be nil)

--- a/test/projectile-session-test.el
+++ b/test/projectile-session-test.el
@@ -491,6 +491,20 @@
           (kill-buffer (file-name-nondirectory tmp)))
         (delete-file tmp))))
 
+  (it "skips a session file from an incompatible version with a message"
+    (let ((file (make-temp-file "projectile-session-ver" nil ".eld")))
+      (unwind-protect
+          (progn
+            (projectile-serialize
+             (list :projectile-session-version
+                   (1+ projectile-session--format-version)
+                   :buffers nil)
+             file)
+            (spy-on 'message)
+            (expect (projectile-session--read-file file) :to-be nil)
+            (expect 'message :to-have-been-called))
+        (delete-file file))))
+
   (it "does not error restoring a layout whose file is gone"
     (let ((tmp (make-temp-file "projectile-session-gone" nil ".txt")))
       (let* ((projectile-session-directory projectile-session-test--dir)

--- a/test/projectile-watch-test.el
+++ b/test/projectile-watch-test.el
@@ -502,11 +502,26 @@ watch bookkeeping into each other, caching is on (transient) and
       (projectile-watch-test-env
         (projectile-watch-test--spy-file-notify)
         (let ((projectile-auto-update-cache-with-watches nil)
+              (projectile-mode t)
               (root (projectile-project-root)))
           (puthash root '("a.el") projectile-projects-cache)
           (funcall (get 'projectile-auto-update-cache-with-watches 'custom-set)
                    'projectile-auto-update-cache-with-watches t)
           (expect (gethash root projectile--project-watches) :not :to-be nil)))))
+
+  (it "does not arm watches when the mode is off"
+    (projectile-test-with-stub-root "project" ("a.el")
+      (projectile-watch-test-env
+        (projectile-watch-test--spy-file-notify)
+        (let ((projectile-auto-update-cache-with-watches nil)
+              (projectile-mode nil)
+              (root (projectile-project-root)))
+          (puthash root '("a.el") projectile-projects-cache)
+          ;; arming watches with the mode off would leave them with no
+          ;; mode-disable teardown to clean them up
+          (funcall (get 'projectile-auto-update-cache-with-watches 'custom-set)
+                   'projectile-auto-update-cache-with-watches t)
+          (expect (gethash root projectile--project-watches) :to-be nil)))))
 
   (it "disabling projectile-mode tears down all watches"
     (spy-on 'projectile--teardown-all-watches)


### PR DESCRIPTION
Follow-up to #2081 with the remaining nice-to-haves from the 3.1 review.

The frecency store capped files per project but not the number of roots, so churning through projects grew it forever; `projectile-frecency-max-projects` (default 100) now drops the least recently active roots on save. Ripgrep gets its own `:stderr` so a diagnostic line can not split a match across filter chunks. `projectile-replace-scan-chunk-size` becomes a public defcustom. File-notify watches are only armed from the option `:set` when `projectile-mode` is on, and `projectile--current-project` is reset when the mode is disabled so `projectile-project-changed-functions` fires again on re-entry. Session reads now say something when they skip a session written in an incompatible format version, instead of silently restoring nothing.

Deliberately left for later: the 3.1.0 to 3.2.0 version-metadata reconciliation, and the rg parity / end-to-end rg tests, which need `rg` in CI.