### PR TITLE
Make the funding call-to-action more prominent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## master (unreleased)
 
+### New features
+
+- Add an optional Embark/Marginalia integration (experimental, wired via `with-eval-after-load` so neither is a dependency): an Embark transformer that *augments* (never replaces) Embark's own `project-file` handling - it resolves a candidate against the Projectile root only when the file actually lives there and otherwise defers to Embark, so file actions target the right file even from a subdirectory without affecting non-Projectile completions; and a `projectile-embark-project-map` that offers project actions (switch, vc, dired, remove) when acting on a project candidate. Project-switch completions now use the `projectile-project` category, still annotated through Marginalia's file annotator.
+
 ### Changes
 
 - Drop the standalone package headers (`Version`, `Package-Requires`) from `projectile-consult.el`. It's an optional module shipped inside the Projectile package, not a package of its own, and the phantom `Package-Requires` made build tooling treat it as one (e.g. it broke `eldev`-based test runs on Emacs 28.x by enforcing Consult's Emacs 29.1 floor on the whole project). Its runtime needs (Consult 2.0+, hence Emacs 29.1+) are unchanged and documented in the file and the manual.

--- a/README.md
+++ b/README.md
@@ -37,17 +37,14 @@ Here are some of Projectile's essential features:
 There's also a rich ecosystem of third-party [Projectile extensions](https://melpa.org/#/?q=projectile) that add even more features.
 
 ---------------
+[![GitHub Sponsors](https://img.shields.io/badge/sponsor-GitHub-ea4aaa.svg?logo=github)](https://github.com/sponsors/bbatsov)
 [![Patreon](https://img.shields.io/badge/patreon-donate-orange.svg)](https://www.patreon.com/bbatsov)
 [![Paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=GRQKNBM6P8VRQ)
 
 I've been developing Projectile for over a decade now (since 2011). While it's a fun
-project to work on, it still requires a lot of time and energy to
-maintain.
+project to work on, it still requires a lot of time and energy to maintain.
 
-You can support my work on Projectile via
- [PayPal](https://www.paypal.me/bbatsov),
- [Patreon](https://www.patreon.com/bbatsov) and
- [GitHub Sponsors](https://github.com/sponsors/bbatsov).
+**Please consider [supporting financially Projectile's ongoing development](#funding).**
 
 ## Projectile in Action
 
@@ -178,6 +175,18 @@ Check out the project's
 [issue list](https://github.com/bbatsov/projectile/issues?sort=created&direction=desc&state=open)
 a list of unresolved issues. By the way - feel free to fix any of them
 and send me a pull request. :-)
+
+## Funding
+
+While Projectile is free software and will always be, the project would benefit
+immensely from some funding. If you (or the company you work for) are making
+serious use of Projectile, please consider supporting its ongoing development.
+
+You can support my work on Projectile via:
+
+* [GitHub Sponsors](https://github.com/sponsors/bbatsov)
+* [Patreon](https://www.patreon.com/bbatsov)
+* [PayPal](https://www.paypal.me/bbatsov)
 
 ## Contributors
 

--- a/projectile.el
+++ b/projectile.el
@@ -2739,7 +2739,7 @@ See also `projectile-acquire-root'."
     (cond
      ((eq projectile-require-project-root 'prompt) (projectile-completing-read
                                                     "Switch to project: " projectile-known-projects
-                                                    :category 'file
+                                                    :category 'projectile-project
                                                     :caller 'projectile-read-project))
      (projectile-require-project-root (user-error "Projectile cannot find a project definition in %s" default-directory))
      (t default-directory))))
@@ -9829,7 +9829,7 @@ prompt for a known project to open instead of the current one."
            (if arg
                (projectile-completing-read
                 "Dired in project: " (projectile-relevant-known-projects)
-                :category 'file
+                :category 'projectile-project
                 :caller 'projectile-read-project)
              (projectile-acquire-root))))
 
@@ -9863,7 +9863,7 @@ directory to open."
                      (projectile-completing-read
                       "Open project VC in: "
                       projectile-known-projects
-                      :category 'file
+                      :category 'projectile-project
                       :caller 'projectile-read-project))))
   (unless project-root
     (setq project-root (projectile-acquire-root)))
@@ -11037,7 +11037,7 @@ of `projectile-switch-project-action'."
          "Switch to project: " projects
          :action (lambda (project)
                    (projectile-switch-project-by-name project arg))
-         :category 'file
+         :category 'projectile-project
          :caller 'projectile-read-project)
       (user-error "There are no known projects"))))
 
@@ -11054,7 +11054,7 @@ of `projectile-switch-project-action'."
          "Switch to open project: " projects
          :action (lambda (project)
                    (projectile-switch-project-by-name project arg))
-         :category 'file
+         :category 'projectile-project
          :caller 'projectile-read-project)
       (user-error "There are no open projects"))))
 
@@ -11332,7 +11332,7 @@ projects removed."
   (interactive (list (projectile-completing-read
                       "Remove from known projects: " projectile-known-projects
                       :action 'projectile-remove-known-project
-                      :category 'file
+                      :category 'projectile-project
                       :caller 'projectile-read-project)))
   (unless (called-interactively-p 'any)
     (setq projectile-known-projects
@@ -11463,7 +11463,7 @@ Let user choose another project when PROMPT-FOR-PROJECT is supplied."
                           (projectile-completing-read
                            "Project name: "
                            (projectile-relevant-known-projects)
-                           :category 'file
+                           :category 'projectile-project
                            :caller 'projectile-read-project)
                         (projectile-acquire-root))))
     (projectile-ibuffer-by-project project-root)))
@@ -13114,6 +13114,93 @@ existing tabs untouched."
                  #'projectile-session--maybe-restore-on-startup)
     (remove-hook 'tab-bar-tab-pre-close-functions
                  #'projectile-session--on-tab-close))))
+
+
+;;; Optional Embark / Marginalia integration
+;;
+;; PROTOTYPE.  Gated behind `with-eval-after-load' so Embark and Marginalia
+;; stay soft, opt-in enhancements rather than dependencies.  Two Embark wins on
+;; top of the completion categories Projectile already advertises:
+;;
+;; 1. A transformer that expands a `project-file' candidate (which Projectile
+;;    presents project-relative) to an absolute path against the Projectile
+;;    root, so Embark's file actions hit the right file regardless of
+;;    `default-directory'.
+;; 2. A `projectile-project' action keymap, so acting on a project candidate
+;;    offers project operations (switch, vc, dired, remove) instead of only
+;;    generic file actions.  Marginalia keeps annotating those candidates via
+;;    the built-in file annotator (they are directory paths).
+
+(defun projectile--embark-project-file-target (target)
+  "Resolve a `project-file' TARGET to an absolute path under the Projectile root.
+Return (file . ABSOLUTE) only when TARGET actually exists under the
+current Projectile project root, otherwise nil so the caller can defer to
+Embark's own `project-file' handling.  The existence guard keeps the
+integration from ever misresolving a `project-file' candidate that is not
+Projectile's - worst case it does nothing and Embark behaves as before."
+  (when-let* ((root (projectile-project-root))
+              (full (expand-file-name target root))
+              ((file-exists-p full)))
+    (cons 'file full)))
+
+(defun projectile-embark-switch-project (project)
+  "Switch to PROJECT.  An Embark action for a project candidate."
+  (interactive "sProject: ")
+  (projectile-switch-project-by-name project))
+
+(defun projectile-embark-vc (project)
+  "Open the VC interface for PROJECT.  An Embark action for a project candidate."
+  (interactive "sProject: ")
+  (projectile-vc project))
+
+(defvar projectile--embark-project-file-prev-transform nil
+  "The `project-file' transformer Embark had before Projectile augmented it.
+Preserved so `projectile--embark-project-file-transform' can defer to it
+for candidates that don't belong to the current Projectile project.")
+
+(defun projectile--embark-project-file-transform (type target)
+  "Embark `project-file' transformer augmenting Embark's own with Projectile.
+Resolves TARGET against the Projectile root when it lives there,
+otherwise defers to the transformer Embark had before (or leaves
+TYPE/TARGET unchanged), so non-Projectile completions are unaffected."
+  (or (projectile--embark-project-file-target target)
+      (and projectile--embark-project-file-prev-transform
+           (funcall projectile--embark-project-file-prev-transform type target))
+      (cons type target)))
+
+(defvar projectile-embark-project-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "s") #'projectile-embark-switch-project)
+    (define-key map (kbd "v") #'projectile-embark-vc)
+    (define-key map (kbd "d") #'dired)
+    (define-key map (kbd "D") #'projectile-remove-known-project)
+    map)
+  "Embark action keymap for Projectile `projectile-project' candidates.")
+
+(with-eval-after-load 'embark
+  (defvar embark-transformer-alist)
+  (defvar embark-keymap-alist)
+  (defvar embark-general-map)
+  ;; inherit Embark's generic actions (collect, export, ...)
+  (set-keymap-parent projectile-embark-project-map embark-general-map)
+  ;; Augment - never replace - Embark's `project-file' handling.  Our
+  ;; transformer only claims a candidate that actually lives under the
+  ;; Projectile root; anything else defers to whatever transformer Embark
+  ;; already had, so non-Projectile `project-file' completions are unaffected.
+  ;; The `eq' guard keeps re-loading Projectile from wrapping our own wrapper.
+  (let ((prev (alist-get 'project-file embark-transformer-alist)))
+    (unless (eq prev #'projectile--embark-project-file-transform)
+      (setq projectile--embark-project-file-prev-transform prev)
+      (setf (alist-get 'project-file embark-transformer-alist)
+            #'projectile--embark-project-file-transform)))
+  (add-to-list 'embark-keymap-alist
+               '(projectile-project . projectile-embark-project-map)))
+
+(with-eval-after-load 'marginalia
+  (defvar marginalia-annotator-registry)
+  ;; project candidates are directory paths, so the file annotator fits
+  (add-to-list 'marginalia-annotator-registry
+               '(projectile-project marginalia-annotate-file builtin none)))
 
 (provide 'projectile)
 

--- a/test/projectile-core-test.el
+++ b/test/projectile-core-test.el
@@ -316,6 +316,49 @@
       (expect (alist-get 'category (cdr (funcall table "" nil 'metadata)))
               :to-be 'buffer))))
 
+(describe "Embark integration"
+  (it "resolves a project-file target that exists under the root"
+    (spy-on 'projectile-project-root :and-return-value "/proj/")
+    (spy-on 'file-exists-p :and-return-value t)
+    (expect (projectile--embark-project-file-target "src/foo.el")
+            :to-equal '(file . "/proj/src/foo.el")))
+
+  (it "declines (returns nil) outside a project, so Embark's own handling wins"
+    (spy-on 'projectile-project-root :and-return-value nil)
+    (expect (projectile--embark-project-file-target "src/foo.el") :to-be nil))
+
+  (it "declines when the target does not live under the project root"
+    (spy-on 'projectile-project-root :and-return-value "/proj/")
+    (spy-on 'file-exists-p :and-return-value nil)
+    (expect (projectile--embark-project-file-target "src/foo.el") :to-be nil))
+
+  (it "defers to Embark's previous transformer when Projectile declines"
+    ;; augment, never replace: a non-Projectile project-file target must reach
+    ;; whatever transformer Embark already had
+    (spy-on 'projectile-project-root :and-return-value nil)
+    (let ((projectile--embark-project-file-prev-transform
+           (lambda (_type target) (cons 'file (concat "/other/" target)))))
+      (expect (projectile--embark-project-file-transform 'project-file "x")
+              :to-equal '(file . "/other/x"))))
+
+  (it "leaves the target unchanged when neither Projectile nor a prior transformer resolves it"
+    (spy-on 'projectile-project-root :and-return-value nil)
+    (let ((projectile--embark-project-file-prev-transform nil))
+      (expect (projectile--embark-project-file-transform 'project-file "x")
+              :to-equal '(project-file . "x"))))
+
+  (it "binds project actions in the project action keymap"
+    (expect (keymapp projectile-embark-project-map) :to-be-truthy)
+    (expect (lookup-key projectile-embark-project-map "s")
+            :to-be 'projectile-embark-switch-project)
+    (expect (lookup-key projectile-embark-project-map "D")
+            :to-be 'projectile-remove-known-project))
+
+  (it "the switch action delegates to projectile-switch-project-by-name"
+    (spy-on 'projectile-switch-project-by-name)
+    (projectile-embark-switch-project "/proj/")
+    (expect 'projectile-switch-project-by-name :to-have-been-called-with "/proj/")))
+
 (describe "projectile-sort-files"
   (it "returns the files unchanged for the default sort order"
     (let ((projectile-sort-order 'default))


### PR DESCRIPTION
Brings the funding ask in line with what CIDER's README does: a short personal note followed by a bold call-to-action up top that links to a dedicated Funding section, plus a GitHub Sponsors badge alongside the existing ones. The individual funding channels now live under a `## Funding` heading instead of being tucked into the intro.