### PR TITLE
Stop the test suite blocking on a real minibuffer prompt

### DIFF
--- a/test/projectile-switch-test.el
+++ b/test/projectile-switch-test.el
@@ -50,8 +50,13 @@
 
   (it "fails when there is no projectile project"
     (projectile-test-with-sandbox
-     (let ((default-directory "/"))
-       (expect (projectile-add-dir-local-variable nil 'fooo 1) :to-throw 'error)))))
+     ;; `projectile-require-project-root' defaults to `prompt', which would
+     ;; send this down the "Switch to project:" completing-read path instead
+     ;; of the error path the spec is about.
+     (let ((default-directory "/")
+           (projectile-require-project-root t))
+       (expect (projectile-add-dir-local-variable nil 'fooo 1)
+               :to-throw 'user-error)))))
 
 (describe "projectile-delete-dir-local-variable"
   (it "deletes existing dir-local variables"
@@ -78,8 +83,12 @@
 
   (it "fails when there is no projectile project"
     (projectile-test-with-sandbox
-     (let ((default-directory "/"))
-       (expect (projectile-delete-dir-local-variable nil 'fooo 1) :to-throw 'error)))))
+     (let ((default-directory "/")
+           (projectile-require-project-root t))
+       ;; two arguments: passing three used to fail with
+       ;; `wrong-number-of-arguments' before reaching the body at all
+       (expect (projectile-delete-dir-local-variable nil 'fooo)
+               :to-throw 'user-error)))))
 
 (describe "projectile-most-recent-project"
   (it "records the project switched away from"

--- a/test/projectile-test-helpers.el
+++ b/test/projectile-test-helpers.el
@@ -46,6 +46,19 @@
   (when (fboundp fn)
     (advice-add fn :override #'ignore)))
 
+;; A spec that reaches a real `completing-read' blocks on stdin in batch mode.
+;; Whether that shows up as a failure or as a hang depends on nothing more than
+;; whether stdin happens to be at EOF: under `eldev test' it usually is, so the
+;; read errors out and the spec "passes"; run the same suite with anything
+;; still holding the pipe open (a CI wrapper, a pager, `sleep 300 | ...') and it
+;; waits forever instead.  Turn any unstubbed prompt into an immediate, legible
+;; failure.  `spy-on' and `cl-letf' stubs replace `symbol-function', so they
+;; still win over this.
+(dolist (fn '(completing-read read-from-minibuffer))
+  (advice-add fn :override
+              (lambda (prompt &rest _)
+                (error "Unexpected minibuffer prompt in a spec: %s" prompt))))
+
 ;; Useful debug information
 (message "Running tests on Emacs %s" emacs-version)
 


### PR DESCRIPTION
The two "fails when there is no projectile project" specs never bound `projectile-require-project-root`, which defaults to `prompt`, so they took the "Switch to project:" `completing-read` path instead of the error path they claim to test. In batch that read blocks on stdin, and whether it looks like a failure or a hang comes down to whether stdin is at EOF: under a plain `eldev test` it is, the read errors out, and the spec passes for the wrong reason. Hold the pipe open and the suite waits forever - `sleep 300 | eldev -p -dtT test` reproduces it every time, which is the intermittent hang I kept hitting locally.

Both specs now bind the variable and assert the `user-error` rather than any error at all. The delete one was also passing three arguments to a two-argument function, so it never reached the body.

`completing-read` and `read-from-minibuffer` are now overridden in the test helpers to signal instead of prompting. A probe across all 936 specs found exactly one unstubbed call, so nothing else relies on it, and a future stray prompt fails immediately with the prompt text instead of wedging the run.

Unrelated but noticed nearby: several specs call `projectile-add-known-project` without binding `projectile-known-projects-file`, so they write sandbox paths into `.eldev/*/emacs-dir/projectile-bookmarks.eld` (it currently holds 10 stale entries). Left alone here.