### PR TITLE
Stop treating projectile-consult.el as a standalone package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+- Drop the standalone package headers (`Version`, `Package-Requires`) from `projectile-consult.el`. It's an optional module shipped inside the Projectile package, not a package of its own, and the phantom `Package-Requires` made build tooling treat it as one (e.g. it broke `eldev`-based test runs on Emacs 28.x by enforcing Consult's Emacs 29.1 floor on the whole project). Its runtime needs (Consult 2.0+, hence Emacs 29.1+) are unchanged and documented in the file and the manual.
+
 ## 3.2.1 (2026-07-13)
 
 ### Bugs fixed

--- a/Eldev
+++ b/Eldev
@@ -15,17 +15,13 @@
 ;; `projectile-consult.el' is an optional Consult integration that ships with
 ;; Projectile but is loaded only on demand (Consult is a soft dependency, not
 ;; part of Projectile's `Package-Requires').  Pull Consult in just for building
-;; and testing so the module can be byte-compiled and exercised in CI.  Consult
-;; requires Emacs 29.1+, so on older Emacsen we cannot install it: exclude the
-;; module (and its test, which `require's it) from the build/test filesets there.
-(if (version<= "29.1" emacs-version)
-    (progn
-      (eldev-add-extra-dependencies 'build 'consult)
-      (eldev-add-extra-dependencies 'test 'consult))
-  (setf eldev-standard-excludes
-        `(:or ,eldev-standard-excludes
-              "./projectile-consult.el"
-              "./test/projectile-consult-test.el")))
+;; and testing so the module compiles against the real library and its specs
+;; run.  Consult requires Emacs 29.1+, so we can only install it there; on older
+;; Emacsen the module still byte-compiles cleanly without Consult (the functions
+;; it uses are forward-declared) and its specs self-skip via `assume'.
+(when (version<= "29.1" emacs-version)
+  (eldev-add-extra-dependencies 'build 'consult)
+  (eldev-add-extra-dependencies 'test 'consult))
 
 ;; Eldev regenerates `projectile-pkg.el' from the package headers on every
 ;; build.  Some CI images then byte-compile the leftover copy and, under

--- a/doc/modules/ROOT/pages/indexing.adoc
+++ b/doc/modules/ROOT/pages/indexing.adoc
@@ -557,9 +557,8 @@ in `projectile-consult.el`. It's an optional module with a soft dependency on
 indexing command and streams the candidates into Consult as they arrive, so
 there's no wait for the whole project to be indexed before you can start
 typing. Because it goes through `projectile-project-files-producer`, it stays
-VCS-aware and honours the project's indexing configuration. The module
-requires Emacs 29.1+ (Consult's floor) and may be split into a standalone
-package in the future.
+VCS-aware and honours the project's indexing configuration. The module needs
+Consult 2.0+, which in turn requires Emacs 29.1+.
 
 === File exists cache
 

--- a/projectile-consult.el
+++ b/projectile-consult.el
@@ -5,8 +5,12 @@
 ;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: https://github.com/bbatsov/projectile
 ;; Keywords: project, convenience, matching
-;; Version: 0.1.0
-;; Package-Requires: ((emacs "29.1") (projectile "3.0.0") (consult "2.0"))
+
+;; This file is an optional module shipped inside the Projectile package; it
+;; carries no `Package-Requires' header of its own so it isn't mistaken for a
+;; standalone package.  At runtime it needs `consult' 2.0+, which in turn
+;; requires Emacs 29.1+, but Projectile core never loads it, so those are not
+;; Projectile dependencies (see the Commentary).
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -38,13 +42,10 @@
 ;; you can start typing.
 ;;
 ;; Projectile core does NOT load this file; require it yourself (it pulls in
-;; `consult'):
+;; `consult', which needs Emacs 29.1+):
 ;;
 ;;   (require 'projectile-consult)
 ;;   (define-key projectile-command-map (kbd "f") #'projectile-consult-find-file)
-;;
-;; It is intentionally self-contained so it can be split out into its own
-;; package in the future.
 
 ;;; Code:
 

--- a/test/projectile-consult-test.el
+++ b/test/projectile-consult-test.el
@@ -29,10 +29,15 @@
 (require 'projectile-test-helpers)
 
 (defvar projectile-consult-available
-  ;; On Emacs < 29.1 Consult cannot be installed (it requires 29.1), so the
-  ;; `require' may signal rather than just return nil; swallow that too.
-  (ignore-errors (require 'projectile-consult nil t))
-  "Non-nil when `projectile-consult' (and thus Consult) could be loaded.")
+  ;; The module loads on any Emacs (it only soft-requires Consult), so its
+  ;; presence says nothing about whether the specs can run - what matters is
+  ;; Consult itself, which needs Emacs 29.1+ and drives every command under
+  ;; test.  Probe for Consult directly and skip when it's absent.  Wrapped in
+  ;; `ignore-errors' because the `require' can signal rather than return nil.
+  (and (ignore-errors (require 'projectile-consult nil t))
+       (ignore-errors (require 'consult nil t))
+       t)
+  "Non-nil when Consult is available so the integration specs can run.")
 
 (describe "projectile-consult--file-command"
   (it "wraps the indexing command in a shell with a NUL->newline translation"


### PR DESCRIPTION
CI on `master` is red on the Emacs 28.2 job, and it has nothing to do with any recent code change. `projectile-consult.el` ships *inside* the Projectile package but carried its own `Version` and `Package-Requires` headers, so build tooling treats it as a standalone package. A fresh `eldev` picked up on that and started enforcing Consult's Emacs 29.1 floor across the whole project, so the 28.2 run bails out with "Emacs version 29.1 is required" before a single spec runs. Same double life that caused #2037.

So stop pretending it is a package and drop the two headers. Its runtime needs (Consult 2.0+, hence Emacs 29.1+) are unchanged and still spelled out in the file header, the manual, and the `Eldev` config, which pulls Consult in only on Emacs 29.1+ and relies on the module byte-compiling cleanly without it elsewhere.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)