### PR TITLE
Use spy-on for the clearest cl-letf stubs (selective)

### DIFF
--- a/test/projectile-dir-locals-test.el
+++ b/test/projectile-dir-locals-test.el
@@ -40,14 +40,12 @@ Return the resulting buffer contents."
 
 (describe "projectile-read-variable"
   (it "returns the selected variable name"
-    (cl-letf (((symbol-function 'completing-read)
-               (lambda (&rest _) "compile-command")))
-      (expect (projectile-read-variable) :to-equal "compile-command")))
+    (spy-on 'completing-read :and-return-value "compile-command")
+    (expect (projectile-read-variable) :to-equal "compile-command"))
 
   (it "returns nil on empty input"
-    (cl-letf (((symbol-function 'completing-read)
-               (lambda (&rest _) "")))
-      (expect (projectile-read-variable) :to-be nil))))
+    (spy-on 'completing-read :and-return-value "")
+    (expect (projectile-read-variable) :to-be nil)))
 
 (describe "projectile-skel-dir-locals"
   (it "keeps entered variables when the loop ends with an empty variable name"

--- a/test/projectile-file-kinds-test.el
+++ b/test/projectile-file-kinds-test.el
@@ -266,13 +266,12 @@
           (:file-kinds projectile--rails-file-kinds)
         (let ((root (file-truename (expand-file-name "project/"))))
           (spy-on 'find-file)
-          (cl-letf (((symbol-function 'buffer-file-name)
-                     (lambda (&optional _)
-                       (expand-file-name "app/controllers/users_controller.rb" root))))
-            (setq last-command nil this-command 'projectile-toggle-related-file)
-            (projectile-toggle-related-file)
-            (expect 'find-file :to-have-been-called-with
-                    (expand-file-name "app/models/user.rb" root)))))))
+          (spy-on 'buffer-file-name :and-return-value
+                  (expand-file-name "app/controllers/users_controller.rb" root))
+          (setq last-command nil this-command 'projectile-toggle-related-file)
+          (projectile-toggle-related-file)
+          (expect 'find-file :to-have-been-called-with
+                  (expand-file-name "app/models/user.rb" root))))))
   (it "resolves the visited file's symlinks against the project root"
     (projectile-test-with-sandbox
       (projectile-test-with-files-using-custom-project
@@ -287,13 +286,12 @@
                            (file-name-as-directory (expand-file-name "linkproj")))))
           (make-symbolic-link "project" "linkproj")
           (spy-on 'find-file)
-          (cl-letf (((symbol-function 'buffer-file-name)
-                     (lambda (&optional _) link-file)))
-            (setq last-command nil this-command 'projectile-toggle-related-file)
-            ;; without truename'ing the file this raises "No related files"
-            (projectile-toggle-related-file)
-            (expect 'find-file :to-have-been-called-with
-                    (expand-file-name "app/models/user.rb" root)))))))
+          (spy-on 'buffer-file-name :and-return-value link-file)
+          (setq last-command nil this-command 'projectile-toggle-related-file)
+          ;; without truename'ing the file this raises "No related files"
+          (projectile-toggle-related-file)
+          (expect 'find-file :to-have-been-called-with
+                  (expand-file-name "app/models/user.rb" root))))))
   (it "cycles through several related kinds on repeated invocation"
     (projectile-test-with-sandbox
       (projectile-test-with-files-using-custom-project
@@ -306,19 +304,19 @@
           (spy-on 'find-file :and-call-fake
                   (lambda (path)
                     (setq current (file-relative-name path root))))
-          (cl-letf (((symbol-function 'buffer-file-name)
-                     (lambda (&optional _) (expand-file-name current root))))
-            ;; simulate repeated presses of the command
-            ;; ring is (model controller view) in table order; starting on
-            ;; the controller, repeated presses advance through it and wrap
-            (setq this-command 'projectile-toggle-related-file
-                  last-command 'projectile-toggle-related-file)
-            (projectile-toggle-related-file)
-            (expect current :to-equal "app/views/users/index.html.erb")
-            (projectile-toggle-related-file)
-            (expect current :to-equal "app/models/user.rb")
-            (projectile-toggle-related-file)
-            (expect current :to-equal "app/controllers/users_controller.rb")))))))
+          (spy-on 'buffer-file-name :and-call-fake
+                  (lambda (&optional _) (expand-file-name current root)))
+          ;; simulate repeated presses of the command
+          ;; ring is (model controller view) in table order; starting on
+          ;; the controller, repeated presses advance through it and wrap
+          (setq this-command 'projectile-toggle-related-file
+                last-command 'projectile-toggle-related-file)
+          (projectile-toggle-related-file)
+          (expect current :to-equal "app/views/users/index.html.erb")
+          (projectile-toggle-related-file)
+          (expect current :to-equal "app/models/user.rb")
+          (projectile-toggle-related-file)
+          (expect current :to-equal "app/controllers/users_controller.rb"))))))
 
 (describe "projectile-related-files-fn with :file-kinds"
   (it "merges a hand-written related-files-fn with the compiled kinds fn"


### PR DESCRIPTION
A deliberately small, safe pass converting only the crystal-clear `cl-letf ((symbol-function ...))` stubs to `spy-on`:

- the `buffer-file-name` stubs in the `projectile-toggle-related-file` specs (one ordinary function, constant or simple value)
- the `completing-read` stubs in the `projectile-read-variable` specs

`spy-on` reads better and buttercup restores it automatically per spec.

Left the messier `cl-letf` uses **alone on purpose** - they're not safe/clean spy-on candidates:
- the relation specs stub *primitives* (`file-exists-p`, `file-relative-name`), several at once
- the test-at-point specs fake tree-sitter primitives
- the replace-review helpers scope `pop-to-buffer` narrowly to dodge buttercup's interactive-form check on a spied command
- a few set a function to `nil` (unbinding), which `spy-on` can't express

889 specs green, clean `--warnings-as-errors`, relint clean.