### PR TITLE
Fix projectile-search crash on the backend name symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#2094](https://github.com/bbatsov/projectile/issues/2094): Fix a `wrong-type-argument stringp` crash when running `projectile-search` (a 3.2.0 regression): the search-prompt tool tag now accepts the backend name symbol, not just a string.
+
 ## 3.2.0 (2026-07-12)
 
 ### New features

--- a/projectile.el
+++ b/projectile.el
@@ -7035,10 +7035,12 @@ This is a subset of `grep-read-files', where either a matching entry from
 
 (defun projectile--search-tool-tag (tool)
   "Return a faced `[TOOL]' tag for a search prompt.
-Used where the backend varies (e.g. `projectile-search' or the
-reviewable search's ripgrep/elisp fast-path) so the prompt makes clear
-which tool will run."
-  (format "[%s]" (propertize tool 'face 'projectile-search-prompt-tool)))
+TOOL is the backend, given as a symbol or a string: `projectile-search'
+passes the backend name symbol while the reviewable search passes a
+\"ripgrep\"/\"elisp\" string.  Used where the backend varies so the
+prompt makes clear which tool will run."
+  (format "[%s]" (propertize (format "%s" tool)
+                             'face 'projectile-search-prompt-tool)))
 
 (defun projectile--read-search-string-with-default (prompt-label)
   "Read a search string, defaulting to the symbol or region at point.

--- a/test/projectile-search-test.el
+++ b/test/projectile-search-test.el
@@ -95,6 +95,22 @@
       (expect (get-text-property 1 'face tag)
               :to-equal 'projectile-search-prompt-tool)))
 
+  (it "accepts a backend name symbol as well as a string (#2094)"
+    ;; `projectile-search' passes the backend symbol, not a string
+    (expect (projectile--search-tool-tag 'grep) :to-equal "[grep]"))
+
+  (it "projectile-search builds its prompt without erroring on the backend symbol (#2094)"
+    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    (spy-on 'projectile-prepend-project-name :and-call-fake #'identity)
+    (let (prompt
+          (projectile-search-backends
+           (list (cons 'grep (list :search (lambda (&rest _) nil)))))
+          (projectile-search-backend 'grep))
+      (spy-on 'read-string :and-call-fake (lambda (p &rest _) (setq prompt p) "foo"))
+      ;; term nil -> the interactive prompt path that used to crash
+      (projectile-search nil nil)
+      (expect prompt :to-match (regexp-quote "[grep]"))))
+
   (describe "projectile--read-search-string-with-default"
     (before-each
       (spy-on 'projectile-prepend-project-name :and-call-fake #'identity))


### PR DESCRIPTION
Fixes #2094 - a 3.2.0 regression.

`projectile-search` builds its prompt with `(projectile--search-tool-tag (car backend))`, where `(car backend)` is the backend **name symbol** (`grep`). The tag helper called `propertize` on it directly, and `propertize` requires a string - so the command crashed with `wrong-type-argument stringp grep`.

Fix: format the tool through `%s` in the helper, so it accepts a symbol (`projectile-search`) *or* a string (`projectile-grep`/`-ag`/`-ripgrep` and the reviewable search all pass strings).

The suggested `symbol-name` fix from the issue would just flip the crash onto the string callers, so I went with the format-based one that handles both.

Tests: a symbol-input unit test plus one that drives `projectile-search`'s interactive prompt path (the actual crash) and checks it produces `[grep]` without erroring. 914 specs green, clean `--warnings-as-errors`, relint clean.