### PR TITLE
Honor dirconfig keep entries under alien indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Changes
 
+- [#2109](https://github.com/bbatsov/projectile/pull/2109): `alien` indexing now honors dirconfig `+` keep entries, which it previously ignored without saying so.
+- [#2109](https://github.com/bbatsov/projectile/pull/2109): Fix indexing failing outright when a dirconfig had `+` keep entries and the indexing command was a shell pipeline (the plain `find` fallback, svn, fossil, pijul), since the kept paths were appended to the last stage of the pipeline rather than to the lister.
 - [#2107](https://github.com/bbatsov/projectile/pull/2107): Projectile's ignore configuration now speaks gitignore patterns everywhere, matched the same way by every indexing method.
   - `projectile-globally-ignored-directories`, `projectile-globally-ignored-files` and `projectile-globally-ignored-file-suffixes` join the `.projectile` `-` entries in one pattern language and one matcher: a slashless pattern matches at any depth, a pattern with a slash is anchored at the project root, a trailing `/` means directory-only, and `*`, `**`, `?` and `[...]` are wildcards.
   - The `*` prefix in `projectile-globally-ignored-directories` is no longer a marker meaning "at any depth" (that's now the default) - it's a plain wildcard, so `*node_modules` should become `node_modules`. The default entry `*.osc` became `.osc` accordingly.

--- a/doc/modules/ROOT/pages/ignoring.adoc
+++ b/doc/modules/ROOT/pages/ignoring.adoc
@@ -11,8 +11,9 @@ comparison] for the full matrix of what each method honors.
 NOTE: All three indexing methods honor the `-` ignore and `!` unignore entries
 below.  Under `alien` the ignore entries are handed to the external indexing
 tool as exclusion arguments (see xref:indexing.adoc#alien-ignores[Indexing]).
-The `+` keep entries have no equivalent in those tools, so they apply under
-`hybrid` and `native` only.
+The `+` keep entries apply everywhere too: under `alien` they are passed to the
+indexing tool as path arguments, or applied to its output for the few tools that
+can't take them.
 
 If you'd like to instruct Projectile to ignore certain files in a
 project, when indexing it you can do so in the `.projectile` file by
@@ -141,10 +142,10 @@ left, and because neither has a slash they match at any depth: one `-dist/`
 handles every package's build output, and one `-node_modules/` catches both the
 top-level and the nested one.
 
-WARNING: `+` keep entries only apply under `native` and `hybrid`. Run this same
-project under `alien` (the default) and `packages/legacy/src/c.ts` comes back,
-because the external indexing tool has no way to express "list only these
-directories". If you rely on `+`, set `projectile-indexing-method` accordingly.
+NOTE: Under `alien` the kept directories are handed to the indexing tool as
+path arguments (`git ls-files -- src tests`, `fd --search-path`), so the
+restriction costs nothing extra. Tools whose command is a shell pipeline can't
+take path arguments, so there the listing is filtered inside Emacs instead.
 
 ==== Rescuing a file the ignore rules would drop
 

--- a/doc/modules/ROOT/pages/indexing.adoc
+++ b/doc/modules/ROOT/pages/indexing.adoc
@@ -195,7 +195,7 @@ below summarises which configuration knobs take effect under which mode:
 | Honors `.projectile` (dirconfig) `+` keep rules
 | Yes
 | Yes
-| No
+| Yes
 
 | Honors `.projectile` (dirconfig) `!` unignore rules
 | Yes
@@ -279,10 +279,12 @@ defer entirely to the tool's own ignore rules (`.gitignore` and friends).
 NOTE: An exclusion argument can't be taken back, so a project whose dirconfig
 has `!` ensure entries is filtered in Emacs Lisp under `alien` too, rather than
 pushed down - the rules are the same, only the fast path is given up. Dirconfig
-`+` keep entries have no equivalent at all and remain `hybrid`/`native` only.
-Neither can any method add back files the external tool never listed in the
-first place (because `.gitignore` excludes them); only `hybrid` does that, via
-its VCS-aware unignore pass.
+`+` keep entries are passed to the tool as path arguments where it takes them,
+and applied to its output where it doesn't.
+
+NOTE: No indexing method can add back files the external tool never listed in
+the first place (because `.gitignore` excludes them); only `hybrid` does that,
+via its VCS-aware unignore pass.
 
 NOTE: Ignore matching is case-sensitive under every indexing method. With
 `.elc` in `projectile-globally-ignored-file-suffixes`, a file named `BUILD.ELC`

--- a/projectile.el
+++ b/projectile.el
@@ -3186,20 +3186,26 @@ without shelling out per kept directory."
      (t (projectile-files-via-ext-command
          directory (projectile--alien-ext-command vcs directory) subdirs)))))
 
+(defun projectile--restrict-to-subdirs (files subdirs)
+  "Keep only the FILES that live under one of SUBDIRS.
+FILES and SUBDIRS are both relative to the project root.  Returns FILES
+unchanged when SUBDIRS is nil."
+  (if (null subdirs)
+      files
+    (let ((normalized (mapcar #'file-name-as-directory subdirs)))
+      (seq-filter
+       (lambda (f)
+         (seq-some (lambda (sd) (string-prefix-p sd f)) normalized))
+       files))))
+
 (defun projectile--restricted-sub-projects-files (project-root vcs subdirs)
   "Return git submodule files under PROJECT-ROOT, optionally restricted to SUBDIRS.
 SUBDIRS is a list of paths relative to PROJECT-ROOT; when non-nil
 only files whose project-relative path starts with one of those
 subdirectories are returned.  When nil, behaves exactly like
 `projectile-get-sub-projects-files'."
-  (let ((files (projectile-get-sub-projects-files project-root vcs)))
-    (if subdirs
-        (let ((normalized (mapcar #'file-name-as-directory subdirs)))
-          (seq-filter
-           (lambda (f)
-             (seq-some (lambda (sd) (string-prefix-p sd f)) normalized))
-           files))
-      files)))
+  (projectile--restrict-to-subdirs
+   (projectile-get-sub-projects-files project-root vcs) subdirs))
 
 (defun projectile-git-deleted-files (directory)
   "Get a list of deleted but unstaged files in DIRECTORY."
@@ -3410,6 +3416,17 @@ VCS is the VCS of the project."
     (when cmd
       (projectile-files-via-ext-command project (concat cmd " " dir)))))
 
+(defun projectile--command-accepts-pathspecs-p (command)
+  "Return non-nil when COMMAND can take trailing path arguments.
+
+Several of the indexing commands Projectile ships are shell pipelines:
+the svn, fossil and pijul recipes, and the plain find fallback, all end
+in a `tr' stage.  Appending a path to one of those hands it to that last
+stage rather than to the lister, which fails outright instead of
+restricting the listing, so the caller has to filter the command output
+itself (see `projectile--restrict-to-subdirs')."
+  (and command (not (string-match-p "|" command))))
+
 (defun projectile--ext-command-line (command pathspecs)
   "Return COMMAND with PATHSPECS appended as shell-quoted positional arguments.
 PATHSPECS may be nil, in which case COMMAND is returned unchanged.
@@ -3492,9 +3509,13 @@ project.  Either way COMMAND's stderr is captured into the
 
 Only text sent to standard output is taken into account."
   (when (and (stringp command) (not (string-empty-p command)))
-    (let ((default-directory root)
-          (full-command (projectile--ext-command-line command pathspecs))
-          (errors-file (make-temp-file "projectile-files-errors")))
+    (let* ((default-directory root)
+           ;; A pipeline can't take the pathspecs; run it unrestricted and
+           ;; filter its output below instead.
+           (pathspecs-on-command (and (projectile--command-accepts-pathspecs-p command)
+                                      pathspecs))
+           (full-command (projectile--ext-command-line command pathspecs-on-command))
+           (errors-file (make-temp-file "projectile-files-errors")))
       (unwind-protect
           (with-temp-buffer
             ;; `process-file-shell-command' goes through TRAMP for remote
@@ -3521,7 +3542,9 @@ Only text sent to standard output is taken into account."
                      "Projectile indexing command failed with exit code %d: %s\n\
 See the *projectile-files-errors* buffer for details"
                      exit-code full-command)))))
-              files))
+              (if pathspecs-on-command
+                  files
+                (projectile--restrict-to-subdirs files pathspecs))))
         (when (file-exists-p errors-file)
           (delete-file errors-file))))))
 
@@ -3560,7 +3583,12 @@ Remote ROOTs are handled via TRAMP (`make-process' is given a non-nil
            ;; `make-process' :stderr support over TRAMP.
            (errors-file (make-nearby-temp-file "projectile-files-errors"))
            (errors-localname (or (file-remote-p errors-file 'localname) errors-file))
-           (full-command (concat "{ " (projectile--ext-command-line command pathspecs)
+           ;; See the synchronous runner: a pipeline can't take the pathspecs,
+           ;; so it runs unrestricted and its output is filtered instead.
+           (pathspecs-on-command (and (projectile--command-accepts-pathspecs-p command)
+                                      pathspecs))
+           (restrict (unless pathspecs-on-command pathspecs))
+           (full-command (concat "{ " (projectile--ext-command-line command pathspecs-on-command)
                                  "; } 2>" (shell-quote-argument errors-localname)))
            (stdout-buffer (generate-new-buffer " *projectile-async-index*"))
            (proc
@@ -3588,8 +3616,10 @@ Remote ROOTs are handled via TRAMP (`make-process' is given a non-nil
                      ;; failure or clobber the errors buffer - just clean up.
                      (unless (process-get proc 'projectile-aborted)
                        (let ((exit-code (process-exit-status proc))
-                             (files (with-current-buffer stdout-buffer
-                                      (projectile--ext-command-output-files))))
+                             (files (projectile--restrict-to-subdirs
+                                     (with-current-buffer stdout-buffer
+                                       (projectile--ext-command-output-files))
+                                     restrict)))
                          (cond
                           ;; Clean exit: pass the listing through.
                           ((and (numberp exit-code) (zerop exit-code))
@@ -4568,14 +4598,21 @@ CALLER is accepted for backward compatibility but no longer used."
         (message "Projectile is initializing cache for %s ..." project-root))
       (setq files
             (if (eq projectile-indexing-method 'alien)
-                ;; In alien mode we let the external tool walk the whole
-                ;; root.  Projectile's ignore rules ride along as exclusion
-                ;; arguments on the command itself; only the tools that
-                ;; can't express them need a pass over the output here.
-                (let ((vcs (projectile-project-vcs project-root)))
+                ;; In alien mode the external tool does the walking.  The
+                ;; ignore rules ride along as exclusion arguments on the
+                ;; command; dirconfig `+' keep entries ride along as
+                ;; pathspecs (or, for a tool that can't take them, as a
+                ;; filter over its output).  Only the tools that can't
+                ;; express the ignores need a further pass here.
+                (let* ((vcs (projectile-project-vcs project-root))
+                       (dirs (projectile-get-project-directories project-root))
+                       (subdirs (unless (equal dirs (list project-root))
+                                  (mapcar (lambda (d)
+                                            (file-relative-name d project-root))
+                                          dirs))))
                   (projectile--alien-apply-ignores
                    project-root vcs
-                   (projectile--dir-files-alien-maybe-async project-root vcs)))
+                   (projectile--dir-files-alien-maybe-async project-root vcs subdirs)))
               (let ((dirs (projectile-get-project-directories project-root)))
                 (cond
                  ((and (eq projectile-indexing-method 'hybrid) (cdr dirs))

--- a/test/projectile-indexing-test.el
+++ b/test/projectile-indexing-test.el
@@ -1155,6 +1155,74 @@
           (expect alien :not :to-contain "q1.txt")
           (expect alien :not :to-contain "build.elc")))))))
 
+(describe "dirconfig keep entries under alien"
+  (it "restricts the listing to the kept directories"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/" "project/src/a.txt" "project/tests/b.txt" "project/other/c.txt")
+      (let* ((root (projectile-test-project-root))
+             (default-directory root))
+        (with-temp-file (expand-file-name ".projectile" root)
+          (insert "+/src\n+/tests\n"))
+        (call-process "git" nil nil nil "init")
+        (call-process "git" nil nil nil "add" "-A")
+        (spy-on 'projectile-project-root :and-return-value root)
+        (let ((projectile-enable-caching nil)
+              (projectile-indexing-method 'alien)
+              (projectile-git-use-fd nil)
+              (projectile-fd-executable nil))
+          (let ((files (projectile-project-files root)))
+            (expect files :to-contain "src/a.txt")
+            (expect files :to-contain "tests/b.txt")
+            (expect files :not :to-contain "other/c.txt")))))))
+
+  (it "restricts the listing for a tool that cannot take pathspecs"
+    ;; the shipped svn/fossil/pijul commands and the plain `find' fallback are
+    ;; shell pipelines: appending a path lands it on the last stage, so the
+    ;; listing is filtered in Emacs instead
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/" "project/src/a.txt" "project/other/c.txt")
+      (let* ((root (projectile-test-project-root))
+             (default-directory root))
+        (with-temp-file (expand-file-name ".projectile" root)
+          (insert "+/src\n"))
+        (spy-on 'projectile-project-root :and-return-value root)
+        ;; the sandbox sits inside Projectile's own git repo, so pin the VCS
+        ;; or the walk-up finds it and picks `git ls-files' instead
+        (spy-on 'projectile-project-vcs :and-return-value 'none)
+        (let ((projectile-enable-caching nil)
+              (projectile-indexing-method 'alien)
+              (projectile-git-use-fd nil)
+              (projectile-fd-executable nil)
+              (projectile-generic-command
+               "find . -type f | cut -c3- | tr \'\\n\' \'\\0\'"))
+          (let ((files (projectile-project-files root)))
+            (expect files :to-contain "src/a.txt")
+            (expect files :not :to-contain "other/c.txt"))))))))
+
+(describe "projectile--command-accepts-pathspecs-p"
+  (it "declines pipelines and accepts plain commands"
+    (expect (projectile--command-accepts-pathspecs-p projectile-git-command)
+            :to-be-truthy)
+    (expect (projectile--command-accepts-pathspecs-p projectile-hg-command)
+            :to-be-truthy)
+    (expect (projectile--command-accepts-pathspecs-p projectile-svn-command)
+            :to-be nil)
+    (expect (projectile--command-accepts-pathspecs-p
+             "find . -type f | cut -c3- | tr '\\n' '\\0'")
+            :to-be nil)
+    (expect (projectile--command-accepts-pathspecs-p nil) :to-be nil)))
+
+(describe "projectile--restrict-to-subdirs"
+  (it "keeps only files under one of the subdirs"
+    (expect (projectile--restrict-to-subdirs
+             '("src/a" "tests/b" "other/c") '("src" "tests"))
+            :to-equal '("src/a" "tests/b")))
+  (it "is a no-op without subdirs"
+    (expect (projectile--restrict-to-subdirs '("a" "b") nil)
+            :to-equal '("a" "b"))))
+
 (describe "alien/hybrid dirconfig parity"
   ;; The acceptance test for pushing the ignore rules into the external
   ;; tool: against a real git repo, alien must produce the same file set


### PR DESCRIPTION
`alien` ignored `+` keep entries outright and said nothing about it, which is worst in exactly the monorepo case most likely to use them. The plumbing to restrict the walk already existed and `hybrid` used it - `projectile-dir-files-alien` and friends take a SUBDIRS argument, and `projectile--ext-command-line` appends them as pathspecs with an `fd --search-path` special case - so alien simply never passed them along.

Looking at that turned up a live bug on master. Appending pathspecs to a shell pipeline doesn't restrict anything, it breaks the command: the svn, fossil and pijul recipes and the plain `find` fallback all end in a `tr` stage, so the paths land on `tr`.

```
find . -type f | cut -c3- | tr '\n' '\0' src/ tests/
```

`hybrid` with two or more keep entries hits this on any of those tools, which includes anyone without `fd` installed - indexing fails with a `user-error` rather than degrading. Commands that can't take path arguments now run unrestricted and get their output filtered by path prefix, which is exact and costs one pass.

Verified across native, hybrid, alien+git, alien+fd and both pipeline cases; all six return the same file set for a project mixing `+` keeps with a `-` ignore. The docs said `+` was hybrid/native only in three places, including the WARNING added a couple of hours ago - all updated, and the indexing comparison table now says Yes.