### PR TITLE
Give the ignore configuration gitignore semantics everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [#2104](https://github.com/bbatsov/projectile/pull/2104): Alien indexing now honors Projectile's ignore rules, which it previously skipped entirely.
   - The rules are pushed into the external tool (`git ls-files` exclude pathspecs, `fd --exclude`), so the filtering still happens outside Emacs.
   - Tools that can't express exclusions (svn, fossil, bzr, darcs, pijul, plain `find`) have their output filtered in Emacs Lisp instead.
-  - Dirconfig `+` keep and `!` unignore entries have no equivalent in the tools and stay `hybrid`/`native` only.
+  - Dirconfig `+` keep entries have no equivalent in the tools and stay `hybrid`/`native` only.
   - Alien projects will list fewer files than before; set `projectile-alien-honors-ignores` to nil for the old behavior.
 - [#2096](https://github.com/bbatsov/projectile/pull/2096): Add an optional Embark/Marginalia integration, wired via `with-eval-after-load` so neither package becomes a dependency.
   - A `project-file` transformer resolves Projectile's project-relative candidates, augmenting Embark's own rather than replacing it.
@@ -19,9 +19,15 @@
 
 ### Changes
 
+- [#2107](https://github.com/bbatsov/projectile/pull/2107): Projectile's ignore configuration now speaks gitignore patterns everywhere, matched the same way by every indexing method.
+  - `projectile-globally-ignored-directories`, `projectile-globally-ignored-files` and `projectile-globally-ignored-file-suffixes` join the `.projectile` `-` entries in one pattern language and one matcher: a slashless pattern matches at any depth, a pattern with a slash is anchored at the project root, a trailing `/` means directory-only, and `*`, `**`, `?` and `[...]` are wildcards.
+  - The `*` prefix in `projectile-globally-ignored-directories` is no longer a marker meaning "at any depth" (that's now the default) - it's a plain wildcard, so `*node_modules` should become `node_modules`. The default entry `*.osc` became `.osc` accordingly.
+  - A bare entry is no longer top-level-only under `hybrid`; write `/tmp` if you meant only the project root.
+  - `projectile-global-ignore-file-patterns` stays what it always was - Emacs regexps - and therefore applies under `native` indexing only.
+  - Dirconfig `!` ensure entries now apply under `alien` too (such a project gives up the push-down and is filtered in Emacs Lisp, since an exclusion argument can't be taken back).
+  - `projectile-index-directory` no longer takes the three optional list arguments; it derives everything from the compiled patterns it is handed.
 - [#2104](https://github.com/bbatsov/projectile/pull/2104): Ignore matching is now case-sensitive under every indexing method, where `native` and `hybrid` previously folded case (so `.elc` also hid `BUILD.ELC`); the external tools behind `alien` can't express that, so spell out both cases if you relied on it.
 - [#2104](https://github.com/bbatsov/projectile/pull/2104): Drop `.ensime_cache` and `.eunit` from the default `projectile-globally-ignored-directories`, as ENSIME was archived in 2018 and `.eunit` is a rebar2 artifact.
-- [#2104](https://github.com/bbatsov/projectile/pull/2104): Fix a leading `*` in `projectile-globally-ignored-directories` being treated as a wildcard rather than the "at any depth" marker it is, which also affected `project.el`'s `project-ignores` and the ripgrep search path.
 - [#2104](https://github.com/bbatsov/projectile/pull/2104): Remove `projectile-warn-when-dirconfig-is-ignored`, which existed only to warn that `alien` bypassed the dirconfig.
 - [#2099](https://github.com/bbatsov/projectile/pull/2099): Drop the standalone package headers (`Version`, `Package-Requires`) from `projectile-consult.el`, since the phantom `Package-Requires` made build tooling treat an in-package module as its own package (it broke `eldev` test runs on Emacs 28.x).
 

--- a/doc/modules/ROOT/pages/ignoring.adoc
+++ b/doc/modules/ROOT/pages/ignoring.adoc
@@ -8,17 +8,17 @@ comparison] for the full matrix of what each method honors.
 
 == Ignoring files using `.projectile` (a.k.a. dirconfig)
 
-NOTE: All three indexing methods honor the `-` ignore entries below.  Under
-`alien` they are handed to the external indexing tool as exclusion arguments
-(see xref:indexing.adoc#alien-ignores[Indexing]).  The `+` keep and `!` unignore
-entries have no equivalent in those tools, so they apply under `hybrid` and
-`native` only.
+NOTE: All three indexing methods honor the `-` ignore and `!` unignore entries
+below.  Under `alien` the ignore entries are handed to the external indexing
+tool as exclusion arguments (see xref:indexing.adoc#alien-ignores[Indexing]).
+The `+` keep entries have no equivalent in those tools, so they apply under
+`hybrid` and `native` only.
 
 If you'd like to instruct Projectile to ignore certain files in a
 project, when indexing it you can do so in the `.projectile` file by
-adding each path to ignore, where the paths all are relative to the
-root directory and start with a slash. Everything ignored should be
-preceded with a `-` sign.
+adding one pattern per line, each preceded with a `-` sign. The
+patterns follow gitignore rules and are matched against paths relative
+to the project root - a leading slash anchors a pattern there.
 
 NOTE: Lines without any prefix at all are still accepted and treated
 as ignore patterns for backward compatibility, but the implicit form
@@ -34,8 +34,8 @@ Here's an example for a typical Rails application:
 -/public/uploads
 ----
 
-This would ignore the folders only at the root of the project.
-Projectile also supports relative pathname ignores:
+This would ignore those folders only at the root of the project.
+Patterns without a slash match at any depth instead:
 
 ----
 -tmp
@@ -76,33 +76,29 @@ When a path is overridden, its contents are still subject to ignore
 patterns. To override those files as well, specify their full path
 with a bang prefix.
 
-=== Path entries vs. glob patterns
+[#pattern-language]
+=== The pattern language
 
-The two ignore examples above look similar but go through different
-matchers. An entry that begins with a slash (e.g. `-/log`,
-`+/src/foo`, `!/src/foo`) is treated as a *path* relative to the
-project root and is expanded literally. An entry without a leading
-slash (e.g. `-tmp`, `-*.rb`) is treated as a *glob pattern* matched
-against every file's root-relative path, with rules modeled on
-`.gitignore` (since Projectile 3.1; the rules are identical under the
-`native` and `hybrid` indexing methods):
+Both ignore examples above are the same thing: gitignore patterns,
+matched against every file's root-relative path. There's one pattern
+language and one matcher, shared by every indexing method and by the
+global ignore variables described below.
 
 * A pattern without a slash matches the file name or any directory
   segment at any depth: `-log` ignores a file or directory called
   `log` anywhere in the tree, but won't match `xlog` or `log.txt`.
-* A pattern containing a slash is anchored at the project root:
-  `-src/gen` ignores only `src/gen`, not `lib/src/gen`. Prefix the
-  pattern with `**/` to match at any depth.
+* A pattern containing a slash is anchored at the project root, and a
+  leading slash anchors without naming a directory of its own:
+  `-src/gen` and `-/log` ignore only `src/gen` and `log` at the root,
+  not `lib/src/gen` or `src/log`. Prefix the pattern with `**/` to
+  match at any depth.
 * A trailing slash restricts the pattern to directories: `-vendor/`
   ignores `vendor` directories, but not files named `vendor`.
 * A matched directory covers its entire subtree.
 * `*` matches within a single path segment, while `**` also crosses
   `/`; `?` matches a single character, and `[...]`/`[!...]`
   character classes are supported.
-
-If a glob pattern doesn't behave the way you'd expect, try the
-explicit path form first to confirm whether the file is being indexed
-at all.
+* Matching is case-sensitive.
 
 === Comments
 
@@ -133,39 +129,45 @@ way to further adjust what you want to see in Projectile.
 == Global ignore and unignore settings
 
 In addition to per-project ignores, Projectile provides several variables for
-globally ignoring files and directories.  These take effect with every indexing
-method; under `alien` they are pushed down into the external indexing tool.  The
-`projectile-globally-unignored-*` variables are the exception - they apply with
-`native` and `hybrid` indexing only.
+globally ignoring files and directories.  Except for
+`projectile-global-ignore-file-patterns` (see below) their entries are the
+gitignore patterns described xref:pattern-language[above], and they take effect
+with every indexing method; under `alien` they are pushed down into the external
+indexing tool.
 
 [source,elisp]
 ----
+;; Ignore files by name, at any depth
+(setq projectile-globally-ignored-files '("TAGS" "GPATH"))
+
 ;; Ignore files by suffix (e.g. compiled artifacts)
 (setq projectile-globally-ignored-file-suffixes '(".o" ".pyc" ".elc"))
 
-;; Ignore files matching regexp patterns
-(setq projectile-global-ignore-file-patterns '("\\.min\\.js$" "\\.map$"))
+;; Ignore directories - the entries are patterns, so `*' is a wildcard
+(setq projectile-globally-ignored-directories
+      '("node_modules"  ; any directory named node_modules, at any depth
+        "/tmp"          ; only ./tmp, at the project root
+        "*.egg-info"))  ; any directory whose name ends in .egg-info
 ----
 
-=== Anchored vs anywhere directory ignores
-
-`projectile-globally-ignored-directories` distinguishes between *anchored*
-entries (matched as a path prefix relative to the project root) and *anywhere*
-entries (matched at any depth in the tree). The leading `*` is **not** a glob
-character — it is the marker that promotes an entry from anchored to anywhere.
+`projectile-global-ignore-file-patterns` is the odd one out: its entries are
+Emacs regexps, matched against absolute file names, not patterns. They can't be
+handed to an external tool or expressed as a glob, so they only apply under
+`native` indexing.
 
 [source,elisp]
 ----
-(setq projectile-globally-ignored-directories
-      '("tmp"           ; only ignores ./tmp at the project root
-        "*node_modules" ; ignores any directory named node_modules at any depth
-        ))
+;; Ignore files matching regexp patterns (native indexing only)
+(setq projectile-global-ignore-file-patterns '("\\.min\\.js$" "\\.map$"))
 ----
 
-The `*` prefix only matters for the `hybrid` post-processor; in `native`
-indexing every entry is matched by directory basename at every traversal step
-(so `tmp` and `*tmp` behave the same). Under `alien` both forms are translated
-into an exclusion matching the directory name at any depth.
+NOTE: Before Projectile 3.3 a leading `*` in
+`projectile-globally-ignored-directories` was a marker meaning "at any depth"
+rather than a wildcard, and a bare entry was matched at the top level only
+(under `hybrid`) or by directory name at any depth (under `native`). Now every
+entry is a plain gitignore pattern, matched identically by every indexing
+method: drop the `*` prefix from entries like `*node_modules`, and write `/tmp`
+if you really mean only the one at the project root.
 
 You can also _unignore_ specific files or directories that would otherwise be
 excluded.  This is useful when your VCS ignores files that you still want

--- a/doc/modules/ROOT/pages/indexing.adoc
+++ b/doc/modules/ROOT/pages/indexing.adoc
@@ -122,10 +122,10 @@ TIP: It's a great idea to install https://github.com/sharkdp/fd[fd] which is muc
  If `fd` is found, projectile will use it as a replacement for `find` for non-VCS projects.
 
 WARNING: The `find` fallback does *not* exclude common build/cache directories
- (`.git`, `node_modules`, `target`, `build`, …); a non-VCS project under `alien`
- indexing on a host without `fd` will list everything.  Either install `fd`,
- switch to `hybrid` indexing so `projectile-globally-ignored-directories`
- applies, or override `projectile-generic-command` with a tighter recipe.
+ (`.git`, `node_modules`, `target`, `build`, …) itself, so it walks the whole
+ tree even though Projectile then drops the ignored entries from its output (see
+ xref:#alien-ignores[below]).  Install `fd` or override
+ `projectile-generic-command` with a tighter recipe if that walk is slow.
 
 By default, `fd` is also used inside Git repositories (instead of `git ls-files`),
 because `git ls-files` has the limitation that it lists deleted files until the
@@ -159,9 +159,8 @@ words, it's `alien` plus a second pass that applies:
 
 * `.projectile` (dirconfig) ignore/keep/ensure entries
 * `projectile-globally-ignored-files`,
-  `projectile-globally-ignored-directories`,
-  `projectile-globally-ignored-file-suffixes`, and
-  `projectile-global-ignore-file-patterns`
+  `projectile-globally-ignored-directories` and
+  `projectile-globally-ignored-file-suffixes`
 * `projectile-globally-unignored-files` and
   `projectile-globally-unignored-directories`
 * The configured sort order from `projectile-sort-order`
@@ -193,18 +192,33 @@ below summarises which configuration knobs take effect under which mode:
 | Yes
 | Yes
 
-| Honors `.projectile` (dirconfig) `+` keep and `!` unignore rules
+| Honors `.projectile` (dirconfig) `+` keep rules
 | Yes
 | Yes
 | No
 
-| Honors `projectile-globally-ignored-files` / `-directories` / `-file-suffixes` / `projectile-global-ignore-file-patterns`
+| Honors `.projectile` (dirconfig) `!` unignore rules
 | Yes
 | Yes
 | Yes
 
+| Honors `projectile-globally-ignored-files` / `-directories` / `-file-suffixes`
+| Yes
+| Yes
+| Yes
+
+| Honors `projectile-global-ignore-file-patterns` (Emacs regexps)
+| Yes
+| No
+| No
+
 | Honors `projectile-globally-unignored-*`
 | Yes
+| Yes
+| Yes
+
+| Re-adds files the VCS itself ignores (`projectile-globally-unignored-*`, `!` entries)
+| n/a
 | Yes
 | No
 
@@ -230,8 +244,9 @@ below summarises which configuration knobs take effect under which mode:
 `alien` honors the ignore rules without giving up its speed: instead of
 filtering the tool's output in Emacs, it hands the rules to the tool as
 exclusion arguments. Which tools can do that varies, so the ones that can't get
-their output filtered in Emacs Lisp after all. Either way the resulting file set
-is the same - the difference is only where the work happens:
+their output filtered in Emacs Lisp after all. Every path applies the same
+gitignore rules to the same pattern list, so the resulting file set is the same
+- the difference is only where the work happens:
 
 [cols="1,2,2",options="header"]
 |===
@@ -261,11 +276,13 @@ is the same - the difference is only where the work happens:
 Set `projectile-alien-honors-ignores` to nil to get the raw listing back and
 defer entirely to the tool's own ignore rules (`.gitignore` and friends).
 
-NOTE: Dirconfig `+` keep entries and `!` unignore entries, and the
-`projectile-globally-unignored-*` variables, have no equivalent in any of these
-tools and can't be reproduced by filtering a listing that already omits the
-files. They remain `hybrid`/`native` only, and a project that relies on them
-still needs one of those indexing methods.
+NOTE: An exclusion argument can't be taken back, so a project whose dirconfig
+has `!` ensure entries is filtered in Emacs Lisp under `alien` too, rather than
+pushed down - the rules are the same, only the fast path is given up. Dirconfig
+`+` keep entries have no equivalent at all and remain `hybrid`/`native` only.
+Neither can any method add back files the external tool never listed in the
+first place (because `.gitignore` excludes them); only `hybrid` does that, via
+its VCS-aware unignore pass.
 
 NOTE: Ignore matching is case-sensitive under every indexing method. With
 `.elc` in `projectile-globally-ignored-file-suffixes`, a file named `BUILD.ELC`
@@ -273,12 +290,11 @@ is *not* ignored - spell out both cases if you want both. Before Projectile 3.3
 `native` and `hybrid` folded case here (a side effect of the Emacs functions
 they matched with), which `alien` had no way to reproduce in the external tools.
 
-WARNING: A bare entry in `projectile-globally-ignored-directories` matches at
-any depth under `alien`, the same as it does under `native`, whereas `hybrid`
-matches it only at the top level. The `*` prefix (which marks an entry as
-"at any depth" rather than acting as a wildcard) makes no difference under
-`alien`. If you depend on the distinction, `hybrid` is the method that honors
-it.
+NOTE: Since Projectile 3.3 every ignore option speaks gitignore patterns and
+every indexing method matches them the same way, so a bare entry in
+`projectile-globally-ignored-directories` matches at any depth everywhere. It
+used to be top-level-only under `hybrid`, and a `*` prefix was a marker rather
+than a wildcard; both quirks are gone.
 
 TIP: For the details of each ignore mechanism (`.projectile`, the indexing
 tools, and the global ignore/unignore variables), see

--- a/projectile.el
+++ b/projectile.el
@@ -594,8 +594,11 @@ such line, listing the offending entries."
 (defcustom projectile-globally-ignored-files
   (list projectile-tags-file-name projectile-cache-file)
   "A list of files globally ignored by projectile.
-Note that files aren't filtered if `projectile-indexing-method'
-is set to `alien'."
+
+Entries are gitignore patterns: a plain name matches a file with that
+name at any depth, a name containing a slash is anchored at the project
+root, and `*', `**', `?' and `[...]' are the usual wildcards.  See
+`projectile-globally-ignored-directories' for the full pattern language."
   :safe (lambda (x) (not (remq t (mapcar #'stringp x))))
   :group 'projectile
   :type '(repeat string)
@@ -604,8 +607,8 @@ is set to `alien'."
 (defcustom projectile-globally-unignored-files nil
   "A list of files globally unignored by projectile.
 
-Note that files aren't filtered if `projectile-indexing-method'
-is set to `alien'."
+Entries cancel out the matching `projectile-globally-ignored-files'
+entries."
   :group 'projectile
   :type '(repeat string)
   :package-version '(projectile . "0.14.0"))
@@ -613,8 +616,9 @@ is set to `alien'."
 (defcustom projectile-globally-ignored-file-suffixes
   nil
   "A list of file suffixes globally ignored by projectile.
-Note that files aren't filtered if `projectile-indexing-method'
-is set to `alien'."
+Each suffix is matched at the end of a file name at any depth, as if it
+were the gitignore pattern `*SUFFIX' (e.g. \".elc\" ignores every
+`.elc' file in the project)."
   :group 'projectile
   :type '(repeat string)
   :package-version '(projectile . "0.12.0"))
@@ -637,21 +641,23 @@ is set to `alien'."
     ".clangd"
     ".sl"
     ".jj"
-    "*.osc")
+    ".osc")
   "A list of directories globally ignored by projectile.
 
-Strings that don't start with * are only ignored at the top level
-of the project.  Strings that start with * are ignored everywhere
-in the project, as if there was no *.  So note that * when used as
-a prefix is not a wildcard; it is an indicator that the directory
-should be ignored at all levels, not just root.
+Entries are gitignore patterns, matched against paths relative to the
+project root and applied by every indexing method alike:
 
-Examples: \"tmp\" ignores only ./tmp at the top level of the
-project, but not ./src/tmp.  \"*tmp\" will ignore both ./tmp and
-./src/tmp, but not ./not-a-tmp or ./src/not-a-tmp.
+- a pattern without a slash matches a directory with that name at any
+  depth, so \"tmp\" ignores both ./tmp and ./src/tmp
+- a pattern containing a slash is anchored at the project root, so
+  \"/tmp\" and \"doc/frotz\" only match there
+- `*' is a wildcard within a path segment, `**' spans segments, `?'
+  matches a single non-slash character and `[...]'/`[!...]' are
+  character classes
 
-Note that files aren't filtered if `projectile-indexing-method'
-is set to `alien'.
+Matching is case-sensitive.  Note that a leading `*' is a plain
+wildcard - it used to be a marker meaning \"at any depth\", which is
+now the default for every slashless pattern.
 
 See also `projectile-global-ignore-file-patterns'."
   :safe (lambda (x) (not (remq t (mapcar #'stringp x))))
@@ -661,8 +667,9 @@ See also `projectile-global-ignore-file-patterns'."
 
 (defcustom projectile-globally-unignored-directories nil
   "A list of directories globally unignored by projectile.
-Note that files aren't filtered if `projectile-indexing-method'
-is set to `alien'."
+
+Entries cancel out the matching `projectile-globally-ignored-directories'
+entries."
   :group 'projectile
   :type '(repeat string)
   :package-version '(projectile . "0.14.0"))
@@ -671,12 +678,15 @@ is set to `alien'."
   nil
   "A list of file regexp patterns ignored by Projectile.
 
-It complements `projectile-globally-ignored-files' and
-`projectile-globally-ignored-directories'.  See also
-`projectile-ignored-file-p' and `projectile-ignored-directory-p'.
+Unlike `projectile-globally-ignored-files' and
+`projectile-globally-ignored-directories', which speak gitignore
+patterns, the entries here are Emacs regexps, matched against absolute
+file names.  They complement the pattern-based options; because they
+can't be handed to an external tool, nor expressed as globs, they are
+only applied by `native' indexing.
 
-Note that files aren't filtered if `projectile-indexing-method'
-is set to `alien'."
+See also `projectile-ignored-file-p' and
+`projectile-ignored-directory-p'."
   :safe (lambda (x) (not (remq t (mapcar #'stringp x))))
   :group 'projectile
   :type '(repeat string)
@@ -2857,41 +2867,14 @@ Files are returned as relative paths to DIRECTORY."
             (projectile-index-directory directory (projectile-filtering-patterns)
                                         progress-reporter))))
 
-(defun projectile--list->set (list)
-  "Return a hash table whose keys are the elements of LIST.
-Values are all `t'.  Tests with `equal'."
-  (let ((set (make-hash-table :test 'equal :size (max 1 (length list)))))
-    (dolist (elt list set)
-      (puthash elt t set))))
-
-(defun projectile--make-walk-rules (ignored-files ignored-directories globally-ignored-directories)
-  "Build a plist of pre-computed rule sets used by `projectile-index-directory'.
-IGNORED-FILES and IGNORED-DIRECTORIES are the absolute paths to
-ignore; GLOBALLY-IGNORED-DIRECTORIES is the list of directory
-basenames to ignore anywhere in the tree."
-  (list :ignored-files-set (projectile--list->set ignored-files)
-        :ignored-dirs-set (projectile--list->set ignored-directories)
-        :globally-ignored-dir-names-set
-        (projectile--list->set globally-ignored-directories)))
-
-(defun projectile--ignored-file-fast-p (file rules)
-  "Like `projectile-ignored-file-p' but consulting pre-built RULES.
-Used on the hot indexing path to avoid O(N*M) `member' scans."
-  (or (gethash file (plist-get rules :ignored-files-set))
-      (seq-some (lambda (re) (let ((case-fold-search nil))
-                               (string-match-p re file)))
-                projectile-global-ignore-file-patterns)
-      (seq-some (lambda (suf) (string-suffix-p suf file))
-                projectile-globally-ignored-file-suffixes)))
-
-(defun projectile--ignored-directory-fast-p (directory local-name rules)
-  "Like `projectile-ignored-directory-p' but consulting pre-built RULES.
-LOCAL-NAME is the basename of DIRECTORY."
-  (or (gethash directory (plist-get rules :ignored-dirs-set))
-      (seq-some (lambda (re) (let ((case-fold-search nil))
-                               (string-match-p re directory)))
-                projectile-global-ignore-file-patterns)
-      (gethash local-name (plist-get rules :globally-ignored-dir-names-set))))
+(defun projectile--global-ignore-regexp-p (path)
+  "Return non-nil when PATH matches `projectile-global-ignore-file-patterns'.
+PATH is an absolute file name.  Those patterns are Emacs regexps rather
+than globs, which is why they are a separate mechanism from the ignore
+patterns proper; matching is case-sensitive."
+  (seq-some (lambda (re) (let ((case-fold-search nil))
+                           (string-match-p re path)))
+            projectile-global-ignore-file-patterns))
 
 (defun projectile--glob-to-regexp (glob)
   "Translate the dirconfig GLOB into a regexp fragment.
@@ -2922,47 +2905,45 @@ pass through (with `!' translated to `^')."
       (setq i (1+ i)))
     (apply #'concat (nreverse fragments))))
 
-(defun projectile--dirconfig-pattern-to-regexp (pattern)
-  "Translate a dirconfig ignore/ensure PATTERN into a regexp.
-The regexp matches root-relative paths using gitignore-like rules:
-a pattern without a slash matches the file name or any directory
+(defun projectile--ignore-pattern-to-regexp (pattern)
+  "Translate an ignore/ensure PATTERN into a regexp.
+The regexp matches root-relative paths using gitignore rules: a
+pattern without a slash matches the file name or any directory
 segment anywhere in the tree, while a pattern containing a slash is
-anchored at the project root.  A trailing slash restricts the match
-to directories (and thus everything below them).  Directories must
-be matched with a trailing slash appended."
+anchored at the project root (a leading `/' anchors without naming a
+directory of its own).  A trailing slash restricts the match to
+directories (and thus everything below them).  Directories must be
+matched with a trailing slash appended."
   (let* ((dir-only (string-suffix-p "/" pattern))
          (pattern (string-remove-suffix "/" pattern))
          (floating (string-prefix-p "**/" pattern))
          (pattern (if floating (substring pattern 3) pattern))
-         (anchored (string-search "/" pattern)))
+         (rooted (string-prefix-p "/" pattern))
+         (pattern (if rooted (substring pattern 1) pattern))
+         (anchored (or rooted (string-search "/" pattern))))
     (concat (cond (floating "\\`\\(?:.*/\\)?")
                   (anchored "\\`")
                   (t "\\(?:\\`\\|/\\)"))
             (projectile--glob-to-regexp pattern)
             (if dir-only "/" "\\(?:/\\|\\'\\)"))))
 
-(defun projectile--compile-dirconfig-patterns (patterns)
-  "Compile dirconfig PATTERNS into a single regexp.
+(defun projectile--compile-ignore-patterns (patterns)
+  "Compile the gitignore-style PATTERNS into a single regexp.
 Return nil when PATTERNS is empty.  The regexp matches a
 root-relative path when any of PATTERNS does; pass directory paths
 with a trailing slash so directory-only patterns can match them."
   (when patterns
-    (mapconcat #'projectile--dirconfig-pattern-to-regexp patterns "\\|")))
+    (mapconcat #'projectile--ignore-pattern-to-regexp patterns "\\|")))
 
-(defun projectile-index-directory (directory patterns progress-reporter &optional ignored-files ignored-directories globally-ignored-directories)
+(defun projectile-index-directory (directory patterns progress-reporter)
   "Index DIRECTORY taking into account PATTERNS.
 
-The function dispatches to an internal walker that uses pre-built
-hash sets, so the per-file membership checks stay O(1) on large
-projects.  The PROGRESS-REPORTER is updated while the function is
-executing.  Lists of IGNORED-FILES, IGNORED-DIRECTORIES, and
-GLOBALLY-IGNORED-DIRECTORIES may optionally be provided to share
-state across calls."
-  (let* ((ignored-files (or ignored-files (projectile-ignored-files)))
-         (ignored-directories (or ignored-directories (projectile-ignored-directories)))
-         (globally-ignored-directories (or globally-ignored-directories
-                                           (projectile-globally-ignored-directory-names)))
-         ;; Dirconfig patterns match root-relative paths, so when DIRECTORY
+PATTERNS is a cons of the ignore and the ensure patterns, as returned by
+`projectile-filtering-patterns'; both are compiled into a single regexp
+each, so the per-entry check is one regexp match regardless of how many
+rules there are.  The PROGRESS-REPORTER is updated while the function is
+executing."
+  (let* (;; Ignore patterns match root-relative paths, so when DIRECTORY
          ;; is a subdirectory of the project (a dirconfig `+' keep entry)
          ;; the paths matched must stay relative to the project root, not
          ;; to the walked directory.  Fall back to DIRECTORY when it isn't
@@ -2975,13 +2956,9 @@ state across calls."
                                                walk-base))
                          (file-name-as-directory (expand-file-name project-root))
                        walk-base))
-         (rules (append (projectile--make-walk-rules ignored-files ignored-directories
-                                                     globally-ignored-directories)
-                        (list :dirconfig-ignore-re
-                              (projectile--compile-dirconfig-patterns (car patterns))
-                              :dirconfig-ensure-re
-                              (projectile--compile-dirconfig-patterns (cdr patterns))
-                              :match-base-len (length match-base))))
+         (rules (list :ignore-re (projectile--compile-ignore-patterns (car patterns))
+                      :ensure-re (projectile--compile-ignore-patterns (cdr patterns))
+                      :match-base-len (length match-base)))
          ;; A 1-element list whose car is the accumulator.  Using a
          ;; mutable cell lets the recursive walker push results onto a
          ;; single shared list (O(N) total) instead of `apply append'-ing
@@ -2997,7 +2974,7 @@ public entry point.  ACC-CELL is a 1-element list whose car
 accumulates discovered file paths in reverse order.
 
 Ignore matching is case-sensitive, so `case-fold-search' is pinned off
-for the dirconfig regexps matched below."
+for the regexps matched below."
   ;; Use ignore-errors to skip unreadable directories (e.g.
   ;; .Spotlight-V100 on macOS) instead of aborting the entire indexing
   ;; operation.
@@ -3012,8 +2989,8 @@ for the dirconfig regexps matched below."
          (entries (ignore-errors
                     (directory-files-and-attributes
                      directory t directory-files-no-dot-files-regexp nil 'integer)))
-         (ignore-re (plist-get rules :dirconfig-ignore-re))
-         (ensure-re (plist-get rules :dirconfig-ensure-re))
+         (ignore-re (plist-get rules :ignore-re))
+         (ensure-re (plist-get rules :ensure-re))
          (match-base-len (plist-get rules :match-base-len)))
     (dolist (entry entries)
       (let* ((f (car entry))
@@ -3024,27 +3001,22 @@ for the dirconfig regexps matched below."
              ;; follow-symlink behaviour; that extra stat only happens for
              ;; the rare symlink entry, not for every file.
              (type (file-attribute-type (cdr entry)))
-             (local-f (file-name-nondirectory (directory-file-name f)))
              (directory-p (if (stringp type) (file-directory-p f) (eq type t)))
-             ;; Dirconfig patterns match against the root-relative path,
-             ;; with a trailing slash appended for directories so that
+             ;; Ignore patterns match against the root-relative path, with
+             ;; a trailing slash appended for directories so that
              ;; directory-only patterns (trailing `/') can match.
              (match-name (and ignore-re
                               (concat (substring f match-base-len)
                                       (and directory-p "/")))))
-        (unless (and match-name
-                     (string-match-p ignore-re match-name)
-                     (not (and ensure-re (string-match-p ensure-re match-name))))
+        (unless (or (and match-name
+                         (string-match-p ignore-re match-name)
+                         (not (and ensure-re (string-match-p ensure-re match-name))))
+                    (projectile--global-ignore-regexp-p f))
           (progress-reporter-update progress-reporter)
-          (cond
-           (directory-p
-            (unless (projectile--ignored-directory-fast-p
-                     (file-name-as-directory f) local-f rules)
+          (if directory-p
               (projectile--index-directory-walk f progress-reporter
-                                                rules acc-cell)))
-           (t
-            (unless (projectile--ignored-file-fast-p f rules)
-              (setcar acc-cell (cons f (car acc-cell)))))))))))
+                                                rules acc-cell)
+            (setcar acc-cell (cons f (car acc-cell)))))))))
 
 ;;; Alien Project Indexing
 ;;
@@ -3068,22 +3040,25 @@ is how Projectile spells \"external-command indexing is disabled\"."
 (defun projectile--alien-exclude-glob (glob style)
   "Translate GLOB into an exclusion pattern of the given STYLE.
 
-GLOB is an entry as produced by `projectile--project-ignore-globs': a
-leading `./' means the entry is anchored at the project root, a trailing
-`/' means it names a directory (so its whole subtree is excluded), and
-anything else matches at any depth.
+GLOB is an entry as produced by `projectile--project-ignore-globs', i.e.
+a gitignore pattern: any slash other than a trailing one anchors it at
+the project root, a trailing `/' means it names a directory (so its
+whole subtree is excluded), and a pattern without a slash matches at any
+depth.
 
 STYLE is `git' for a `git ls-files' pathspec body (wildmatch semantics,
 where `**' crosses directory separators) or `fd' for an `fd --exclude'
 pattern (gitignore semantics, where a leading `/' anchors to the search
 root)."
-  (let* ((rooted (string-prefix-p "./" glob))
-         (body (if rooted (substring glob 2) glob))
-         (dirp (string-suffix-p "/" body))
-         (body (if dirp (substring body 0 -1) body)))
+  (let* ((dirp (string-suffix-p "/" glob))
+         (body (if dirp (substring glob 0 -1) glob))
+         (rooted (string-search "/" body))
+         (body (string-remove-prefix "/" body)))
     (pcase style
+      ;; A pathspec is anchored at the pathspec root already, so an
+      ;; any-depth pattern is the one that needs the `**/' prefix.
       ('git (concat (unless rooted "**/") body (when dirp "/**")))
-      ('fd (concat (when rooted "/") body))
+      ('fd (concat (when rooted "/") body (when dirp "/")))
       (_ (error "Unknown exclusion style `%S'" style)))))
 
 (defun projectile--alien-exclude-args (vcs command globs)
@@ -3124,22 +3099,31 @@ folded in as exclusion arguments when the tool understands them and
   (let ((command (projectile-get-ext-command vcs directory)))
     (if-let* ((command)
               (projectile-alien-honors-ignores)
-              ;; Only alien pushes the rules down.  Hybrid applies them to
-              ;; the output itself, and doing both would silently give it
-              ;; alien's semantics for the rules where the two differ (a
-              ;; bare `projectile-globally-ignored-directories' entry is
-              ;; top-level-only under hybrid, any-depth under alien).
+              ;; Only alien pushes the rules down; hybrid applies them to
+              ;; the output itself.  Both speak the same rules now, so
+              ;; doing both would just be wasted work.
               ((eq projectile-indexing-method 'alien))
+              ((projectile--alien-command-excludes-p vcs command directory))
               (globs (projectile--project-ignore-globs directory))
               (args (projectile--alien-exclude-args vcs command globs)))
         (concat command " " args)
       command)))
 
-(defun projectile--alien-command-excludes-p (vcs command)
-  "Return non-nil when COMMAND for VCS carries the ignore rules itself.
-When it doesn't, the ignore rules have to be applied to the command's
-output instead."
-  (or (projectile--fd-command-p command) (eq vcs 'git)))
+(defun projectile--alien-command-excludes-p (vcs command &optional directory)
+  "Return non-nil when COMMAND for VCS can carry the ignore rules itself.
+When it can't, the ignore rules have to be applied to the command's
+output instead.
+
+Besides the tools that have no way to express exclusions at all, that's
+also the case for a project whose dirconfig has `!' ensure entries: an
+exclusion argument can't be taken back (neither a git exclude pathspec
+nor `fd --exclude' has a way to un-exclude a path), so such a project is
+filtered in Lisp, where the ensure patterns can rescue the files the
+ignore patterns matched.  DIRECTORY is the project root the ensure
+entries are read from; it defaults to `default-directory'."
+  (and (or (projectile--fd-command-p command) (eq vcs 'git))
+       (null (projectile--ensure-patterns directory))
+       t))
 
 (defun projectile--maybe-remove-ignored (project-root files)
   "Remove PROJECT-ROOT's ignored entries from FILES, honoring the option.
@@ -3156,7 +3140,7 @@ ignore configuration is read for the right project."
 Does nothing when the external command for VCS already excluded them
 itself, which is the fast path (see `projectile--alien-exclude-args')."
   (if (projectile--alien-command-excludes-p
-       vcs (projectile-get-ext-command vcs project-root))
+       vcs (projectile-get-ext-command vcs project-root) project-root)
       files
     (projectile--maybe-remove-ignored project-root files)))
 
@@ -3841,56 +3825,24 @@ PROJECT-ROOT defaults to the current project."
 (defun projectile-remove-ignored (files)
   "Remove ignored files and folders from FILES.
 
-If ignored directory prefixed with `*', then ignore all
-directories/subdirectories with matching filename,
-otherwise operates relative to project root.
-
-Dirconfig ignore patterns (the non-slash-prefixed `-' entries of the
-`.projectile' file) are also applied, compiled via
-`projectile--compile-dirconfig-patterns'; `!' ensure patterns rescue
-files from them."
+FILES are paths relative to the project root.  They are matched against
+the project's ignore patterns (see `projectile--ignore-patterns'), the
+same gitignore-style rules the native indexer and the alien push-down
+apply; `!' ensure patterns rescue files from them."
   (let* (;; Ignore matching is case-sensitive; `string-match-p' would
          ;; otherwise fold case, since `case-fold-search' defaults to t.
          (case-fold-search nil)
          (filtering-patterns (projectile-filtering-patterns))
-         (dirconfig-ignore-re (projectile--compile-dirconfig-patterns
-                               (car filtering-patterns)))
-         (dirconfig-ensure-re (projectile--compile-dirconfig-patterns
-                               (cdr filtering-patterns)))
-         (ignored-files (projectile-ignored-files-rel))
-         (ignored-dirs (projectile-ignored-directories-rel))
-         ;; Hash basenames of ignored files for O(1) lookup per project
-         ;; file (the original `seq-some'/`string=' over the list was
-         ;; O(M) per file).
-         (ignored-files-set (projectile--list->set ignored-files))
-         ;; Split ignored dirs into the two matching modes used below:
-         ;; entries prefixed with `*' are matched as a path *segment*
-         ;; (basename anywhere in the file's directory chain), the rest
-         ;; are matched as a literal path *prefix*.  Hash the segment
-         ;; entries so the per-file segment loop becomes O(segments).
-         (any-segment-dir-names nil)
-         (prefix-dirs nil))
-    (dolist (dir ignored-dirs)
-      (if (string-prefix-p "*" dir)
-          (push (string-remove-suffix "/" (substring dir 1))
-                any-segment-dir-names)
-        (push dir prefix-dirs)))
-    (let ((any-segment-dir-set (projectile--list->set any-segment-dir-names))
-          (suffixes projectile-globally-ignored-file-suffixes))
+         (ignore-re (projectile--compile-ignore-patterns
+                     (car filtering-patterns)))
+         (ensure-re (projectile--compile-ignore-patterns
+                     (cdr filtering-patterns))))
+    (if (null ignore-re)
+        files
       (seq-remove
        (lambda (file)
-         (or (gethash (file-name-nondirectory file) ignored-files-set)
-             (and any-segment-dir-names
-                  (seq-some
-                   (lambda (segment) (gethash segment any-segment-dir-set))
-                   (delete "" (split-string
-                               (or (file-name-directory file) "") "/"))))
-             (seq-some (lambda (dir) (string-prefix-p dir file)) prefix-dirs)
-             (seq-some (lambda (suf) (string-suffix-p suf file)) suffixes)
-             (and dirconfig-ignore-re
-                  (string-match-p dirconfig-ignore-re file)
-                  (not (and dirconfig-ensure-re
-                            (string-match-p dirconfig-ensure-re file))))))
+         (and (string-match-p ignore-re file)
+              (not (and ensure-re (string-match-p ensure-re file)))))
        files))))
 
 (defun projectile-keep-ignored-files (project vcs files)
@@ -4344,9 +4296,49 @@ Unignored files/directories are not included."
   "Return a list of relative file patterns."
   (projectile-normalise-patterns (projectile--dirconfig-ensure)))
 
-(defun projectile-filtering-patterns ()
-  (cons (projectile-patterns-to-ignore)
-        (projectile-patterns-to-ensure)))
+(defun projectile--ignore-patterns (&optional root)
+  "Return ROOT's ignore rules as a list of gitignore-style patterns.
+
+This is Projectile's single source of ignore patterns: every indexing
+method and every external tool Projectile drives is configured from this
+list, so they all apply the same rules the same way.  It merges
+
+- `projectile-globally-ignored-directories', as directory-only patterns
+  \(a trailing `/' is appended)
+- `projectile-globally-ignored-files', as-is
+- `projectile-globally-ignored-file-suffixes', as `*SUFFIX' globs
+- the `-' (ignore) entries of the project's dirconfig, which are already
+  written in this language
+
+The `projectile-globally-unignored-*' options cancel out the matching
+entries.  `projectile-global-ignore-file-patterns' is deliberately not
+part of this: those are Emacs regexps, not patterns, and can't be handed
+to an external tool.
+
+ROOT defaults to the current project's root and only matters for the
+dirconfig entries; outside a project the global patterns are returned on
+their own.  See `projectile--ignore-pattern-to-regexp' for the matching
+rules."
+  (let ((default-directory (or root default-directory)))
+    (append
+     (mapcar (lambda (name) (concat (directory-file-name name) "/"))
+             (projectile-globally-ignored-directory-names))
+     (seq-difference projectile-globally-ignored-files
+                     projectile-globally-unignored-files)
+     (projectile--globally-ignored-file-suffixes-glob)
+     (projectile--dirconfig-ignore))))
+
+(defun projectile--ensure-patterns (&optional root)
+  "Return ROOT's ensure rules as a list of gitignore-style patterns.
+These are the `!' entries of the project's dirconfig; a path they match
+is kept even when `projectile--ignore-patterns' also matches it."
+  (let ((default-directory (or root default-directory)))
+    (projectile--dirconfig-ensure)))
+
+(defun projectile-filtering-patterns (&optional root)
+  "Return ROOT's ignore and ensure patterns as a cons cell."
+  (cons (projectile--ignore-patterns root)
+        (projectile--ensure-patterns root)))
 
 (defun projectile-project-unignored ()
   "Return list of project ignored files/directories."
@@ -7425,15 +7417,17 @@ Requires the `ag' Emacs package."
     (funcall ag-command search-term (projectile-acquire-root))))
 
 (defun projectile--ripgrep-ignore-globs ()
-  "Return ripgrep `--glob' exclusions for the globally ignored files and dirs.
+  "Return ripgrep `--glob' exclusions for the project's ignore patterns.
+
+The patterns come from `projectile--ignore-patterns' and are passed to
+ripgrep as they are - ripgrep's globs follow gitignore rules too.
 
 Uses the `--glob=!PATTERN' form rather than `--glob \\='!PATTERN\\='', whose
 surrounding single quotes are only stripped by POSIX shells - on Windows
 `cmd' they become part of the pattern and the exclusion silently fails
 \(see #1946)."
   (mapcar (lambda (val) (concat "--glob=!" val))
-          (append projectile-globally-ignored-files
-                  projectile-globally-ignored-directories)))
+          (projectile--ignore-patterns)))
 
 (defun projectile--ripgrep (search-term &optional regexp)
   "Run a ripgrep (rg) search for SEARCH-TERM in the project.
@@ -7575,37 +7569,21 @@ installed to work."
     (projectile-search search-term arg)))
 
 (defun projectile--project-ignore-globs (root)
-  "Return ROOT's ignore patterns as globs in `project-ignores' format.
-Derived from Projectile's ignore configuration: globally ignored
-directory names and file suffixes match at any depth, while the
-files and directories ignored via the project's dirconfig
-\(`.projectile') are rooted at ROOT with a leading `./'."
-  (let ((default-directory root))
-    (append
-     ;; Globally ignored directory names, matched at any depth.  A leading
-     ;; `*' in `projectile-globally-ignored-directories' is a marker meaning
-     ;; "at any depth", not a wildcard, so it has to be stripped rather than
-     ;; passed on to a glob matcher that would read it as one (`*.osc' names
-     ;; the directory `.osc', it doesn't match `foo.osc').
-     (mapcar (lambda (name)
-               (concat (directory-file-name
-                        (string-remove-prefix "*" name))
-                       "/"))
-             (projectile-globally-ignored-directory-names))
-     ;; globally ignored files, matched at any depth
-     (copy-sequence projectile-globally-ignored-files)
-     ;; globally ignored file suffixes as globs, e.g. "*.elc"
-     (projectile--globally-ignored-file-suffixes-glob)
-     ;; dirconfig patterns, matched by base name at any depth
-     (projectile-patterns-to-ignore)
-     ;; dirconfig ignored directories, rooted at the project root
-     (mapcar (lambda (dir)
-               (concat "./" (file-relative-name (directory-file-name dir)) "/"))
-             (projectile-project-ignored-directories))
-     ;; dirconfig ignored files, rooted at the project root
-     (mapcar (lambda (file)
-               (concat "./" (file-relative-name file)))
-             (projectile-project-ignored-files)))))
+  "Return ROOT's ignore patterns as gitignore globs.
+That's `projectile--ignore-patterns' verbatim: gitignore syntax is
+exactly what the tools Projectile hands these to speak (`fd --exclude',
+`git ls-files' exclude pathspecs, `rg --glob')."
+  (projectile--ignore-patterns root))
+
+(defun projectile--project-el-ignore-glob (glob)
+  "Translate the gitignore GLOB into project.el's `project-ignores' format.
+There a root-anchored pattern is spelled with a leading `./' instead of
+gitignore's leading `/' (or an interior slash), and everything else
+matches at any depth."
+  (let ((body (string-remove-suffix "/" glob)))
+    (if (string-search "/" body)
+        (concat "./" (string-remove-prefix "/" glob))
+      glob)))
 
 (defun projectile-find-references (&optional symbol)
   "Find textual references to SYMBOL across the current project.
@@ -7626,7 +7604,10 @@ Projectile project too when `projectile-mode' is enabled."
                      (read-string
                       (projectile-prepend-project-name "Find references to: ")
                       (projectile-symbol-or-selection-at-point))))
-         (ignores (projectile--project-ignore-globs project-root))
+         ;; `xref-matches-in-directory' reads its IGNORES in project.el's
+         ;; format, not gitignore's.
+         (ignores (mapcar #'projectile--project-el-ignore-glob
+                          (projectile--project-ignore-globs project-root)))
          ;; `xref-matches-in-directory' greps for the pattern (honouring
          ;; IGNORES) and re-matches it in-buffer to pin down columns, so a
          ;; plain quoted symbol is the portable choice: symbol/word-boundary
@@ -9296,8 +9277,11 @@ the deterministic elisp scan."
 CASE-FOLD selects case-insensitive matching; WORD restricts matches to
 whole words (`--word-regexp'); GLOBS is a list of ignore patterns (from
 `projectile--project-ignore-globs') passed as `--glob' exclusions so
-Projectile's ignores narrow ripgrep's own ignore rules.  The search path
-is the relative `./', so the caller must run the process with
+Projectile's ignores narrow ripgrep's own ignore rules.  They are
+gitignore patterns, which is what ripgrep's globs are, so they need no
+translation - but a root-anchored one only resolves against the project
+root when the searched path is relative, which is why the search path
+below is `./' and the caller must run the process with
 `default-directory' bound to the project root."
   (append
    (list (projectile-search--rg-executable)
@@ -9305,17 +9289,7 @@ is the relative `./', so the caller must run the process with
          "--color" "never"
          (if case-fold "--ignore-case" "--case-sensitive"))
    (when word (list "--word-regexp"))
-   ;; Projectile's `project-ignores' globs mark a root-anchored pattern with a
-   ;; leading `./' (e.g. a `.projectile' `-/vendor' line); ripgrep spells a
-   ;; root-anchored glob with a leading `/', so translate `./PAT' to `/PAT'.
-   ;; rg honors that only when searching a path relative to the root, which is
-   ;; why the search path below is `./' and the caller binds default-directory.
-   (mapcan (lambda (g)
-             (list "--glob"
-                   (concat "!" (if (string-prefix-p "./" g)
-                                   (substring g 1)
-                                 g))))
-           globs)
+   (mapcan (lambda (g) (list "--glob" (concat "!" g))) globs)
    ;; `--' terminates options so a TERM starting with `-' is not misread.
    (list "--" term "./")))
 
@@ -12322,15 +12296,14 @@ when opening new files.  PROJECT-ROOT defaults to the current project."
 (cl-defmethod project-ignores ((project (head projectile)) _dir)
   "Return a list of glob patterns to ignore in PROJECT.
 
-The patterns are derived from Projectile's ignore configuration and
-returned in the format expected by project.el (see `project-ignores'):
-globally ignored directory names and file suffixes are matched at any
-depth, while the files and directories ignored via the project's
-dirconfig (`.projectile') are rooted at the project root with a
-leading `./'."
+The patterns are Projectile's own ignore patterns (see
+`projectile--ignore-patterns'), converted to the format project.el
+expects (see `project-ignores'): a pattern anchored at the project root
+is spelled with a leading `./' there, the rest match at any depth."
   ;; PROJECT is Projectile's own `(projectile . root)' representation, so read
   ;; the root straight from the cdr rather than going through `project-root'.
-  (projectile--project-ignore-globs (cdr project)))
+  (mapcar #'projectile--project-el-ignore-glob
+          (projectile--project-ignore-globs (cdr project))))
 
 ;;;###autoload
 (defun project-projectile (dir)

--- a/test/projectile-grep-test.el
+++ b/test/projectile-grep-test.el
@@ -31,21 +31,28 @@
   (it "greps the project for the (regexp-quoted) symbol, scoped and honouring ignores"
     (spy-on 'projectile-acquire-root :and-return-value "/my/root/")
     (spy-on 'projectile--project-ignore-globs
-            :and-return-value '("*.elc" "./build/"))
+            :and-return-value '("*.elc" "/build/"))
     (spy-on 'xref-matches-in-directory :and-return-value nil)
     ;; `xref-show-xrefs' would try to display; run the fetcher and stop.
     (spy-on 'xref-show-xrefs :and-call-fake
             (lambda (fetcher &rest _) (funcall fetcher)))
     (projectile-find-references "foo.bar")
     (expect 'xref-matches-in-directory :to-have-been-called-with
+            ;; the gitignore patterns are respelled in project.el's format
             "foo\\.bar" "*" "/my/root/" '("*.elc" "./build/"))))
 
 (describe "projectile--ripgrep-ignore-globs"
   (it "builds unquoted --glob=! exclusions that also work on Windows (#1946)"
+    (spy-on 'projectile--dirconfig-ignore :and-return-value '("*.log"))
     (let ((projectile-globally-ignored-files '("TAGS" "GTAGS"))
+          (projectile-globally-unignored-files nil)
+          (projectile-globally-ignored-file-suffixes nil)
+          (projectile-globally-unignored-directories nil)
           (projectile-globally-ignored-directories '(".git" ".svn")))
       (expect (projectile--ripgrep-ignore-globs)
-              :to-equal '("--glob=!TAGS" "--glob=!GTAGS" "--glob=!.git" "--glob=!.svn")))))
+              :to-equal '("--glob=!.git/" "--glob=!.svn/"
+                          "--glob=!TAGS" "--glob=!GTAGS"
+                          "--glob=!*.log")))))
 
 (describe "projectile-grep"
   (describe "multi-root grep"

--- a/test/projectile-ignore-test.el
+++ b/test/projectile-ignore-test.el
@@ -471,96 +471,90 @@
           (projectile-parse-dirconfig-file))
         (expect 'display-warning :not :to-have-been-called))))))
 
-(describe "projectile--ignored-file-fast-p"
-  (it "matches global ignore patterns and suffixes case-sensitively"
-    ;; `string-match-p' and `string-suffix-p' both fold case by default
-    (let ((rules (projectile--make-walk-rules nil nil nil))
-          (projectile-global-ignore-file-patterns '("build"))
-          (projectile-globally-ignored-file-suffixes '(".elc")))
-      (expect (projectile--ignored-file-fast-p "/r/build/a.o" rules) :to-be-truthy)
-      (expect (projectile--ignored-file-fast-p "/r/BUILD/a.o" rules) :not :to-be-truthy)
-      (expect (projectile--ignored-file-fast-p "/r/a.elc" rules) :to-be-truthy)
-      (expect (projectile--ignored-file-fast-p "/r/a.ELC" rules) :not :to-be-truthy)))
+(describe "projectile--global-ignore-regexp-p"
+  (it "matches the regexps case-sensitively"
+    ;; `string-match-p' folds case by default
+    (let ((projectile-global-ignore-file-patterns '("build")))
+      (expect (projectile--global-ignore-regexp-p "/r/build/a.o") :to-be-truthy)
+      (expect (projectile--global-ignore-regexp-p "/r/BUILD/a.o") :not :to-be-truthy)))
+  (it "matches against the absolute file name"
+    (let ((projectile-global-ignore-file-patterns '("\\.min\\.js\\'")))
+      (expect (projectile--global-ignore-regexp-p "/r/foo.min.js") :to-be-truthy)
+      (expect (projectile--global-ignore-regexp-p "/r/foo.js") :not :to-be-truthy)))
+  (it "returns nil when there are no patterns"
+    (let ((projectile-global-ignore-file-patterns nil))
+      (expect (projectile--global-ignore-regexp-p "/r/foo.js") :not :to-be-truthy))))
 
-  (it "returns t for files in the pre-computed ignored-files-set"
-    (let ((rules (projectile--make-walk-rules
-                  '("/r/TAGS") nil nil)))
-      (expect (projectile--ignored-file-fast-p "/r/TAGS" rules) :to-be-truthy)
-      (expect (projectile--ignored-file-fast-p "/r/keep.el" rules)
-              :not :to-be-truthy)))
-  (it "honors projectile-globally-ignored-file-suffixes"
-    (let ((rules (projectile--make-walk-rules nil nil nil))
+(describe "projectile--ignore-patterns"
+  (before-each
+    (spy-on 'projectile--dirconfig-ignore :and-return-value '("-only-me" "/rooted")))
+  (it "merges the global ignore options into one gitignore pattern list"
+    (let ((projectile-globally-ignored-directories '("node_modules" ".git"))
+          (projectile-globally-unignored-directories nil)
+          (projectile-globally-ignored-files '("TAGS"))
+          (projectile-globally-unignored-files nil)
           (projectile-globally-ignored-file-suffixes '(".elc")))
-      (expect (projectile--ignored-file-fast-p "/r/foo.elc" rules) :to-be-truthy)
-      (expect (projectile--ignored-file-fast-p "/r/foo.el" rules)
-              :not :to-be-truthy)))
-  (it "honors projectile-global-ignore-file-patterns"
-    (let ((rules (projectile--make-walk-rules nil nil nil))
-          (projectile-global-ignore-file-patterns '("\\.min\\.js\\'")))
-      (expect (projectile--ignored-file-fast-p "/r/foo.min.js" rules) :to-be-truthy)
-      (expect (projectile--ignored-file-fast-p "/r/foo.js" rules)
-              :not :to-be-truthy))))
-
-(describe "projectile--ignored-directory-fast-p"
-  (it "matches absolute ignored-dirs entries"
-    (let ((rules (projectile--make-walk-rules
-                  nil '("/r/build/") nil)))
-      (expect (projectile--ignored-directory-fast-p "/r/build/" "build" rules)
-              :to-be-truthy)))
-  (it "matches globally ignored directory basenames"
-    (let ((rules (projectile--make-walk-rules nil nil '(".git"))))
-      (expect (projectile--ignored-directory-fast-p "/r/.git/" ".git" rules)
-              :to-be-truthy)
-      (expect (projectile--ignored-directory-fast-p "/r/src/" "src" rules)
-              :not :to-be-truthy))))
+      (expect (projectile--ignore-patterns "/r/")
+              :to-equal '("node_modules/" ".git/" "TAGS" "*.elc"
+                          "-only-me" "/rooted"))))
+  (it "honors the globally unignored options"
+    (let ((projectile-globally-ignored-directories '("node_modules" ".git"))
+          (projectile-globally-unignored-directories '(".git"))
+          (projectile-globally-ignored-files '("TAGS" "GTAGS"))
+          (projectile-globally-unignored-files '("GTAGS"))
+          (projectile-globally-ignored-file-suffixes nil))
+      (expect (projectile--ignore-patterns "/r/")
+              :to-equal '("node_modules/" "TAGS" "-only-me" "/rooted")))))
 
 (describe "projectile-remove-ignored"
   (it "removes files whose suffix matches projectile-globally-ignored-file-suffixes"
     (spy-on 'projectile-project-root :and-return-value "/path/to/project")
     (spy-on 'projectile-project-name :and-return-value "project")
-    (spy-on 'projectile-ignored-files-rel)
-    (spy-on 'projectile-ignored-directories-rel)
-    (let* ((file-names '("foo.c" "foo.o" "foo.so" "foo.o.gz" "foo.tar.gz" "foo.tar.GZ"))
-           (files (mapcar 'projectile-expand-root file-names)))
-      (let ((projectile-globally-ignored-file-suffixes '(".o" ".so" ".tar.gz")))
-        ;; matching is case-sensitive, so `foo.tar.GZ' survives `.tar.gz'
-        (expect (projectile-remove-ignored files)
-                :to-equal (mapcar 'projectile-expand-root
-                                  '("foo.c" "foo.o.gz" "foo.tar.GZ"))))))
+    (spy-on 'projectile--dirconfig-ignore)
+    (let ((file-names '("foo.c" "foo.o" "foo.so" "foo.o.gz" "foo.tar.gz" "foo.tar.GZ"))
+          (projectile-globally-ignored-directories nil)
+          (projectile-globally-ignored-files nil)
+          (projectile-globally-ignored-file-suffixes '(".o" ".so" ".tar.gz")))
+      ;; matching is case-sensitive, so `foo.tar.GZ' survives `.tar.gz'
+      (expect (projectile-remove-ignored file-names)
+              :to-equal '("foo.c" "foo.o.gz" "foo.tar.GZ"))))
 
   (it "matches ignored suffixes case-sensitively"
     (spy-on 'projectile-project-root :and-return-value "/path/to/project")
-    (spy-on 'projectile-ignored-files-rel)
-    (spy-on 'projectile-ignored-directories-rel)
-    (let ((projectile-globally-ignored-file-suffixes '(".elc")))
+    (spy-on 'projectile--dirconfig-ignore)
+    (let ((projectile-globally-ignored-directories nil)
+          (projectile-globally-ignored-files nil)
+          (projectile-globally-ignored-file-suffixes '(".elc")))
       (expect (projectile-remove-ignored '("a.elc" "B.ELC" "c.Elc"))
               :to-equal '("B.ELC" "c.Elc"))))
 
   (it "matches dirconfig ignore patterns case-sensitively"
     (spy-on 'projectile-project-root :and-return-value "/path/to/project")
-    (spy-on 'projectile-ignored-files-rel)
-    (spy-on 'projectile-ignored-directories-rel)
     (spy-on 'projectile-filtering-patterns :and-return-value '(("*.log") . nil))
     (expect (projectile-remove-ignored '("a.log" "B.LOG"))
             :to-equal '("B.LOG")))
-  (it "drops files whose basename matches an ignored entry"
-    (spy-on 'projectile-ignored-files-rel :and-return-value '("TAGS"))
-    (spy-on 'projectile-ignored-directories-rel :and-return-value nil)
+  (it "drops an ignored file name at any depth"
+    (spy-on 'projectile-filtering-patterns :and-return-value '(("TAGS") . nil))
     (expect (projectile-remove-ignored '("a/TAGS" "src/foo.el" "TAGS"))
             :to-equal '("src/foo.el")))
-  (it "treats `*'-prefixed entries as any-segment matches"
-    (spy-on 'projectile-ignored-files-rel :and-return-value nil)
-    (spy-on 'projectile-ignored-directories-rel :and-return-value '("*node_modules/"))
+  (it "matches a slashless directory pattern at any depth"
+    (spy-on 'projectile-filtering-patterns
+            :and-return-value '(("node_modules/") . nil))
     (expect (projectile-remove-ignored
              '("src/foo.js"
                "node_modules/lib/index.js"
                "vendor/node_modules/lib/index.js"))
             :to-equal '("src/foo.js")))
-  (it "treats plain entries as path-prefix matches"
-    (spy-on 'projectile-ignored-files-rel :and-return-value nil)
-    (spy-on 'projectile-ignored-directories-rel :and-return-value '("build/"))
-    (expect (projectile-remove-ignored '("build/foo.o" "src/foo.c" "buildbot/x"))
-            :to-equal '("src/foo.c" "buildbot/x"))))
+  (it "anchors a rooted pattern at the project root"
+    (spy-on 'projectile-filtering-patterns :and-return-value '(("/build/") . nil))
+    (expect (projectile-remove-ignored
+             '("build/foo.o" "src/foo.c" "buildbot/x" "src/build/gen.o"))
+            :to-equal '("src/foo.c" "buildbot/x" "src/build/gen.o")))
+  (it "rescues ensure-pattern matches from an ignore pattern"
+    (spy-on 'projectile-filtering-patterns
+            :and-return-value '(("*.elc") . ("keep.elc")))
+    (expect (projectile-remove-ignored '("a.elc" "sub/keep.elc"))
+            :to-equal '("sub/keep.elc"))))
 
 (describe "projectile-ignored-project-p"
   (it "matches abbreviated paths against truename-resolved ignored list"
@@ -616,15 +610,12 @@
   (it "returns ignore globs in the format expected by project.el"
     (let ((root (file-truename (expand-file-name "/my/root/")))
           (projectile-globally-ignored-files '("TAGS" ".#foo"))
+          (projectile-globally-unignored-files nil)
           (projectile-globally-ignored-file-suffixes '(".elc" ".o")))
       (spy-on 'projectile-globally-ignored-directory-names
               :and-return-value '(".git" ".svn/"))
-      (spy-on 'projectile-patterns-to-ignore :and-return-value '("*.log"))
-      (spy-on 'projectile-project-ignored-directories
-              :and-return-value (list (concat root "build/")
-                                      (concat root "dist/")))
-      (spy-on 'projectile-project-ignored-files
-              :and-return-value (list (concat root "TODO")))
+      (spy-on 'projectile--dirconfig-ignore
+              :and-return-value '("*.log" "/build/" "/TODO" "src/gen"))
       (let ((ignores (project-ignores (cons 'projectile root) root)))
         ;; globally ignored directory names match at any depth
         (expect (member ".git/" ignores) :to-be-truthy)
@@ -633,13 +624,22 @@
         (expect (member "TAGS" ignores) :to-be-truthy)
         ;; suffixes become globs
         (expect (member "*.elc" ignores) :to-be-truthy)
-        ;; dirconfig patterns are passed through
+        ;; slashless dirconfig patterns are passed through
         (expect (member "*.log" ignores) :to-be-truthy)
-        ;; dirconfig ignored directories are rooted and end with a slash
+        ;; anchored patterns are spelled with a leading `./' there
         (expect (member "./build/" ignores) :to-be-truthy)
-        (expect (member "./dist/" ignores) :to-be-truthy)
-        ;; dirconfig ignored files are rooted
-        (expect (member "./TODO" ignores) :to-be-truthy)))))
+        (expect (member "./TODO" ignores) :to-be-truthy)
+        (expect (member "./src/gen" ignores) :to-be-truthy)))))
+
+(describe "projectile--project-el-ignore-glob"
+  (it "leaves any-depth patterns alone"
+    (expect (projectile--project-el-ignore-glob "TAGS") :to-equal "TAGS")
+    (expect (projectile--project-el-ignore-glob "*.elc") :to-equal "*.elc")
+    (expect (projectile--project-el-ignore-glob ".git/") :to-equal ".git/"))
+  (it "respells anchored patterns with a leading ./"
+    (expect (projectile--project-el-ignore-glob "/build/") :to-equal "./build/")
+    (expect (projectile--project-el-ignore-glob "/TODO") :to-equal "./TODO")
+    (expect (projectile--project-el-ignore-glob "src/gen") :to-equal "./src/gen")))
 
 (describe "projectile-normalise-patterns"
   (it "drops absolute (path) patterns and keeps relative globs"
@@ -648,9 +648,9 @@
   (it "returns an empty list when every pattern is a path"
     (expect (projectile-normalise-patterns '("/a" "/b")) :to-equal nil)))
 
-(describe "projectile--dirconfig-pattern-to-regexp"
+(describe "projectile--ignore-pattern-to-regexp"
   (cl-flet ((matches (pattern path)
-              (string-match-p (projectile--compile-dirconfig-patterns
+              (string-match-p (projectile--compile-ignore-patterns
                                (list pattern))
                               path)))
     (it "matches a slashless glob against the file name anywhere"
@@ -697,11 +697,11 @@
       (expect (matches "a+b.c" "a+b.c") :to-be-truthy)
       (expect (matches "a+b.c" "aab.c") :not :to-be-truthy))))
 
-(describe "projectile--compile-dirconfig-patterns"
+(describe "projectile--compile-ignore-patterns"
   (it "returns nil for no patterns"
-    (expect (projectile--compile-dirconfig-patterns nil) :to-be nil))
+    (expect (projectile--compile-ignore-patterns nil) :to-be nil))
   (it "matches when any of several patterns matches"
-    (let ((re (projectile--compile-dirconfig-patterns '("*.o" "vendor/"))))
+    (let ((re (projectile--compile-ignore-patterns '("*.o" "vendor/"))))
       (expect (string-match-p re "x/y.o") :to-be-truthy)
       (expect (string-match-p re "vendor/z.js") :to-be-truthy)
       (expect (string-match-p re "src/main.c") :not :to-be-truthy))))

--- a/test/projectile-indexing-test.el
+++ b/test/projectile-indexing-test.el
@@ -367,16 +367,6 @@
             (expect (cl-some (lambda (f) (string-match-p "/alias\\.el\\'" f)) files)
                     :to-be-truthy))))))))
 
-(describe "projectile--list->set"
-  (it "puts all elements as keys with value t and tests with equal"
-    (let ((set (projectile--list->set '("a" "b/" "c"))))
-      (expect (gethash "a" set) :to-be t)
-      (expect (gethash "b/" set) :to-be t)
-      (expect (gethash "missing" set) :to-be nil)))
-  (it "handles the empty list without error"
-    (let ((set (projectile--list->set nil)))
-      (expect (hash-table-count set) :to-equal 0))))
-
 (describe "projectile-get-sub-projects-command"
   (it "gets sub projects command for git"
     (expect (string-prefix-p "git" (projectile-get-sub-projects-command 'git)) :to-be-truthy))
@@ -908,15 +898,15 @@
        "projectA/src/html/index.html"
        "projectA/.projectile")
 
-      ;; verify that indexing only invokes these funcs once during recursion
-      (spy-on 'projectile-ignored-files :and-call-through)
-      (spy-on 'projectile-ignored-directories :and-call-through)
-      (spy-on 'projectile-globally-ignored-directory-names :and-call-through)
+      ;; the ignore rules are computed and compiled once per indexing run,
+      ;; not once per visited directory
+      (spy-on 'projectile--ignore-patterns :and-call-through)
+      (spy-on 'projectile--compile-ignore-patterns :and-call-through)
 
       (projectile-dir-files-native "projectA/")
-      (expect 'projectile-ignored-files :to-have-been-called-times 1)
-      (expect 'projectile-globally-ignored-directory-names :to-have-been-called-times 1)
-      (expect 'projectile-ignored-directories :to-have-been-called-times 1))))
+      (expect 'projectile--ignore-patterns :to-have-been-called-times 1)
+      ;; once for the ignore patterns, once for the ensure ones
+      (expect 'projectile--compile-ignore-patterns :to-have-been-called-times 2))))
   (it "ignores globally ignored directories when using native indexing"
       (projectile-test-with-sandbox
        (projectile-test-with-files
@@ -930,6 +920,46 @@
 
         (setq projectile-globally-ignored-directories '(".ignoreme"))
         (expect (projectile-dir-files-native "project") :to-equal '("config.conf"))))))
+
+(describe "globally ignored directories under native indexing"
+  ;; The entries are gitignore patterns: slashless names match at any
+  ;; depth, a leading `/' anchors at the root and `*' is a real wildcard.
+  (before-each
+    (setq projectile-globally-ignored-files nil
+          projectile-globally-ignored-file-suffixes nil))
+  (it "matches a slashless name at any depth"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/" "project/tmp/a" "project/src/tmp/b" "project/src/keep.c")
+      (setq projectile-globally-ignored-directories '("tmp"))
+      (expect (projectile-dir-files-native "project")
+              :to-equal '("src/keep.c")))))
+  (it "anchors a rooted name at the project root"
+    (projectile-test-with-stub-root "project"
+        ("tmp/a" "src/tmp/b" "src/keep.c")
+      (setq projectile-globally-ignored-directories '("/tmp"))
+      (expect (projectile-dir-files-native "project")
+              :to-have-same-items-as '("src/tmp/b" "src/keep.c"))))
+  (it "treats a leading `*' as a wildcard, not as a marker"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/" "project/.osc/a" "project/foo.osc/b" "project/keep.c")
+      (setq projectile-globally-ignored-directories '("*.osc"))
+      (expect (projectile-dir-files-native "project") :to-equal '("keep.c")))))
+  (it "matches only the named directory when the pattern has no wildcard"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/" "project/.osc/a" "project/foo.osc/b" "project/keep.c")
+      (setq projectile-globally-ignored-directories '(".osc"))
+      (expect (projectile-dir-files-native "project")
+              :to-have-same-items-as '("foo.osc/b" "keep.c")))))
+  (it "spares a file that shares its name with an ignored directory"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/" "project/node_modules/a" "project/lib/node_modules")
+      (setq projectile-globally-ignored-directories '("node_modules"))
+      (expect (projectile-dir-files-native "project")
+              :to-equal '("lib/node_modules"))))))
 
 (describe "projectile--vcs-from-directory-listing"
   (it "detects the VCS from a marker directly inside the directory"
@@ -1005,16 +1035,20 @@
             :to-equal "**/node_modules/**")
     (expect (projectile--alien-exclude-glob "TAGS" 'git) :to-equal "**/TAGS")
     (expect (projectile--alien-exclude-glob "*.elc" 'git) :to-equal "**/*.elc")
-    (expect (projectile--alien-exclude-glob "./vendor/" 'git) :to-equal "vendor/**")
-    (expect (projectile--alien-exclude-glob "./a/b.txt" 'git) :to-equal "a/b.txt"))
+    ;; a pathspec is anchored already, so an anchored pattern loses the `**/'
+    (expect (projectile--alien-exclude-glob "/vendor/" 'git) :to-equal "vendor/**")
+    (expect (projectile--alien-exclude-glob "/a/b.txt" 'git) :to-equal "a/b.txt")
+    ;; an interior slash anchors too
+    (expect (projectile--alien-exclude-glob "a/b.txt" 'git) :to-equal "a/b.txt"))
 
   (it "translates ignore globs into fd exclude patterns"
     ;; fd speaks gitignore, where a leading slash anchors to the search root
     (expect (projectile--alien-exclude-glob "node_modules/" 'fd)
-            :to-equal "node_modules")
+            :to-equal "node_modules/")
     (expect (projectile--alien-exclude-glob "*.elc" 'fd) :to-equal "*.elc")
-    (expect (projectile--alien-exclude-glob "./vendor/" 'fd) :to-equal "/vendor")
-    (expect (projectile--alien-exclude-glob "./a/b.txt" 'fd) :to-equal "/a/b.txt"))
+    (expect (projectile--alien-exclude-glob "/vendor/" 'fd) :to-equal "/vendor/")
+    (expect (projectile--alien-exclude-glob "/a/b.txt" 'fd) :to-equal "/a/b.txt")
+    (expect (projectile--alien-exclude-glob "a/b.txt" 'fd) :to-equal "/a/b.txt"))
 
   (it "declines for tools that cannot express exclusions"
     ;; svn and friends are shell pipelines, so the caller filters in Lisp
@@ -1024,6 +1058,18 @@
             :to-be nil)
     (expect (projectile--alien-command-excludes-p 'git projectile-git-command)
             :to-be-truthy))
+
+  (it "declines for a project with dirconfig ensure entries"
+    ;; an exclusion argument can't be taken back, so a project with `!'
+    ;; entries has to be filtered in Lisp, where they can rescue files
+    (spy-on 'projectile--ensure-patterns :and-return-value '("keep.elc"))
+    (expect (projectile--alien-command-excludes-p 'git projectile-git-command "/proj/")
+            :to-be nil)
+    (spy-on 'projectile-get-ext-command :and-return-value "git ls-files -z")
+    (spy-on 'projectile--project-ignore-globs :and-return-value '("*.elc"))
+    (let ((projectile-indexing-method 'alien))
+      (expect (projectile--alien-ext-command 'git "/proj/")
+              :to-equal "git ls-files -z")))
 
   (it "leaves the command alone when the option is off"
     (spy-on 'projectile-get-ext-command :and-return-value "git ls-files -z")
@@ -1047,16 +1093,15 @@
       (expect (projectile--alien-ext-command 'git "/proj/")
               :not :to-equal "git ls-files -z")))
 
-  (it "treats a `*'-prefixed ignored directory as a name, not a wildcard"
-    ;; `*.osc' names the directory `.osc' at any depth - a glob matcher
-    ;; would read the `*' as a wildcard and also drop `foo.osc'
+  (it "emits the ignore patterns as they are, gitignore syntax being what the tools want"
     (spy-on 'projectile-parse-dirconfig-file :and-return-value nil)
-    (let ((projectile-globally-ignored-directories '("*.osc"))
+    (let ((projectile-globally-ignored-directories '(".osc" "node_modules"))
           (projectile-globally-unignored-directories nil)
-          (projectile-globally-ignored-files nil)
-          (projectile-globally-ignored-file-suffixes nil))
-      (expect (projectile--project-ignore-globs "/proj/") :to-contain ".osc/")
-      (expect (projectile--project-ignore-globs "/proj/") :not :to-contain "*.osc/"))))
+          (projectile-globally-ignored-files '("TAGS"))
+          (projectile-globally-unignored-files nil)
+          (projectile-globally-ignored-file-suffixes '(".elc")))
+      (expect (projectile--project-ignore-globs "/proj/")
+              :to-equal '(".osc/" "node_modules/" "TAGS" "*.elc")))))
 
 (describe "native/alien dirconfig parity"
   ;; Native is the semantic reference: it walks the tree in Emacs Lisp and

--- a/test/projectile-search-review-test.el
+++ b/test/projectile-search-review-test.el
@@ -404,7 +404,7 @@ REGEXP-P selects `projectile-search-regexp-review'."
 (describe "projectile-search--rg-command"
   (it "builds a fixed-strings, ignore-aware command with the term after --"
     (let ((cmd (projectile-search--rg-command
-                "foo-bar" t nil '("node_modules/" "*.elc" "./vendor/"))))
+                "foo-bar" t nil '("node_modules/" "*.elc" "/vendor/"))))
       (expect (member "--fixed-strings" cmd) :to-be-truthy)
       (expect (member "--ignore-case" cmd) :to-be-truthy)
       (expect (member "--case-sensitive" cmd) :to-be nil)
@@ -413,9 +413,8 @@ REGEXP-P selects `projectile-search-regexp-review'."
       ;; a basename glob becomes a negated --glob verbatim
       (expect (member "!node_modules/" cmd) :to-be-truthy)
       (expect (member "!*.elc" cmd) :to-be-truthy)
-      ;; a root-anchored `./' glob is translated to ripgrep's `/'-anchored form
+      ;; ripgrep speaks gitignore, so a root-anchored glob is passed as is
       (expect (member "!/vendor/" cmd) :to-be-truthy)
-      (expect (member "!./vendor/" cmd) :to-be nil)
       ;; the term is right after the -- terminator, then the relative `./' root
       (let ((tail (cdr (member "--" cmd))))
         (expect (car tail) :to-equal "foo-bar")


### PR DESCRIPTION
`projectile-globally-ignored-directories` had its own pattern language: a bare entry meant "top level only" and a leading `*` was a marker meaning "at any depth", not a wildcard. Exactly one of the five code paths implemented that. Native matched basenames at every depth and never saw the marker, so `*tmp` looked for a directory literally named `*tmp`; alien stripped the marker for git and fd but fell back to hybrid's rules for the other tools, so it wasn't even consistent with itself; and the ripgrep path passed entries to `rg --glob=!` verbatim, where `*` really is a wildcard.

The `.projectile` dirconfig patterns already speak gitignore, via `projectile--dirconfig-pattern-to-regexp`. This routes the global ignore variables through that same matcher, so there's one pattern language and one implementation of it: slashless matches at any depth, a slash anchors to the project root, a trailing `/` is directory-only, and `*`/`**`/`?`/`[...]` are wildcards. `/tmp` is how you now say "only the project root", and it works globally rather than only in a per-project `.projectile`.

Fallout worth knowing about: a bare entry is no longer top-level-only under `hybrid`, the `*` prefix is a plain wildcard (so `*node_modules` should become `node_modules`, and the default `*.osc` became `.osc`), and `projectile-index-directory` lost three optional arguments. Dirconfig `!` entries now work under `alien` as well, by having such projects skip the push-down and filter in Lisp, since an exclusion argument can't be taken back.

Verified with a differential harness across native, hybrid, alien+git, alien+fd and alien's Lisp fallback: 23 cases covering anchoring, wildcards, `**/`, character classes, directory-only patterns and ensure-rescue, all five agreeing. That last path is new coverage - it's where the old inconsistency was hiding.