### PR TITLE
Honor Projectile's ignore rules under alien indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,22 @@
 
 ### New features
 
-- Alien indexing now honors Projectile's ignore rules, which it previously skipped entirely.
+- [#2104](https://github.com/bbatsov/projectile/pull/2104): Alien indexing now honors Projectile's ignore rules, which it previously skipped entirely.
   - The rules are pushed into the external tool (`git ls-files` exclude pathspecs, `fd --exclude`), so the filtering still happens outside Emacs.
   - Tools that can't express exclusions (svn, fossil, bzr, darcs, pijul, plain `find`) have their output filtered in Emacs Lisp instead.
   - Dirconfig `+` keep and `!` unignore entries have no equivalent in the tools and stay `hybrid`/`native` only.
   - Alien projects will list fewer files than before; set `projectile-alien-honors-ignores` to nil for the old behavior.
-- Add an optional Embark/Marginalia integration, wired via `with-eval-after-load` so neither package becomes a dependency.
+- [#2096](https://github.com/bbatsov/projectile/pull/2096): Add an optional Embark/Marginalia integration, wired via `with-eval-after-load` so neither package becomes a dependency.
   - A `project-file` transformer resolves Projectile's project-relative candidates, augmenting Embark's own rather than replacing it.
   - Project prompts use a new `projectile-project` category with an action keymap (switch, vc, dired, remove) and a Marginalia annotator.
 
 ### Changes
 
-- Ignore matching is now case-sensitive under every indexing method, where `native` and `hybrid` previously folded case (so `.elc` also hid `BUILD.ELC`); the external tools behind `alien` can't express that, so spell out both cases if you relied on it.
-- Drop `.ensime_cache` and `.eunit` from the default `projectile-globally-ignored-directories`, as ENSIME was archived in 2018 and `.eunit` is a rebar2 artifact.
-- Fix a leading `*` in `projectile-globally-ignored-directories` being treated as a wildcard rather than the "at any depth" marker it is, which also affected `project.el`'s `project-ignores` and the ripgrep search path.
-- Remove `projectile-warn-when-dirconfig-is-ignored`, which existed only to warn that `alien` bypassed the dirconfig.
-- Drop the standalone package headers (`Version`, `Package-Requires`) from `projectile-consult.el`, since the phantom `Package-Requires` made build tooling treat an in-package module as its own package (it broke `eldev` test runs on Emacs 28.x).
+- [#2104](https://github.com/bbatsov/projectile/pull/2104): Ignore matching is now case-sensitive under every indexing method, where `native` and `hybrid` previously folded case (so `.elc` also hid `BUILD.ELC`); the external tools behind `alien` can't express that, so spell out both cases if you relied on it.
+- [#2104](https://github.com/bbatsov/projectile/pull/2104): Drop `.ensime_cache` and `.eunit` from the default `projectile-globally-ignored-directories`, as ENSIME was archived in 2018 and `.eunit` is a rebar2 artifact.
+- [#2104](https://github.com/bbatsov/projectile/pull/2104): Fix a leading `*` in `projectile-globally-ignored-directories` being treated as a wildcard rather than the "at any depth" marker it is, which also affected `project.el`'s `project-ignores` and the ripgrep search path.
+- [#2104](https://github.com/bbatsov/projectile/pull/2104): Remove `projectile-warn-when-dirconfig-is-ignored`, which existed only to warn that `alien` bypassed the dirconfig.
+- [#2099](https://github.com/bbatsov/projectile/pull/2099): Drop the standalone package headers (`Version`, `Package-Requires`) from `projectile-consult.el`, since the phantom `Package-Requires` made build tooling treat an in-package module as its own package (it broke `eldev` test runs on Emacs 28.x).
 
 ## 3.2.1 (2026-07-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@
 
 ### New features
 
+- Alien indexing now honors Projectile's ignore rules. Previously `alien` (the default indexing method) delegated the whole walk to an external tool and applied none of `projectile-globally-ignored-files` / `-directories` / `-file-suffixes`, `projectile-global-ignore-file-patterns` or the `-` entries of a project's `.projectile`, which was a frequent source of confusion. The rules are now pushed down into the tool itself (`git ls-files` exclude pathspecs, `fd --exclude`), so the filtering still happens outside Emacs and `alien` stays fast; the few tools that can't express exclusions (svn, fossil, bzr, darcs, pijul, and the plain `find` fallback) have their output filtered in Emacs Lisp instead. Set the new `projectile-alien-honors-ignores` to nil to restore the old behavior. Dirconfig `+` keep and `!` unignore entries have no equivalent in the external tools and remain `hybrid`/`native` only. As a result `alien` projects will list fewer files than before - which is the point, but do check the new `projectile-alien-honors-ignores` if a file you expect goes missing.
 - Add an optional Embark/Marginalia integration, wired via `with-eval-after-load` so neither package becomes a dependency. `embark-act` on a project file now targets the right file even when `default-directory` is a subdirectory, via a transformer that *augments* (never replaces) Embark's own `project-file` handling - it resolves a candidate against the Projectile root only when the file actually lives there, and otherwise defers to Embark, leaving non-Projectile completions untouched. Acting on a project candidate offers project actions (switch, vc, dired, remove) through the new `projectile-embark-project-map`; project prompts now use a `projectile-project` completion category, annotated by Marginalia's file annotator just like before.
 
 ### Changes
 
+- Remove `projectile-warn-when-dirconfig-is-ignored` and the warning it controlled. It existed only to tell you that `alien` indexing was bypassing your `.projectile`, which it no longer does.
 - Drop the standalone package headers (`Version`, `Package-Requires`) from `projectile-consult.el`. It's an optional module shipped inside the Projectile package, not a package of its own, and the phantom `Package-Requires` made build tooling treat it as one (e.g. it broke `eldev`-based test runs on Emacs 28.x by enforcing Consult's Emacs 29.1 floor on the whole project). Its runtime needs (Consult 2.0+, hence Emacs 29.1+) are unchanged and documented in the file and the manual.
 
 ## 3.2.1 (2026-07-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changes
 
+- Ignore matching is now case-sensitive under every indexing method. `native` and `hybrid` used to fold case when matching `projectile-globally-ignored-file-suffixes`, `projectile-global-ignore-file-patterns` and the dirconfig patterns - a side effect of `string-suffix-p`'s IGNORE-CASE argument and of `case-fold-search` defaulting to `t`, rather than a deliberate choice - so `.elc` also hid `BUILD.ELC`. The external tools behind `alien` can't express that, so the three methods disagreed; they now agree on the case-sensitive reading. Spell out both cases if you relied on the old behavior.
 - Drop `.ensime_cache` and `.eunit` from the default `projectile-globally-ignored-directories`. ENSIME was archived in 2018 and `.eunit` is a rebar2 artifact; both just added noise to every project's ignore set. Add them back if you still need them.
 - Fix the globs derived from `projectile-globally-ignored-directories` treating a leading `*` as a wildcard. It is a marker meaning "at any depth", so `*.osc` names the `.osc` directory and must not also match `foo.osc`. This affected the patterns handed to `project.el`'s `project-ignores` and to the ripgrep search path.
 - Remove `projectile-warn-when-dirconfig-is-ignored` and the warning it controlled. It existed only to tell you that `alien` indexing was bypassing your `.projectile`, which it no longer does.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,22 @@
 
 ### New features
 
-- Alien indexing now honors Projectile's ignore rules. Previously `alien` (the default indexing method) delegated the whole walk to an external tool and applied none of `projectile-globally-ignored-files` / `-directories` / `-file-suffixes`, `projectile-global-ignore-file-patterns` or the `-` entries of a project's `.projectile`, which was a frequent source of confusion. The rules are now pushed down into the tool itself (`git ls-files` exclude pathspecs, `fd --exclude`), so the filtering still happens outside Emacs and `alien` stays fast; the few tools that can't express exclusions (svn, fossil, bzr, darcs, pijul, and the plain `find` fallback) have their output filtered in Emacs Lisp instead. Set the new `projectile-alien-honors-ignores` to nil to restore the old behavior. Dirconfig `+` keep and `!` unignore entries have no equivalent in the external tools and remain `hybrid`/`native` only. As a result `alien` projects will list fewer files than before - which is the point, but do check the new `projectile-alien-honors-ignores` if a file you expect goes missing.
-- Add an optional Embark/Marginalia integration, wired via `with-eval-after-load` so neither package becomes a dependency. `embark-act` on a project file now targets the right file even when `default-directory` is a subdirectory, via a transformer that *augments* (never replaces) Embark's own `project-file` handling - it resolves a candidate against the Projectile root only when the file actually lives there, and otherwise defers to Embark, leaving non-Projectile completions untouched. Acting on a project candidate offers project actions (switch, vc, dired, remove) through the new `projectile-embark-project-map`; project prompts now use a `projectile-project` completion category, annotated by Marginalia's file annotator just like before.
+- Alien indexing now honors Projectile's ignore rules, which it previously skipped entirely.
+  - The rules are pushed into the external tool (`git ls-files` exclude pathspecs, `fd --exclude`), so the filtering still happens outside Emacs.
+  - Tools that can't express exclusions (svn, fossil, bzr, darcs, pijul, plain `find`) have their output filtered in Emacs Lisp instead.
+  - Dirconfig `+` keep and `!` unignore entries have no equivalent in the tools and stay `hybrid`/`native` only.
+  - Alien projects will list fewer files than before; set `projectile-alien-honors-ignores` to nil for the old behavior.
+- Add an optional Embark/Marginalia integration, wired via `with-eval-after-load` so neither package becomes a dependency.
+  - A `project-file` transformer resolves Projectile's project-relative candidates, augmenting Embark's own rather than replacing it.
+  - Project prompts use a new `projectile-project` category with an action keymap (switch, vc, dired, remove) and a Marginalia annotator.
 
 ### Changes
 
-- Ignore matching is now case-sensitive under every indexing method. `native` and `hybrid` used to fold case when matching `projectile-globally-ignored-file-suffixes`, `projectile-global-ignore-file-patterns` and the dirconfig patterns - a side effect of `string-suffix-p`'s IGNORE-CASE argument and of `case-fold-search` defaulting to `t`, rather than a deliberate choice - so `.elc` also hid `BUILD.ELC`. The external tools behind `alien` can't express that, so the three methods disagreed; they now agree on the case-sensitive reading. Spell out both cases if you relied on the old behavior.
-- Drop `.ensime_cache` and `.eunit` from the default `projectile-globally-ignored-directories`. ENSIME was archived in 2018 and `.eunit` is a rebar2 artifact; both just added noise to every project's ignore set. Add them back if you still need them.
-- Fix the globs derived from `projectile-globally-ignored-directories` treating a leading `*` as a wildcard. It is a marker meaning "at any depth", so `*.osc` names the `.osc` directory and must not also match `foo.osc`. This affected the patterns handed to `project.el`'s `project-ignores` and to the ripgrep search path.
-- Remove `projectile-warn-when-dirconfig-is-ignored` and the warning it controlled. It existed only to tell you that `alien` indexing was bypassing your `.projectile`, which it no longer does.
-- Drop the standalone package headers (`Version`, `Package-Requires`) from `projectile-consult.el`. It's an optional module shipped inside the Projectile package, not a package of its own, and the phantom `Package-Requires` made build tooling treat it as one (e.g. it broke `eldev`-based test runs on Emacs 28.x by enforcing Consult's Emacs 29.1 floor on the whole project). Its runtime needs (Consult 2.0+, hence Emacs 29.1+) are unchanged and documented in the file and the manual.
+- Ignore matching is now case-sensitive under every indexing method, where `native` and `hybrid` previously folded case (so `.elc` also hid `BUILD.ELC`); the external tools behind `alien` can't express that, so spell out both cases if you relied on it.
+- Drop `.ensime_cache` and `.eunit` from the default `projectile-globally-ignored-directories`, as ENSIME was archived in 2018 and `.eunit` is a rebar2 artifact.
+- Fix a leading `*` in `projectile-globally-ignored-directories` being treated as a wildcard rather than the "at any depth" marker it is, which also affected `project.el`'s `project-ignores` and the ripgrep search path.
+- Remove `projectile-warn-when-dirconfig-is-ignored`, which existed only to warn that `alien` bypassed the dirconfig.
+- Drop the standalone package headers (`Version`, `Package-Requires`) from `projectile-consult.el`, since the phantom `Package-Requires` made build tooling treat an in-package module as its own package (it broke `eldev` test runs on Emacs 28.x).
 
 ## 3.2.1 (2026-07-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Changes
 
+- Drop `.ensime_cache` and `.eunit` from the default `projectile-globally-ignored-directories`. ENSIME was archived in 2018 and `.eunit` is a rebar2 artifact; both just added noise to every project's ignore set. Add them back if you still need them.
+- Fix the globs derived from `projectile-globally-ignored-directories` treating a leading `*` as a wildcard. It is a marker meaning "at any depth", so `*.osc` names the `.osc` directory and must not also match `foo.osc`. This affected the patterns handed to `project.el`'s `project-ignores` and to the ripgrep search path.
 - Remove `projectile-warn-when-dirconfig-is-ignored` and the warning it controlled. It existed only to tell you that `alien` indexing was bypassing your `.projectile`, which it no longer does.
 - Drop the standalone package headers (`Version`, `Package-Requires`) from `projectile-consult.el`. It's an optional module shipped inside the Projectile package, not a package of its own, and the phantom `Package-Requires` made build tooling treat it as one (e.g. it broke `eldev`-based test runs on Emacs 28.x by enforcing Consult's Emacs 29.1 floor on the whole project). Its runtime needs (Consult 2.0+, hence Emacs 29.1+) are unchanged and documented in the file and the manual.
 

--- a/doc/modules/ROOT/pages/configuration_index.adoc
+++ b/doc/modules/ROOT/pages/configuration_index.adoc
@@ -353,9 +353,6 @@ and the other reference pages.
 | `projectile-warn-on-prefixless-dirconfig-lines`
 | Whether to warn about deprecated prefix-less ignore entries.
 
-| `projectile-warn-when-dirconfig-is-ignored`
-| Whether to warn when a non-empty .projectile is bypassed by alien indexing.
-
 | `projectile-watch-directory-limit`
 | Maximum number of file-notify watches to register per project.
 

--- a/doc/modules/ROOT/pages/ignoring.adoc
+++ b/doc/modules/ROOT/pages/ignoring.adoc
@@ -8,8 +8,11 @@ comparison] for the full matrix of what each method honors.
 
 == Ignoring files using `.projectile` (a.k.a. dirconfig)
 
-WARNING: The contents of `.projectile` are ignored when using the
- `alien` project indexing method.
+NOTE: All three indexing methods honor the `-` ignore entries below.  Under
+`alien` they are handed to the external indexing tool as exclusion arguments
+(see xref:indexing.adoc#alien-ignores[Indexing]).  The `+` keep and `!` unignore
+entries have no equivalent in those tools, so they apply under `hybrid` and
+`native` only.
 
 If you'd like to instruct Projectile to ignore certain files in a
 project, when indexing it you can do so in the `.projectile` file by
@@ -130,8 +133,10 @@ way to further adjust what you want to see in Projectile.
 == Global ignore and unignore settings
 
 In addition to per-project ignores, Projectile provides several variables for
-globally ignoring files and directories.  These take effect with `native` and
-`hybrid` indexing but are **not** applied with the `alien` indexing method.
+globally ignoring files and directories.  These take effect with every indexing
+method; under `alien` they are pushed down into the external indexing tool.  The
+`projectile-globally-unignored-*` variables are the exception - they apply with
+`native` and `hybrid` indexing only.
 
 [source,elisp]
 ----
@@ -159,7 +164,8 @@ character — it is the marker that promotes an entry from anchored to anywhere.
 
 The `*` prefix only matters for the `hybrid` post-processor; in `native`
 indexing every entry is matched by directory basename at every traversal step
-(so `tmp` and `*tmp` behave the same). `alien` ignores both forms entirely.
+(so `tmp` and `*tmp` behave the same). Under `alien` both forms are translated
+into an exclusion matching the directory name at any depth.
 
 You can also _unignore_ specific files or directories that would otherwise be
 excluded.  This is useful when your VCS ignores files that you still want

--- a/doc/modules/ROOT/pages/indexing.adoc
+++ b/doc/modules/ROOT/pages/indexing.adoc
@@ -267,6 +267,13 @@ tools and can't be reproduced by filtering a listing that already omits the
 files. They remain `hybrid`/`native` only, and a project that relies on them
 still needs one of those indexing methods.
 
+WARNING: Ignore matching is *case-sensitive* under `alien`, but
+case-insensitive under `native` and `hybrid` (which match suffixes and dirconfig
+patterns through Emacs functions that fold case by default). So with `.elc` in
+`projectile-globally-ignored-file-suffixes`, a file named `BUILD.ELC` is hidden
+under `native`/`hybrid` and listed under `alien`. On a case-insensitive
+filesystem, like the macOS default, you are unlikely to notice.
+
 WARNING: A bare entry in `projectile-globally-ignored-directories` matches at
 any depth under `alien`, the same as it does under `native`, whereas `hybrid`
 matches it only at the top level. The `*` prefix (which marks an entry as

--- a/doc/modules/ROOT/pages/indexing.adoc
+++ b/doc/modules/ROOT/pages/indexing.adoc
@@ -188,7 +188,12 @@ below summarises which configuration knobs take effect under which mode:
 | Fast
 | Fastest
 
-| Honors `.projectile` (dirconfig) `+`/`-`/`!` rules
+| Honors `.projectile` (dirconfig) `-` ignore rules
+| Yes
+| Yes
+| Yes
+
+| Honors `.projectile` (dirconfig) `+` keep and `!` unignore rules
 | Yes
 | Yes
 | No
@@ -196,7 +201,7 @@ below summarises which configuration knobs take effect under which mode:
 | Honors `projectile-globally-ignored-files` / `-directories` / `-file-suffixes` / `projectile-global-ignore-file-patterns`
 | Yes
 | Yes
-| No (rely on the VCS / `fd` / `find` ignores instead)
+| Yes
 
 | Honors `projectile-globally-unignored-*`
 | Yes
@@ -219,11 +224,19 @@ below summarises which configuration knobs take effect under which mode:
 | Requires Unix utilities
 |===
 
-NOTE: When `alien` is in use and a non-empty `.projectile` file is
-present, Projectile emits a one-time warning so the silent bypass
-doesn't catch you off guard.  Switch to `hybrid` (or `native`) if you
-need those rules applied; set
-`projectile-warn-when-dirconfig-is-ignored` to nil to silence.
+[#alien-ignores]
+NOTE: `alien` honors the ignore rules without giving up its speed: they are
+handed to the external tool as exclusion arguments (`git ls-files` pathspecs,
+`fd --exclude`) rather than applied to its output, so no filtering happens in
+Emacs.  The handful of tools that can't express exclusions - `svn`, `fossil`,
+`bzr`, `darcs`, `pijul` and the plain `find` fallback - do get their output
+filtered in Emacs Lisp instead, so the file set is the same either way.  Set
+`projectile-alien-honors-ignores` to nil to get the raw listing back and defer
+entirely to the tool's own ignore rules.
+
+NOTE: Dirconfig `+` keep entries and `!` unignore entries have no equivalent in
+the external tools, so they remain `hybrid`/`native` only.  A project that
+relies on them still needs one of those indexing methods.
 
 TIP: For the details of each ignore mechanism (`.projectile`, the indexing
 tools, and the global ignore/unignore variables), see

--- a/doc/modules/ROOT/pages/indexing.adoc
+++ b/doc/modules/ROOT/pages/indexing.adoc
@@ -267,12 +267,11 @@ tools and can't be reproduced by filtering a listing that already omits the
 files. They remain `hybrid`/`native` only, and a project that relies on them
 still needs one of those indexing methods.
 
-WARNING: Ignore matching is *case-sensitive* under `alien`, but
-case-insensitive under `native` and `hybrid` (which match suffixes and dirconfig
-patterns through Emacs functions that fold case by default). So with `.elc` in
-`projectile-globally-ignored-file-suffixes`, a file named `BUILD.ELC` is hidden
-under `native`/`hybrid` and listed under `alien`. On a case-insensitive
-filesystem, like the macOS default, you are unlikely to notice.
+NOTE: Ignore matching is case-sensitive under every indexing method. With
+`.elc` in `projectile-globally-ignored-file-suffixes`, a file named `BUILD.ELC`
+is *not* ignored - spell out both cases if you want both. Before Projectile 3.3
+`native` and `hybrid` folded case here (a side effect of the Emacs functions
+they matched with), which `alien` had no way to reproduce in the external tools.
 
 WARNING: A bare entry in `projectile-globally-ignored-directories` matches at
 any depth under `alien`, the same as it does under `native`, whereas `hybrid`

--- a/doc/modules/ROOT/pages/indexing.adoc
+++ b/doc/modules/ROOT/pages/indexing.adoc
@@ -225,18 +225,54 @@ below summarises which configuration knobs take effect under which mode:
 |===
 
 [#alien-ignores]
-NOTE: `alien` honors the ignore rules without giving up its speed: they are
-handed to the external tool as exclusion arguments (`git ls-files` pathspecs,
-`fd --exclude`) rather than applied to its output, so no filtering happens in
-Emacs.  The handful of tools that can't express exclusions - `svn`, `fossil`,
-`bzr`, `darcs`, `pijul` and the plain `find` fallback - do get their output
-filtered in Emacs Lisp instead, so the file set is the same either way.  Set
-`projectile-alien-honors-ignores` to nil to get the raw listing back and defer
-entirely to the tool's own ignore rules.
+=== How `alien` applies the ignore rules
 
-NOTE: Dirconfig `+` keep entries and `!` unignore entries have no equivalent in
-the external tools, so they remain `hybrid`/`native` only.  A project that
-relies on them still needs one of those indexing methods.
+`alien` honors the ignore rules without giving up its speed: instead of
+filtering the tool's output in Emacs, it hands the rules to the tool as
+exclusion arguments. Which tools can do that varies, so the ones that can't get
+their output filtered in Emacs Lisp after all. Either way the resulting file set
+is the same - the difference is only where the work happens:
+
+[cols="1,2,2",options="header"]
+|===
+| Indexing command | How the rules are applied | Cost
+
+| `git ls-files`
+| `:(exclude,glob)` pathspecs
+| In the tool
+
+| `fd` (including `projectile-git-use-fd`)
+| repeated `--exclude` globs
+| In the tool
+
+| `hg locate`, `sl locate`, `jj file list`
+| output filtered in Emacs Lisp
+| One pass over the file list
+
+| `svn`, `fossil`, `bzr`, `darcs`, `pijul`
+| output filtered in Emacs Lisp
+| One pass over the file list
+
+| the plain `find` fallback
+| output filtered in Emacs Lisp
+| One pass over the file list
+|===
+
+Set `projectile-alien-honors-ignores` to nil to get the raw listing back and
+defer entirely to the tool's own ignore rules (`.gitignore` and friends).
+
+NOTE: Dirconfig `+` keep entries and `!` unignore entries, and the
+`projectile-globally-unignored-*` variables, have no equivalent in any of these
+tools and can't be reproduced by filtering a listing that already omits the
+files. They remain `hybrid`/`native` only, and a project that relies on them
+still needs one of those indexing methods.
+
+WARNING: A bare entry in `projectile-globally-ignored-directories` matches at
+any depth under `alien`, the same as it does under `native`, whereas `hybrid`
+matches it only at the top level. The `*` prefix (which marks an entry as
+"at any depth" rather than acting as a wildcard) makes no difference under
+`alien`. If you depend on the distinction, `hybrid` is the method that honors
+it.
 
 TIP: For the details of each ignore mechanism (`.projectile`, the indexing
 tools, and the global ignore/unignore variables), see

--- a/projectile.el
+++ b/projectile.el
@@ -144,12 +144,12 @@ and alien indexing.
 
 The alien indexing method optimizes to the limit the speed
 of the hybrid indexing method.  This means that Projectile will
-not do any processing of the files returned by the external
-commands and you're going to get the maximum performance
-possible.  This behaviour makes a lot of sense for most people,
-as they'd typically be putting ignores in their VCS config and
-won't care about any additional ignores/unignores/sorting that
-Projectile might also provide.
+not post-process the files returned by the external commands and
+you're going to get the maximum performance possible.  Projectile's
+ignore rules are still respected - they are handed to the external
+tool as exclusion arguments where it understands them, and applied
+in Emacs Lisp only for the few tools that can't express them (see
+`projectile-alien-honors-ignores').  Sorting is never applied.
 
 The disadvantage of the hybrid and alien methods is that they are not well
 supported on Windows systems.  That's why by default alien indexing is the
@@ -161,6 +161,34 @@ default on all operating systems, except Windows."
           (const :tag "Hybrid" hybrid)
           (const :tag "Alien" alien))
   :package-version '(projectile . "2.0.0"))
+
+(defcustom projectile-alien-honors-ignores t
+  "Whether `alien' indexing applies Projectile's own ignore rules.
+
+The `alien' indexing method delegates the directory walk to an external
+tool (`git ls-files', `fd', `find', ...), which knows nothing about
+Projectile's ignore configuration: `projectile-globally-ignored-files',
+`projectile-globally-ignored-directories',
+`projectile-globally-ignored-file-suffixes' and the `-' entries of a
+project's dirconfig file (see `projectile-dirconfig-file').
+
+When this is non-nil those rules are honored.  Tools that can express
+exclusions themselves (`git ls-files' via pathspecs, `fd' via
+`--exclude') are handed the rules as arguments, so the filtering still
+happens outside Emacs and alien indexing stays fast.  For the few tools
+that can't (svn, fossil, bzr, darcs, pijul, and the plain `find'
+fallback) the rules are applied to the tool's output in Emacs Lisp
+instead.
+
+Set this to nil to get the raw listing back and defer entirely to the
+external tool's own ignore rules (`.gitignore' and friends), which is
+how alien indexing behaved before Projectile 3.3.
+
+Note that dirconfig `+' keep entries and `!' unignore entries are a
+separate mechanism and remain `hybrid'/`native' only."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "3.3.0"))
 
 (defcustom projectile-enable-caching (eq projectile-indexing-method 'native)
   "When t enables project files caching.
@@ -551,17 +579,6 @@ Similar to '#' in .gitignore files."
   :group 'projectile
   :type 'character
   :package-version '(projectile . "2.2.0"))
-
-(defcustom projectile-warn-when-dirconfig-is-ignored t
-  "Whether to warn when a non-empty .projectile is bypassed by alien indexing.
-Under the `alien' indexing method, Projectile does not consult the
-project's dirconfig file at indexing time.  When this option is
-non-nil, a one-time warning is shown for each project where a
-non-empty dirconfig is present alongside alien indexing, since the
-silent bypass is a frequent source of confusion."
-  :group 'projectile
-  :type 'boolean
-  :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-warn-on-prefixless-dirconfig-lines t
   "Whether to warn about deprecated prefix-less ignore entries.
@@ -1048,9 +1065,6 @@ a single pass over the project's cached file list.")
   "Set of project roots already reported as too big (or unable) to watch.
 Used to emit the `projectile-watch-directory-limit' message only once
 per project and session.")
-
-(defvar projectile--alien-dirconfig-warned-projects (make-hash-table :test 'equal)
-  "Set of project roots already warned about alien indexing skipping the dirconfig.")
 
 (defvar projectile--prefixless-dirconfig-warned-projects (make-hash-table :test 'equal)
   "Set of project roots already warned about prefix-less dirconfig entries.")
@@ -3033,6 +3047,109 @@ accumulates discovered file paths in reverse order."
 ;; This corresponds to `projectile-indexing-method' being set to hybrid or alien.
 ;; The only difference between the two methods is that alien doesn't do
 ;; any post-processing of the files obtained via the external command.
+;;
+;; Projectile's own ignore rules are still honored under alien (see
+;; `projectile-alien-honors-ignores'), but they are pushed down into the
+;; external tool as exclusion arguments rather than applied to its output, so
+;; alien keeps doing no Lisp-side filtering.  Only the tools that can't express
+;; exclusions fall back to filtering in Emacs.
+
+(defun projectile--fd-command-p (command)
+  "Return non-nil when COMMAND is one of Projectile's `fd' recipes.
+Recognised by the `--strip-cwd-prefix' flag Projectile puts in them, the
+same way `projectile--ext-command-line' does.  COMMAND may be nil, which
+is how Projectile spells \"external-command indexing is disabled\"."
+  (and command (string-match-p "--strip-cwd-prefix\\b" command)))
+
+(defun projectile--alien-exclude-glob (glob style)
+  "Translate GLOB into an exclusion pattern of the given STYLE.
+
+GLOB is an entry as produced by `projectile--project-ignore-globs': a
+leading `./' means the entry is anchored at the project root, a trailing
+`/' means it names a directory (so its whole subtree is excluded), and
+anything else matches at any depth.
+
+STYLE is `git' for a `git ls-files' pathspec body (wildmatch semantics,
+where `**' crosses directory separators) or `fd' for an `fd --exclude'
+pattern (gitignore semantics, where a leading `/' anchors to the search
+root)."
+  (let* ((rooted (string-prefix-p "./" glob))
+         (body (if rooted (substring glob 2) glob))
+         (dirp (string-suffix-p "/" body))
+         (body (if dirp (substring body 0 -1) body)))
+    (pcase style
+      ('git (concat (unless rooted "**/") body (when dirp "/**")))
+      ('fd (concat (when rooted "/") body))
+      (_ (error "Unknown exclusion style `%S'" style)))))
+
+(defun projectile--alien-exclude-args (vcs command globs)
+  "Return exclusion arguments appending GLOBS to COMMAND, or nil.
+
+Returns nil when GLOBS is empty, or when COMMAND's tool has no way to
+express exclusions - the caller then has to filter the output in Emacs
+Lisp instead (see `projectile--maybe-remove-ignored').
+
+VCS is the project's version-control system as returned by
+`projectile-project-vcs'."
+  (when globs
+    (cond
+     ;; `fd' takes repeated `--exclude' globs.  Checked before VCS because
+     ;; git projects use fd too when `projectile-git-use-fd' is on.
+     ((projectile--fd-command-p command)
+      (mapconcat (lambda (glob)
+                   (concat "-E " (shell-quote-argument
+                                  (projectile--alien-exclude-glob glob 'fd))))
+                 globs " "))
+     ;; `git ls-files' takes exclude pathspecs.  A pathspec list made up
+     ;; entirely of exclusions still lists everything else, so there's no
+     ;; need to add a positive pathspec alongside them.
+     ((eq vcs 'git)
+      (concat "-- "
+              (mapconcat (lambda (glob)
+                           (shell-quote-argument
+                            (concat ":(exclude,glob)"
+                                    (projectile--alien-exclude-glob glob 'git))))
+                         globs " ")))
+     (t nil))))
+
+(defun projectile--alien-ext-command (vcs directory)
+  "Return the external listing command for DIRECTORY, honoring ignore rules.
+Like `projectile-get-ext-command', but with Projectile's ignore rules
+folded in as exclusion arguments when the tool understands them and
+`projectile-alien-honors-ignores' is non-nil."
+  (let ((command (projectile-get-ext-command vcs directory)))
+    (if-let* ((command)
+              (projectile-alien-honors-ignores)
+              (globs (projectile--project-ignore-globs directory))
+              (args (projectile--alien-exclude-args vcs command globs)))
+        (concat command " " args)
+      command)))
+
+(defun projectile--alien-command-excludes-p (vcs command)
+  "Return non-nil when COMMAND for VCS carries the ignore rules itself.
+When it doesn't, the ignore rules have to be applied to the command's
+output instead."
+  (or (projectile--fd-command-p command) (eq vcs 'git)))
+
+(defun projectile--maybe-remove-ignored (project-root files)
+  "Remove PROJECT-ROOT's ignored entries from FILES, honoring the option.
+A no-op when `projectile-alien-honors-ignores' is nil.  FILES are paths
+relative to PROJECT-ROOT, which is bound as `default-directory' so the
+ignore configuration is read for the right project."
+  (if (not projectile-alien-honors-ignores)
+      files
+    (let ((default-directory project-root))
+      (projectile-remove-ignored files))))
+
+(defun projectile--alien-apply-ignores (project-root vcs files)
+  "Apply PROJECT-ROOT's ignore rules to the alien listing FILES.
+Does nothing when the external command for VCS already excluded them
+itself, which is the fast path (see `projectile--alien-exclude-args')."
+  (if (projectile--alien-command-excludes-p
+       vcs (projectile-get-ext-command vcs project-root))
+      files
+    (projectile--maybe-remove-ignored project-root files)))
+
 (defun projectile-dir-files-alien (directory &optional vcs subdirs)
   "Get the files for DIRECTORY using external tools.
 VCS, when supplied, must be the project's VCS as returned by
@@ -3052,9 +3169,14 @@ without shelling out per kept directory."
       (let* ((fd (and projectile-git-use-fd
                       (projectile-fd-executable-for directory)))
              (files (nconc (projectile-files-via-ext-command
-                            directory (projectile-get-ext-command vcs directory)
+                            directory (projectile--alien-ext-command vcs directory)
                             subdirs)
-                           (projectile--restricted-sub-projects-files directory vcs subdirs)))
+                           ;; Submodules are listed by their own `git ls-files'
+                           ;; runs, which never saw our exclusions, so those
+                           ;; files have to be filtered here.
+                           (projectile--maybe-remove-ignored
+                            directory
+                            (projectile--restricted-sub-projects-files directory vcs subdirs))))
              ;; When using git ls-files (not fd), deleted but unstaged
              ;; files are still reported.  Remove them.  Note that the
              ;; fd-availability check is per-DIRECTORY: a project may be
@@ -3067,7 +3189,8 @@ without shelling out per kept directory."
               (dolist (f deleted) (puthash f t deleted-set))
               (seq-remove (lambda (f) (gethash f deleted-set)) files))
           files)))
-     (t (projectile-files-via-ext-command directory (projectile-get-ext-command vcs directory) subdirs)))))
+     (t (projectile-files-via-ext-command
+         directory (projectile--alien-ext-command vcs directory) subdirs)))))
 
 (defun projectile--restricted-sub-projects-files (project-root vcs subdirs)
   "Return git submodule files under PROJECT-ROOT, optionally restricted to SUBDIRS.
@@ -3517,7 +3640,7 @@ files) run synchronously once the main command finishes, inside the
 sentinel - off the caller's critical path - so the assembled result
 matches the synchronous function.  Returns the main command's process."
   (let* ((vcs (or vcs (projectile-project-vcs directory)))
-         (command (projectile-get-ext-command vcs directory)))
+         (command (projectile--alien-ext-command vcs directory)))
     (if (eq vcs 'git)
         (let ((fd (and projectile-git-use-fd
                        (projectile-fd-executable-for directory))))
@@ -3527,8 +3650,12 @@ matches the synchronous function.  Returns the main command's process."
              (if err
                  (funcall callback nil err)
                (let* ((all (nconc files
-                                  (projectile--restricted-sub-projects-files
-                                   directory vcs subdirs)))
+                                  ;; Submodules run their own `git ls-files',
+                                  ;; which never saw our exclusions.
+                                  (projectile--maybe-remove-ignored
+                                   directory
+                                   (projectile--restricted-sub-projects-files
+                                    directory vcs subdirs))))
                       (deleted (unless fd (projectile-git-deleted-files directory))))
                  (funcall callback
                           (if deleted
@@ -3675,7 +3802,11 @@ run Projectile's own indexing command itself:
   :directory  the directory the command should run in (the project root)
   :vcs        the detected version-control system, a symbol (or `none')
   :command    the shell command that lists the files, NUL-separated, or
-              nil when external-command indexing is disabled
+              nil when external-command indexing is disabled.  Carries
+              Projectile's ignore rules as exclusion arguments when the
+              tool understands them (see `projectile-alien-honors-ignores');
+              for the tools that don't, the caller has to apply
+              `projectile-remove-ignored' to the output itself
   :separator  the string that separates records in the command's output
 
 The command's output is exactly what `projectile-files-via-ext-command'
@@ -3690,7 +3821,7 @@ PROJECT-ROOT defaults to the current project."
          (vcs (projectile-project-vcs root)))
     (list :directory root
           :vcs vcs
-          :command (projectile-get-ext-command vcs root)
+          :command (projectile--alien-ext-command vcs root)
           :separator "\0")))
 
 (defun projectile-adjust-files (project vcs files)
@@ -4405,30 +4536,6 @@ CALLER is accepted for backward compatibility but no longer used."
                  nil nil initial-input))))
     (if action (funcall action res) res)))
 
-(defun projectile--dirconfig-non-empty-p ()
-  "Return non-nil if the current project's dirconfig file has any content."
-  (let* ((dirconfig (projectile-dirconfig-file))
-         (attrs (and (projectile-file-exists-p dirconfig)
-                     (file-attributes dirconfig))))
-    (and attrs (> (file-attribute-size attrs) 0))))
-
-(defun projectile--maybe-warn-dirconfig-ignored (project-root)
-  "Warn once per session that PROJECT-ROOT's dirconfig is bypassed by alien mode."
-  (when (and projectile-warn-when-dirconfig-is-ignored
-             (eq projectile-indexing-method 'alien)
-             (not (gethash project-root
-                           projectile--alien-dirconfig-warned-projects))
-             (projectile--dirconfig-non-empty-p))
-    (puthash project-root t projectile--alien-dirconfig-warned-projects)
-    (display-warning
-     'projectile
-     (format "Project %s has a non-empty %s but `projectile-indexing-method' \
-is `alien', which bypasses dirconfig filtering.  Switch to `hybrid' or \
-`native' if you need those rules to apply, or set \
-`projectile-warn-when-dirconfig-is-ignored' to nil to silence this warning."
-             project-root projectile-dirconfig-file)
-     :warning)))
-
 (defun projectile-project-files (project-root)
   "Return a list of files for the PROJECT-ROOT."
   (let (files)
@@ -4456,11 +4563,14 @@ is `alien', which bypasses dirconfig filtering.  Switch to `hybrid' or \
         (message "Projectile is initializing cache for %s ..." project-root))
       (setq files
             (if (eq projectile-indexing-method 'alien)
-                ;; In alien mode we can just skip reading
-                ;; .projectile and find all files in the root dir.
-                (progn
-                  (projectile--maybe-warn-dirconfig-ignored project-root)
-                  (projectile--dir-files-alien-maybe-async project-root))
+                ;; In alien mode we let the external tool walk the whole
+                ;; root.  Projectile's ignore rules ride along as exclusion
+                ;; arguments on the command itself; only the tools that
+                ;; can't express them need a pass over the output here.
+                (let ((vcs (projectile-project-vcs project-root)))
+                  (projectile--alien-apply-ignores
+                   project-root vcs
+                   (projectile--dir-files-alien-maybe-async project-root vcs)))
               (let ((dirs (projectile-get-project-directories project-root)))
                 (cond
                  ((and (eq projectile-indexing-method 'hybrid) (cdr dirs))

--- a/projectile.el
+++ b/projectile.el
@@ -622,8 +622,6 @@ is set to `alien'."
 (defcustom projectile-globally-ignored-directories
   '(".idea"
     ".vscode"
-    ".ensime_cache"
-    ".eunit"
     ".git"
     ".hg"
     ".fslckout"

--- a/projectile.el
+++ b/projectile.el
@@ -3120,6 +3120,12 @@ folded in as exclusion arguments when the tool understands them and
   (let ((command (projectile-get-ext-command vcs directory)))
     (if-let* ((command)
               (projectile-alien-honors-ignores)
+              ;; Only alien pushes the rules down.  Hybrid applies them to
+              ;; the output itself, and doing both would silently give it
+              ;; alien's semantics for the rules where the two differ (a
+              ;; bare `projectile-globally-ignored-directories' entry is
+              ;; top-level-only under hybrid, any-depth under alien).
+              ((eq projectile-indexing-method 'alien))
               (globs (projectile--project-ignore-globs directory))
               (args (projectile--alien-exclude-args vcs command globs)))
         (concat command " " args)
@@ -7569,9 +7575,15 @@ files and directories ignored via the project's dirconfig
 \(`.projectile') are rooted at ROOT with a leading `./'."
   (let ((default-directory root))
     (append
-     ;; globally ignored directory names, matched at any depth
+     ;; Globally ignored directory names, matched at any depth.  A leading
+     ;; `*' in `projectile-globally-ignored-directories' is a marker meaning
+     ;; "at any depth", not a wildcard, so it has to be stripped rather than
+     ;; passed on to a glob matcher that would read it as one (`*.osc' names
+     ;; the directory `.osc', it doesn't match `foo.osc').
      (mapcar (lambda (name)
-               (concat (directory-file-name name) "/"))
+               (concat (directory-file-name
+                        (string-remove-prefix "*" name))
+                       "/"))
              (projectile-globally-ignored-directory-names))
      ;; globally ignored files, matched at any depth
      (copy-sequence projectile-globally-ignored-files)

--- a/projectile.el
+++ b/projectile.el
@@ -2878,16 +2878,18 @@ basenames to ignore anywhere in the tree."
   "Like `projectile-ignored-file-p' but consulting pre-built RULES.
 Used on the hot indexing path to avoid O(N*M) `member' scans."
   (or (gethash file (plist-get rules :ignored-files-set))
-      (seq-some (lambda (re) (string-match-p re file))
+      (seq-some (lambda (re) (let ((case-fold-search nil))
+                               (string-match-p re file)))
                 projectile-global-ignore-file-patterns)
-      (seq-some (lambda (suf) (string-suffix-p suf file t))
+      (seq-some (lambda (suf) (string-suffix-p suf file))
                 projectile-globally-ignored-file-suffixes)))
 
 (defun projectile--ignored-directory-fast-p (directory local-name rules)
   "Like `projectile-ignored-directory-p' but consulting pre-built RULES.
 LOCAL-NAME is the basename of DIRECTORY."
   (or (gethash directory (plist-get rules :ignored-dirs-set))
-      (seq-some (lambda (re) (string-match-p re directory))
+      (seq-some (lambda (re) (let ((case-fold-search nil))
+                               (string-match-p re directory)))
                 projectile-global-ignore-file-patterns)
       (gethash local-name (plist-get rules :globally-ignored-dir-names-set))))
 
@@ -2992,7 +2994,10 @@ state across calls."
   "Recursive walker for `projectile-index-directory'.
 DIRECTORY, PROGRESS-REPORTER and RULES carry the same state as the
 public entry point.  ACC-CELL is a 1-element list whose car
-accumulates discovered file paths in reverse order."
+accumulates discovered file paths in reverse order.
+
+Ignore matching is case-sensitive, so `case-fold-search' is pinned off
+for the dirconfig regexps matched below."
   ;; Use ignore-errors to skip unreadable directories (e.g.
   ;; .Spotlight-V100 on macOS) instead of aborting the entire indexing
   ;; operation.
@@ -3003,12 +3008,13 @@ accumulates discovered file paths in reverse order."
   ;; files from directories without a `file-directory-p' stat per entry -
   ;; that stat is a separate filesystem round-trip each, which dominates the
   ;; walk on large or remote (TRAMP) trees.
-  (let ((entries (ignore-errors
-                   (directory-files-and-attributes
-                    directory t directory-files-no-dot-files-regexp nil 'integer)))
-        (ignore-re (plist-get rules :dirconfig-ignore-re))
-        (ensure-re (plist-get rules :dirconfig-ensure-re))
-        (match-base-len (plist-get rules :match-base-len)))
+  (let* ((case-fold-search nil)
+         (entries (ignore-errors
+                    (directory-files-and-attributes
+                     directory t directory-files-no-dot-files-regexp nil 'integer)))
+         (ignore-re (plist-get rules :dirconfig-ignore-re))
+         (ensure-re (plist-get rules :dirconfig-ensure-re))
+         (match-base-len (plist-get rules :match-base-len)))
     (dolist (entry entries)
       (let* ((f (car entry))
              ;; The type field is t for a directory, a string (the link
@@ -3843,7 +3849,10 @@ Dirconfig ignore patterns (the non-slash-prefixed `-' entries of the
 `.projectile' file) are also applied, compiled via
 `projectile--compile-dirconfig-patterns'; `!' ensure patterns rescue
 files from them."
-  (let* ((filtering-patterns (projectile-filtering-patterns))
+  (let* (;; Ignore matching is case-sensitive; `string-match-p' would
+         ;; otherwise fold case, since `case-fold-search' defaults to t.
+         (case-fold-search nil)
+         (filtering-patterns (projectile-filtering-patterns))
          (dirconfig-ignore-re (projectile--compile-dirconfig-patterns
                                (car filtering-patterns)))
          (dirconfig-ensure-re (projectile--compile-dirconfig-patterns
@@ -3877,7 +3886,7 @@ files from them."
                    (delete "" (split-string
                                (or (file-name-directory file) "") "/"))))
              (seq-some (lambda (dir) (string-prefix-p dir file)) prefix-dirs)
-             (seq-some (lambda (suf) (string-suffix-p suf file t)) suffixes)
+             (seq-some (lambda (suf) (string-suffix-p suf file)) suffixes)
              (and dirconfig-ignore-re
                   (string-match-p dirconfig-ignore-re file)
                   (not (and dirconfig-ensure-re
@@ -4212,7 +4221,7 @@ A pre-computed list of IGNORED-FILES may optionally be provided."
     projectile-global-ignore-file-patterns)
    (seq-some
     (lambda (suffix)
-      (string-suffix-p suffix file t))
+      (string-suffix-p suffix file))
     projectile-globally-ignored-file-suffixes)))
 
 (defun projectile-ignored-files ()

--- a/test/projectile-async-test.el
+++ b/test/projectile-async-test.el
@@ -370,7 +370,8 @@ that stores into it as the async callback."
   (it "describes the external indexing command for the project"
     (spy-on 'projectile-project-vcs :and-return-value 'git)
     (spy-on 'projectile-get-ext-command :and-return-value "git ls-files -zco")
-    (let ((producer (projectile-project-files-producer "/proj/")))
+    (let* ((projectile-alien-honors-ignores nil)
+           (producer (projectile-project-files-producer "/proj/")))
       (expect (plist-get producer :directory) :to-equal "/proj/")
       (expect (plist-get producer :vcs) :to-equal 'git)
       (expect (plist-get producer :command) :to-equal "git ls-files -zco")
@@ -388,6 +389,17 @@ that stores into it as the async callback."
     (spy-on 'projectile-get-ext-command :and-return-value nil)
     (expect (plist-get (projectile-project-files-producer "/proj/") :command)
             :to-be nil))
+
+  (it "folds Projectile's ignore rules into the command as exclusions"
+    ;; external finders driving :command themselves must get the same
+    ;; file set `projectile-find-file' would show
+    (spy-on 'projectile-project-vcs :and-return-value 'git)
+    (spy-on 'projectile-get-ext-command :and-return-value "git ls-files -zco")
+    (spy-on 'projectile--project-ignore-globs :and-return-value '("node_modules/"))
+    (expect (plist-get (projectile-project-files-producer "/proj/") :command)
+            :to-equal
+            (concat "git ls-files -zco -- "
+                    (shell-quote-argument ":(exclude,glob)**/node_modules/**"))))
 
   (it "defaults to the current project when no root is given"
     (spy-on 'projectile-acquire-root :and-return-value "/current/")

--- a/test/projectile-ignore-test.el
+++ b/test/projectile-ignore-test.el
@@ -471,69 +471,6 @@
           (projectile-parse-dirconfig-file))
         (expect 'display-warning :not :to-have-been-called))))))
 
-(describe "alien-mode dirconfig warning"
-  (before-each
-    (clrhash projectile--alien-dirconfig-warned-projects))
-  (it "warns once when alien indexing skips a populated .projectile"
-    (projectile-test-with-sandbox
-     (projectile-test-with-files
-      ("project/.projectile")
-      (let ((root (projectile-test-project-root)))
-        (with-temp-file (expand-file-name ".projectile" root)
-          (insert "-foo\n"))
-        (spy-on 'projectile-project-root :and-return-value root)
-        (spy-on 'projectile-dir-files-alien :and-return-value '("a"))
-        (spy-on 'display-warning)
-        (let ((projectile-indexing-method 'alien)
-              (projectile-enable-caching nil)
-              (projectile-warn-when-dirconfig-is-ignored t))
-          (projectile-project-files root)
-          (projectile-project-files root))
-        (expect 'display-warning :to-have-been-called-times 1)))))
-  (it "does not warn for an empty .projectile"
-    (projectile-test-with-sandbox
-     (projectile-test-with-files
-      ("project/.projectile")
-      (let ((root (projectile-test-project-root)))
-        (spy-on 'projectile-project-root :and-return-value root)
-        (spy-on 'projectile-dir-files-alien :and-return-value '("a"))
-        (spy-on 'display-warning)
-        (let ((projectile-indexing-method 'alien)
-              (projectile-enable-caching nil)
-              (projectile-warn-when-dirconfig-is-ignored t))
-          (projectile-project-files root))
-        (expect 'display-warning :not :to-have-been-called)))))
-  (it "does not warn when the warning is disabled"
-    (projectile-test-with-sandbox
-     (projectile-test-with-files
-      ("project/.projectile")
-      (let ((root (projectile-test-project-root)))
-        (with-temp-file (expand-file-name ".projectile" root)
-          (insert "-foo\n"))
-        (spy-on 'projectile-project-root :and-return-value root)
-        (spy-on 'projectile-dir-files-alien :and-return-value '("a"))
-        (spy-on 'display-warning)
-        (let ((projectile-indexing-method 'alien)
-              (projectile-enable-caching nil)
-              (projectile-warn-when-dirconfig-is-ignored nil))
-          (projectile-project-files root))
-        (expect 'display-warning :not :to-have-been-called)))))
-  (it "does not warn under non-alien indexing"
-    (projectile-test-with-sandbox
-     (projectile-test-with-files
-      ("project/.projectile")
-      (let ((root (projectile-test-project-root)))
-        (with-temp-file (expand-file-name ".projectile" root)
-          (insert "-foo\n"))
-        (spy-on 'projectile-project-root :and-return-value root)
-        (spy-on 'projectile-get-project-directories :and-return-value '())
-        (spy-on 'display-warning)
-        (let ((projectile-indexing-method 'native)
-              (projectile-enable-caching nil)
-              (projectile-warn-when-dirconfig-is-ignored t))
-          (projectile-project-files root))
-        (expect 'display-warning :not :to-have-been-called))))))
-
 (describe "projectile--ignored-file-fast-p"
   (it "returns t for files in the pre-computed ignored-files-set"
     (let ((rules (projectile--make-walk-rules

--- a/test/projectile-ignore-test.el
+++ b/test/projectile-ignore-test.el
@@ -472,6 +472,16 @@
         (expect 'display-warning :not :to-have-been-called))))))
 
 (describe "projectile--ignored-file-fast-p"
+  (it "matches global ignore patterns and suffixes case-sensitively"
+    ;; `string-match-p' and `string-suffix-p' both fold case by default
+    (let ((rules (projectile--make-walk-rules nil nil nil))
+          (projectile-global-ignore-file-patterns '("build"))
+          (projectile-globally-ignored-file-suffixes '(".elc")))
+      (expect (projectile--ignored-file-fast-p "/r/build/a.o" rules) :to-be-truthy)
+      (expect (projectile--ignored-file-fast-p "/r/BUILD/a.o" rules) :not :to-be-truthy)
+      (expect (projectile--ignored-file-fast-p "/r/a.elc" rules) :to-be-truthy)
+      (expect (projectile--ignored-file-fast-p "/r/a.ELC" rules) :not :to-be-truthy)))
+
   (it "returns t for files in the pre-computed ignored-files-set"
     (let ((rules (projectile--make-walk-rules
                   '("/r/TAGS") nil nil)))
@@ -513,7 +523,26 @@
     (let* ((file-names '("foo.c" "foo.o" "foo.so" "foo.o.gz" "foo.tar.gz" "foo.tar.GZ"))
            (files (mapcar 'projectile-expand-root file-names)))
       (let ((projectile-globally-ignored-file-suffixes '(".o" ".so" ".tar.gz")))
-        (expect (projectile-remove-ignored files) :to-equal (mapcar 'projectile-expand-root '("foo.c" "foo.o.gz"))))))
+        ;; matching is case-sensitive, so `foo.tar.GZ' survives `.tar.gz'
+        (expect (projectile-remove-ignored files)
+                :to-equal (mapcar 'projectile-expand-root
+                                  '("foo.c" "foo.o.gz" "foo.tar.GZ"))))))
+
+  (it "matches ignored suffixes case-sensitively"
+    (spy-on 'projectile-project-root :and-return-value "/path/to/project")
+    (spy-on 'projectile-ignored-files-rel)
+    (spy-on 'projectile-ignored-directories-rel)
+    (let ((projectile-globally-ignored-file-suffixes '(".elc")))
+      (expect (projectile-remove-ignored '("a.elc" "B.ELC" "c.Elc"))
+              :to-equal '("B.ELC" "c.Elc"))))
+
+  (it "matches dirconfig ignore patterns case-sensitively"
+    (spy-on 'projectile-project-root :and-return-value "/path/to/project")
+    (spy-on 'projectile-ignored-files-rel)
+    (spy-on 'projectile-ignored-directories-rel)
+    (spy-on 'projectile-filtering-patterns :and-return-value '(("*.log") . nil))
+    (expect (projectile-remove-ignored '("a.log" "B.LOG"))
+            :to-equal '("B.LOG")))
   (it "drops files whose basename matches an ignored entry"
     (spy-on 'projectile-ignored-files-rel :and-return-value '("TAGS"))
     (spy-on 'projectile-ignored-directories-rel :and-return-value nil)

--- a/test/projectile-indexing-test.el
+++ b/test/projectile-indexing-test.el
@@ -92,7 +92,10 @@
     (spy-on 'projectile-get-sub-projects-files :and-return-value nil)
     (spy-on 'projectile-git-deleted-files :and-return-value nil)
     (let ((projectile-git-use-fd t)
-          (projectile-fd-executable "fd"))
+          (projectile-fd-executable "fd")
+          ;; this spec is about which base command is picked, not about
+          ;; the ignore exclusions appended to it
+          (projectile-alien-honors-ignores nil))
       (projectile-dir-files-alien "/my/root/" 'git)
       ;; When fd is on we don't ask git for deleted files.
       (expect 'projectile-git-deleted-files :not :to-have-been-called)
@@ -101,7 +104,8 @@
                 (concat "fd " projectile-git-fd-args)))))
   (it "falls back to the generic command for projects without a VCS"
     (spy-on 'projectile-files-via-ext-command :and-return-value '("a.txt"))
-    (let ((files (projectile-dir-files-alien "/my/root/" 'none)))
+    (let* ((projectile-alien-honors-ignores nil)
+           (files (projectile-dir-files-alien "/my/root/" 'none)))
       (expect files :to-equal '("a.txt"))
       (expect (cadr (spy-calls-args-for 'projectile-files-via-ext-command 0))
               :to-equal projectile-generic-command))))
@@ -994,5 +998,100 @@
           (expect native :not :to-contain "docs/a.text")
           (expect native :not :to-contain "vendor/lib.js")
           (expect native :not :to-contain "src/gen/out.c")))))))
+
+(describe "alien ignore exclusions"
+  (it "translates ignore globs into git pathspec bodies"
+    (expect (projectile--alien-exclude-glob "node_modules/" 'git)
+            :to-equal "**/node_modules/**")
+    (expect (projectile--alien-exclude-glob "TAGS" 'git) :to-equal "**/TAGS")
+    (expect (projectile--alien-exclude-glob "*.elc" 'git) :to-equal "**/*.elc")
+    (expect (projectile--alien-exclude-glob "./vendor/" 'git) :to-equal "vendor/**")
+    (expect (projectile--alien-exclude-glob "./a/b.txt" 'git) :to-equal "a/b.txt"))
+
+  (it "translates ignore globs into fd exclude patterns"
+    ;; fd speaks gitignore, where a leading slash anchors to the search root
+    (expect (projectile--alien-exclude-glob "node_modules/" 'fd)
+            :to-equal "node_modules")
+    (expect (projectile--alien-exclude-glob "*.elc" 'fd) :to-equal "*.elc")
+    (expect (projectile--alien-exclude-glob "./vendor/" 'fd) :to-equal "/vendor")
+    (expect (projectile--alien-exclude-glob "./a/b.txt" 'fd) :to-equal "/a/b.txt"))
+
+  (it "declines for tools that cannot express exclusions"
+    ;; svn and friends are shell pipelines, so the caller filters in Lisp
+    (expect (projectile--alien-exclude-args 'svn projectile-svn-command '("*.elc"))
+            :to-be nil)
+    (expect (projectile--alien-command-excludes-p 'svn projectile-svn-command)
+            :to-be nil)
+    (expect (projectile--alien-command-excludes-p 'git projectile-git-command)
+            :to-be-truthy))
+
+  (it "leaves the command alone when the option is off"
+    (spy-on 'projectile-get-ext-command :and-return-value "git ls-files -z")
+    (let ((projectile-alien-honors-ignores nil))
+      (expect (projectile--alien-ext-command 'git "/proj/")
+              :to-equal "git ls-files -z")))
+
+  (it "leaves a nil command alone when external indexing is disabled"
+    (spy-on 'projectile-get-ext-command :and-return-value nil)
+    (expect (projectile--alien-ext-command 'none "/proj/") :to-be nil)))
+
+(describe "alien/hybrid dirconfig parity"
+  ;; The acceptance test for pushing the ignore rules into the external
+  ;; tool: against a real git repo, alien must produce the same file set
+  ;; hybrid does, even though it never filters the output in Lisp.
+  (it "produces the same file set under alien and hybrid"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/"
+       "project/src/"
+       "project/src/main.c"
+       "project/vendor/"
+       "project/vendor/lib.js"
+       "project/docs/"
+       "project/docs/a.text"
+       "project/README.md"
+       "project/build.elc")
+      (let* ((root (projectile-test-project-root))
+             (default-directory root))
+        (with-temp-file (expand-file-name ".projectile" root)
+          (insert "-*.text\n-vendor/\n"))
+        (call-process "git" nil nil nil "init")
+        (call-process "git" nil nil nil "add" "-A")
+        (spy-on 'projectile-project-root :and-return-value root)
+        ;; projectile-add-unignored asks git for its ignored entries
+        (spy-on 'projectile-get-repo-ignored-files :and-return-value nil)
+        (spy-on 'projectile-get-repo-ignored-directory :and-return-value nil)
+        (let* ((projectile-enable-caching nil)
+               (projectile-globally-ignored-file-suffixes '(".elc"))
+               (projectile-git-use-fd nil)
+               (projectile-fd-executable nil)
+               (alien (let ((projectile-indexing-method 'alien))
+                        (projectile-project-files root)))
+               (hybrid (let ((projectile-indexing-method 'hybrid))
+                         (projectile-project-files root))))
+          (expect alien :to-have-same-items-as hybrid)
+          (expect alien :to-contain "src/main.c")
+          (expect alien :to-contain "README.md")
+          (expect alien :not :to-contain "docs/a.text")
+          (expect alien :not :to-contain "vendor/lib.js")
+          (expect alien :not :to-contain "build.elc"))))))
+
+  (it "lists everything again once the option is turned off"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/" "project/docs/" "project/docs/a.text" "project/README.md")
+      (let* ((root (projectile-test-project-root))
+             (default-directory root))
+        (with-temp-file (expand-file-name ".projectile" root)
+          (insert "-*.text\n"))
+        (call-process "git" nil nil nil "init")
+        (call-process "git" nil nil nil "add" "-A")
+        (spy-on 'projectile-project-root :and-return-value root)
+        (let* ((projectile-enable-caching nil)
+               (projectile-indexing-method 'alien)
+               (projectile-git-use-fd nil)
+               (projectile-fd-executable nil)
+               (projectile-alien-honors-ignores nil))
+          (expect (projectile-project-files root) :to-contain "docs/a.text")))))))
 
 ;;; projectile-indexing-test.el ends here

--- a/test/projectile-indexing-test.el
+++ b/test/projectile-indexing-test.el
@@ -1033,7 +1033,82 @@
 
   (it "leaves a nil command alone when external indexing is disabled"
     (spy-on 'projectile-get-ext-command :and-return-value nil)
-    (expect (projectile--alien-ext-command 'none "/proj/") :to-be nil)))
+    (expect (projectile--alien-ext-command 'none "/proj/") :to-be nil))
+
+  (it "leaves the command alone under hybrid indexing"
+    ;; hybrid filters the output itself; pushing the rules down as well
+    ;; would hand it alien's semantics for the rules where the two differ
+    (spy-on 'projectile-get-ext-command :and-return-value "git ls-files -z")
+    (spy-on 'projectile--project-ignore-globs :and-return-value '("node_modules/"))
+    (let ((projectile-indexing-method 'hybrid))
+      (expect (projectile--alien-ext-command 'git "/proj/")
+              :to-equal "git ls-files -z"))
+    (let ((projectile-indexing-method 'alien))
+      (expect (projectile--alien-ext-command 'git "/proj/")
+              :not :to-equal "git ls-files -z")))
+
+  (it "treats a `*'-prefixed ignored directory as a name, not a wildcard"
+    ;; `*.osc' names the directory `.osc' at any depth - a glob matcher
+    ;; would read the `*' as a wildcard and also drop `foo.osc'
+    (spy-on 'projectile-parse-dirconfig-file :and-return-value nil)
+    (let ((projectile-globally-ignored-directories '("*.osc"))
+          (projectile-globally-unignored-directories nil)
+          (projectile-globally-ignored-files nil)
+          (projectile-globally-ignored-file-suffixes nil))
+      (expect (projectile--project-ignore-globs "/proj/") :to-contain ".osc/")
+      (expect (projectile--project-ignore-globs "/proj/") :not :to-contain "*.osc/"))))
+
+(describe "native/alien dirconfig parity"
+  ;; Native is the semantic reference: it walks the tree in Emacs Lisp and
+  ;; applies the rules directly, so whatever it produces is what the
+  ;; translated exclusions have to reproduce.  Comparing alien against
+  ;; hybrid alone would not catch a mistranslation, since both of those
+  ;; start from the same external listing.
+  (it "produces the same file set under native and alien"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/"
+       "project/keep.txt"
+       "project/src/main.c"
+       "project/docs/a.text"
+       "project/deep/nested/b.text"
+       "project/build.elc"
+       "project/vendor/lib.js"
+       "project/deep/vendor/deep.js"
+       "project/q1.txt"
+       "project/qXY.txt")
+      (let* ((root (projectile-test-project-root))
+             (default-directory root))
+        (with-temp-file (expand-file-name ".projectile" root)
+          ;; a glob, a directory pattern and a single-character wildcard
+          (insert "-*.text\n-vendor/\n-q?.txt\n"))
+        (call-process "git" nil nil nil "init")
+        (call-process "git" nil nil nil "add" "-A")
+        (spy-on 'projectile-project-root :and-return-value root)
+        (spy-on 'projectile-get-repo-ignored-files :and-return-value nil)
+        (spy-on 'projectile-get-repo-ignored-directory :and-return-value nil)
+        (let* ((projectile-enable-caching nil)
+               (projectile-globally-ignored-file-suffixes '(".elc"))
+               ;; pin the ignore config rather than leaning on the defaults;
+               ;; the native walker would otherwise descend into .git, which
+               ;; git ls-files never reports in the first place
+               (projectile-globally-ignored-directories '(".git"))
+               (projectile-globally-ignored-files nil)
+               (projectile-git-use-fd nil)
+               (projectile-fd-executable nil)
+               (native (let ((projectile-indexing-method 'native))
+                         (projectile-project-files root)))
+               (alien (let ((projectile-indexing-method 'alien))
+                        (projectile-project-files root))))
+          (expect alien :to-have-same-items-as native)
+          (expect alien :to-contain "src/main.c")
+          (expect alien :to-contain "qXY.txt")
+          (expect alien :not :to-contain "docs/a.text")
+          (expect alien :not :to-contain "deep/nested/b.text")
+          (expect alien :not :to-contain "vendor/lib.js")
+          (expect alien :not :to-contain "deep/vendor/deep.js")
+          (expect alien :not :to-contain "q1.txt")
+          (expect alien :not :to-contain "build.elc")))))))
 
 (describe "alien/hybrid dirconfig parity"
   ;; The acceptance test for pushing the ignore rules into the external


### PR DESCRIPTION
`alien` is the default indexing method and it applied none of Projectile's ignore rules - not the globally-ignored files/dirs/suffixes, not the `-` entries of a `.projectile`. We even shipped a warning whose only job was to say the dirconfig was being bypassed.

Post-filtering the output is what `hybrid` already does, so instead the rules are handed to the tool: exclude pathspecs for `git ls-files`, `-E` globs for `fd`. Tools that can't express exclusions (svn, fossil, bzr, darcs, pijul, plain `find`) get their output filtered in Lisp. `projectile-alien-honors-ignores` turns it all off.

Two follow-on changes fell out of testing it against `native`: `+` keep and `!` unignore entries stay hybrid/native only (no tool equivalent), and ignore matching is now case-sensitive everywhere - `native`/`hybrid` used to fold case, which `fd` can't reproduce at all.

Alien projects will list fewer files after this. That's the point, but it's the kind of change worth knowing about.