### PR TITLE
Drive the search integration off the canonical ignore patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 ### Changes
 
+- [#2110](https://github.com/bbatsov/projectile/pull/2110): The grep/ag search integration and the ignore predicates now derive their exclusions from the same gitignore patterns indexing uses, instead of expanding the dirconfig into absolute paths on their own.
+  - `projectile-ignored-file-p` and `projectile-ignored-directory-p` now take an optional project root instead of a pre-computed list of ignored paths, and answer exactly what indexing would (ensure entries included, a file under an ignored directory counted as ignored).
+  - Under `rgrep` an ignore pattern is passed as a pattern rather than as whatever it happened to expand to on disk, `!` ensure entries can now rescue root-anchored paths too, and the globally ignored suffixes are no longer also folded into `grep-find-ignored-files`.
+  - Removed `projectile-ignored-files`, `projectile-ignored-directories`, their `-rel` variants, `projectile-project-ignored`, `projectile-project-ignored-files`, `projectile-project-ignored-directories`, `projectile-paths-to-ignore` and `projectile-patterns-to-ignore`, all of which existed only to build those absolute path lists.
 - [#2109](https://github.com/bbatsov/projectile/pull/2109): `alien` indexing now honors dirconfig `+` keep entries, which it previously ignored without saying so.
 - [#2109](https://github.com/bbatsov/projectile/pull/2109): Fix indexing failing outright when a dirconfig had `+` keep entries and the indexing command was a shell pipeline (the plain `find` fallback, svn, fossil, pijul), since the kept paths were appended to the last stage of the pipeline rather than to the lister.
 - [#2107](https://github.com/bbatsov/projectile/pull/2107): Projectile's ignore configuration now speaks gitignore patterns everywhere, matched the same way by every indexing method.

--- a/doc/modules/ROOT/pages/ignoring.adoc
+++ b/doc/modules/ROOT/pages/ignoring.adoc
@@ -101,6 +101,14 @@ global ignore variables described below.
   character classes are supported.
 * Matching is case-sensitive.
 
+The search commands (`projectile-grep`, `projectile-ag`,
+`projectile-ripgrep`, `projectile-find-references`) apply the very same
+patterns, translated into whatever exclusion syntax the underlying tool
+speaks, so a search sees the same set of files indexing does. The one
+place the translation can't be exact is `grep`: `*` in a `find` path
+glob crosses `/`, so a root-anchored pattern like `-/*.txt` also
+excludes deeper matches there.
+
 [#worked-examples]
 === Worked examples
 

--- a/projectile.el
+++ b/projectile.el
@@ -2185,8 +2185,9 @@ PROJECT-ROOT defaults to the current project."
       (let* ((abs-current-file (file-truename (buffer-file-name)))
              (current-file (file-relative-name abs-current-file current-project)))
         (unless (or (projectile-file-cached-p current-file current-project)
-                    (projectile-ignored-directory-p (file-name-directory abs-current-file))
-                    (projectile-ignored-file-p abs-current-file))
+                    ;; A file under an ignored directory is ignored too, so
+                    ;; the single file check covers its parents as well.
+                    (projectile-ignored-file-p abs-current-file current-project))
           (let ((project-files (cons current-file (gethash current-project projectile-projects-cache))))
             (puthash current-project project-files projectile-projects-cache)
             ;; Defer the disk write until Emacs is idle to avoid freezing the
@@ -4175,85 +4176,58 @@ projectile project root."
   (let ((project-root (projectile-project-root)))
     (mapcar (lambda (f) (projectile--project-relative-name f project-root)) files)))
 
-(defun projectile-ignored-directory-p
-    (directory &optional ignored-directories local-directory globally-ignored-directories)
+(defun projectile--ignored-path-p (path root directory-p)
+  "Return non-nil when PATH is ignored in the project at ROOT.
+
+PATH is an absolute file name and DIRECTORY-P says whether it names a
+directory, in which case directory-only patterns (those with a trailing
+slash) can match it.  ROOT defaults to the current project's root.
+
+The check is the one indexing performs: PATH's root-relative name is
+matched against `projectile--ignore-patterns', `!' ensure patterns
+rescue it, and `projectile-global-ignore-file-patterns' is applied to
+the absolute name.  Because an ignored directory covers its whole
+subtree, a path inside one is reported as ignored too."
+  (let* ((path (expand-file-name path))
+         (root (file-name-as-directory
+                (expand-file-name (or root (projectile-project-root)))))
+         (relative-name (projectile--project-relative-name path root))
+         (relative-name (if directory-p
+                            (file-name-as-directory relative-name)
+                          relative-name))
+         (patterns (projectile-filtering-patterns root))
+         (ignore-re (projectile--compile-ignore-patterns (car patterns)))
+         (ensure-re (projectile--compile-ignore-patterns (cdr patterns)))
+         ;; Ignore matching is case-sensitive.
+         (case-fold-search nil))
+    (or (projectile--global-ignore-regexp-p path)
+        (and ignore-re
+             (string-match-p ignore-re relative-name)
+             (not (and ensure-re (string-match-p ensure-re relative-name)))
+             t))))
+
+(defun projectile-ignored-directory-p (directory &optional root)
   "Check if DIRECTORY should be ignored.
 
-Pre-computed lists of IGNORED-DIRECTORIES and GLOBALLY-IGNORED-DIRECTORIES
-and the LOCAL-DIRECTORY name may optionally be provided."
-  (let ((ignored-directories (or ignored-directories (projectile-ignored-directories)))
-        (globally-ignored-directories (or globally-ignored-directories (projectile-globally-ignored-directory-names)))
-        (local-directory (or local-directory (file-name-nondirectory (directory-file-name directory)))))
-    (or (member directory ignored-directories)
-        (seq-some
-         (lambda (name)
-           (string-match-p name directory))
-         projectile-global-ignore-file-patterns)
-        (member local-directory globally-ignored-directories))))
+DIRECTORY is an absolute directory name and ROOT is the project root it
+belongs to, defaulting to the current project's.  The answer is the one
+indexing gives - see `projectile--ignored-path-p'."
+  (projectile--ignored-path-p directory root t))
 
-(defun projectile-ignored-file-p (file &optional ignored-files)
+(defun projectile-ignored-file-p (file &optional root)
   "Check if FILE should be ignored.
 
-A pre-computed list of IGNORED-FILES may optionally be provided."
-  (or
-   (member file (or ignored-files (projectile-ignored-files)))
-   (seq-some
-    (lambda (name)
-      (string-match-p name file))
-    projectile-global-ignore-file-patterns)
-   (seq-some
-    (lambda (suffix)
-      (string-suffix-p suffix file))
-    projectile-globally-ignored-file-suffixes)))
-
-(defun projectile-ignored-files ()
-  "Return list of ignored files.
-
-That's a combination of the globally ignored files and
-files ignored in a project's dirconfig."
-  (seq-difference
-   (mapcar
-    #'projectile-expand-root
-    (append
-     projectile-globally-ignored-files
-     (projectile-project-ignored-files)))
-   (projectile-unignored-files)))
+FILE is an absolute file name and ROOT is the project root it belongs
+to, defaulting to the current project's.  The answer is the one indexing
+gives - see `projectile--ignored-path-p'.  A file inside an ignored
+directory counts as ignored."
+  (projectile--ignored-path-p file root nil))
 
 (defun projectile-globally-ignored-directory-names ()
   "Return list of ignored directory names."
   (seq-difference
    projectile-globally-ignored-directories
    projectile-globally-unignored-directories))
-
-(defun projectile-ignored-directories ()
-  "Return list of ignored directories."
-  (seq-difference
-   (mapcar
-    #'file-name-as-directory
-    (mapcar
-     #'projectile-expand-root
-     (append
-      projectile-globally-ignored-directories
-      (projectile-project-ignored-directories))))
-   (projectile-unignored-directories)))
-
-(defun projectile-ignored-directories-rel ()
-  "Return list of ignored directories, relative to the root."
-  (projectile-make-relative-to-root (projectile-ignored-directories)))
-
-(defun projectile-ignored-files-rel ()
-  "Return list of ignored files, relative to the root."
-  (projectile-make-relative-to-root (projectile-ignored-files)))
-
-(defun projectile-project-ignored-files ()
-  "Return list of project ignored files.
-Unignored files are not included."
-  (seq-remove 'file-directory-p (projectile-project-ignored)))
-
-(defun projectile-project-ignored-directories ()
-  "Return list of project ignored directories.
-Unignored directories are not included."
-  (seq-filter 'file-directory-p (projectile-project-ignored)))
 
 (defun projectile--dirconfig-ignore ()
   "Return the IGNORE entries from the project's dirconfig, or nil."
@@ -4264,20 +4238,6 @@ Unignored directories are not included."
   "Return the ENSURE entries from the project's dirconfig, or nil."
   (when-let* ((cfg (projectile-parse-dirconfig-file)))
     (projectile-dirconfig-ensure cfg)))
-
-(defun projectile-paths-to-ignore ()
-  "Return a list of ignored project paths."
-  (projectile-normalise-paths (projectile--dirconfig-ignore)))
-
-(defun projectile-patterns-to-ignore ()
-  "Return a list of relative file patterns."
-  (projectile-normalise-patterns (projectile--dirconfig-ignore)))
-
-(defun projectile-project-ignored ()
-  "Return list of project ignored files/directories.
-Unignored files/directories are not included."
-  (let ((paths (projectile-paths-to-ignore)))
-    (projectile-expand-paths paths)))
 
 (defun projectile-unignored-files ()
   "Return list of unignored files."

--- a/projectile.el
+++ b/projectile.el
@@ -7214,6 +7214,82 @@ is appended and faced as `(default VALUE)'."
 (defvar projectile-grep-find-ignored-patterns)
 (defvar projectile-grep-find-unignored-patterns)
 
+(defun projectile--grep-find-specs (patterns)
+  "Split gitignore-style PATTERNS into specs for the `find'-based grep.
+Return a cons of the root-anchored patterns, spelled relative to the
+project root, and the floating ones, which match at any depth.  Trailing
+slashes are dropped: `find' sees directory entries without one, and
+pruning a directory takes its whole subtree with it anyway."
+  (let (anchored floating)
+    (dolist (pattern patterns)
+      (let ((body (string-remove-suffix "/" pattern)))
+        (cond ((string-empty-p body))
+              ((string-prefix-p "**/" body) (push (substring body 3) floating))
+              ((string-prefix-p "/" body) (push (substring body 1) anchored))
+              ((string-search "/" body) (push body anchored))
+              (t (push body floating)))))
+    (cons (nreverse anchored) (nreverse floating))))
+
+(defun projectile--grep-rebase-paths (paths project-root root-dir)
+  "Respell root-anchored PATHS relative to ROOT-DIR.
+PATHS are relative to PROJECT-ROOT, while `find' is started in ROOT-DIR -
+either the project root itself or one of the dirconfig `+' keep
+subdirectories.  A path that doesn't live under ROOT-DIR can't match
+anything the search will see, so it is dropped."
+  (let ((prefix (file-relative-name
+                 (file-name-as-directory (expand-file-name root-dir))
+                 (file-name-as-directory (expand-file-name project-root)))))
+    (if (member prefix '("./" "" "."))
+        paths
+      (delq nil (mapcar (lambda (path)
+                          (and (string-prefix-p prefix path)
+                               (substring path (length prefix))))
+                        paths)))))
+
+(defun projectile--grep-find-path-tests (anchored floating)
+  "Return `find' -path tests matching the ANCHORED and FLOATING patterns.
+An anchored pattern is spelled `./PATH', so it only matches from the
+directory `find' was started in; a floating one gets a `*/' prefix, so it
+matches at any depth.  Return nil when both lists are empty.
+
+The one place this can't be exact is that `*' in a `find' -path glob
+crosses `/', where a gitignore `*' stays within a path segment, so an
+anchored pattern like `/*.txt' also prunes deeper matches here."
+  (when-let* ((globs (append
+                      (mapcar (lambda (pattern) (concat "./" pattern)) anchored)
+                      (mapcar (lambda (pattern)
+                                (if (string-prefix-p "*" pattern)
+                                    pattern
+                                  (concat "*/" pattern)))
+                              floating))))
+    (concat " -path " (mapconcat #'shell-quote-argument globs " -o -path "))))
+
+(defun projectile--grep-find-prune-clause ()
+  "Return the `find' prune expression for Projectile's ignore configuration.
+Built from the four `projectile-grep-find-*' variables `projectile--grep'
+binds around the `rgrep' call.  The `!' ensure entries are subtracted
+from the whole ignore expression, so they rescue an anchored path just
+like they rescue a floating pattern - and just like they do when
+indexing."
+  (when-let* ((ignore-tests (projectile--grep-find-path-tests
+                             projectile-grep-find-ignored-paths
+                             projectile-grep-find-ignored-patterns)))
+    (let ((unignore-tests (projectile--grep-find-path-tests
+                           projectile-grep-find-unignored-paths
+                           projectile-grep-find-unignored-patterns)))
+      (concat (shell-quote-argument "(")
+              (if unignore-tests
+                  (concat " " (shell-quote-argument "(")
+                          ignore-tests
+                          " " (shell-quote-argument ")")
+                          " -a " (shell-quote-argument "!")
+                          " " (shell-quote-argument "(")
+                          unignore-tests
+                          " " (shell-quote-argument ")"))
+                ignore-tests)
+              " " (shell-quote-argument ")")
+              " -prune -o "))))
+
 (defun projectile-rgrep-default-command (regexp files dir)
   "Compute the command for \\[rgrep] to use by default.
 
@@ -7273,63 +7349,7 @@ which it shares its arglist."
                  " "
                  (shell-quote-argument ")")
                  " -prune -o "))
-    (and projectile-grep-find-ignored-paths
-         (concat (shell-quote-argument "(")
-                 " -path "
-                 (mapconcat
-                  (lambda (ignore) (shell-quote-argument
-                                    (concat "./" ignore)))
-                  projectile-grep-find-ignored-paths
-                  " -o -path ")
-                 " "
-                 (shell-quote-argument ")")
-                 " -prune -o "))
-    (and projectile-grep-find-ignored-patterns
-         (concat (shell-quote-argument "(")
-                 (and (or projectile-grep-find-unignored-paths
-                          projectile-grep-find-unignored-patterns)
-                      (concat " "
-                              (shell-quote-argument "(")))
-                 " -path "
-                 (mapconcat
-                  (lambda (ignore)
-                    (shell-quote-argument
-                     (if (string-prefix-p "*" ignore) ignore
-                       (concat "*/" ignore))))
-                  projectile-grep-find-ignored-patterns
-                  " -o -path ")
-                 (and (or projectile-grep-find-unignored-paths
-                          projectile-grep-find-unignored-patterns)
-                      (concat " "
-                              (shell-quote-argument ")")
-                              " -a "
-                              (shell-quote-argument "!")
-                              " "
-                              (shell-quote-argument "(")
-                              (and projectile-grep-find-unignored-paths
-                                   (concat " -path "
-                                           (mapconcat
-                                            (lambda (ignore) (shell-quote-argument
-                                                              (concat "./" ignore)))
-                                            projectile-grep-find-unignored-paths
-                                            " -o -path ")))
-                              (and projectile-grep-find-unignored-paths
-                                   projectile-grep-find-unignored-patterns
-                                   " -o")
-                              (and projectile-grep-find-unignored-patterns
-                                   (concat " -path "
-                                           (mapconcat
-                                            (lambda (ignore)
-                                              (shell-quote-argument
-                                               (if (string-prefix-p "*" ignore) ignore
-                                                 (concat "*/" ignore))))
-                                            projectile-grep-find-unignored-patterns
-                                            " -o -path ")))
-                              " "
-                              (shell-quote-argument ")")))
-                 " "
-                 (shell-quote-argument ")")
-                 " -prune -o ")))))
+    (projectile--grep-find-prune-clause))))
 
 ;;; Project search
 ;;
@@ -7394,31 +7414,28 @@ FILES, when non-nil, is an rgrep files specification restricting the
 search.  Honours Projectile's ignore configuration and runs
 `projectile-grep-finished-hook' when done."
   (require 'grep) ;; for `rgrep'
-  (let ((roots (projectile-get-project-directories (projectile-acquire-root))))
+  (let* ((project-root (projectile-acquire-root))
+         (roots (projectile-get-project-directories project-root))
+         ;; The ignore and ensure rules are the project's, so they're read
+         ;; once and respelled per root below.
+         (ignore-specs (projectile--grep-find-specs
+                        (projectile--ignore-patterns project-root)))
+         (ensure-specs (projectile--grep-find-specs
+                        (projectile--ensure-patterns project-root))))
     (dolist (root-dir roots)
       (require 'vc-git) ;; for `vc-git-grep'
       ;; in git projects users have the option to use `vc-git-grep' instead of `rgrep'
       (if (and (eq (projectile-project-vcs) 'git)
                projectile-use-git-grep)
           (vc-git-grep search-regexp (or files "") root-dir)
-        ;; paths for find-grep should relative and without trailing /
-        (let ((grep-find-ignored-files
-               (seq-union (projectile--globally-ignored-file-suffixes-glob)
-                          grep-find-ignored-files))
-              (projectile-grep-find-ignored-paths
-               (append (mapcar (lambda (f) (directory-file-name (file-relative-name f root-dir)))
-                               (projectile-ignored-directories))
-                       (mapcar (lambda (file)
-                                 (file-relative-name file root-dir))
-                               (projectile-ignored-files))))
+        (let ((projectile-grep-find-ignored-paths
+               (projectile--grep-rebase-paths (car ignore-specs)
+                                              project-root root-dir))
+              (projectile-grep-find-ignored-patterns (cdr ignore-specs))
               (projectile-grep-find-unignored-paths
-               (append (mapcar (lambda (f) (directory-file-name (file-relative-name f root-dir)))
-                               (projectile-unignored-directories))
-                       (mapcar (lambda (file)
-                                 (file-relative-name file root-dir))
-                               (projectile-unignored-files))))
-              (projectile-grep-find-ignored-patterns (projectile-patterns-to-ignore))
-              (projectile-grep-find-unignored-patterns (projectile-patterns-to-ensure)))
+               (projectile--grep-rebase-paths (car ensure-specs)
+                                              project-root root-dir))
+              (projectile-grep-find-unignored-patterns (cdr ensure-specs)))
           (grep-compute-defaults)
           (cl-letf (((symbol-function 'rgrep-default-command) #'projectile-rgrep-default-command))
             (rgrep search-regexp (or files "* .*") root-dir)
@@ -7429,6 +7446,22 @@ search.  Honours Projectile's ignore configuration and runs
               (with-current-buffer "*grep*"
                 (rename-buffer (concat "*grep <" root-dir ">*") t)))))))
     (run-hooks 'projectile-grep-finished-hook)))
+
+(defun projectile--ag-ignore-patterns ()
+  "Return `ag-ignore-list' entries for the project's ignore patterns.
+
+They come from `projectile--ignore-patterns'.  `ag' takes plain globs
+with no notion of anchoring, so the gitignore markers it wouldn't make
+sense of - a leading `/' or `**/', a trailing `/' - are stripped; what's
+left matches at any depth, which is as close as `ag' gets."
+  (seq-remove
+   #'string-empty-p
+   (mapcar (lambda (pattern)
+             (let ((body (string-remove-suffix "/" pattern)))
+               (cond ((string-prefix-p "**/" body) (substring body 3))
+                     ((string-prefix-p "/" body) (substring body 1))
+                     (t body))))
+           (projectile--ignore-patterns))))
 
 (defun projectile--ag (search-term &optional regexp)
   "Run an `ag' search for SEARCH-TERM in the project.
@@ -7441,9 +7474,7 @@ Requires the `ag' Emacs package."
                               (seq-uniq
                                (append
                                 ag-ignore-list
-                                (projectile-ignored-files-rel)
-                                (projectile-ignored-directories-rel)
-                                (projectile--globally-ignored-file-suffixes-glob)
+                                (projectile--ag-ignore-patterns)
                                 ;; ag supports git ignore files directly
                                 (unless (eq (projectile-project-vcs) 'git)
                                   (append grep-find-ignored-files

--- a/test/projectile-grep-test.el
+++ b/test/projectile-grep-test.el
@@ -54,6 +54,78 @@
                           "--glob=!TAGS" "--glob=!GTAGS"
                           "--glob=!*.log")))))
 
+(describe "projectile--ag-ignore-patterns"
+  (it "strips the gitignore markers ag can't make sense of"
+    (spy-on 'projectile--dirconfig-ignore
+            :and-return-value '("*.log" "/build/" "**/gen" "src/out"))
+    (let ((projectile-globally-ignored-directories '("node_modules"))
+          (projectile-globally-unignored-directories nil)
+          (projectile-globally-ignored-files '("TAGS"))
+          (projectile-globally-unignored-files nil)
+          (projectile-globally-ignored-file-suffixes '(".elc")))
+      (expect (projectile--ag-ignore-patterns)
+              :to-equal '("node_modules" "TAGS" "*.elc"
+                          "*.log" "build" "gen" "src/out")))))
+
+(describe "the grep and indexing ignore lists"
+  ;; The whole point of deriving grep's exclusions from
+  ;; `projectile--ignore-patterns' is that the two agree, so assert it
+  ;; directly: every pattern indexing filters by has to show up in the
+  ;; find expression, on the right side of the anchored/floating split.
+  (before-each
+    (spy-on 'projectile--dirconfig-ignore
+            :and-return-value '("*.log" "/build/" "vendor/" "src/gen" "**/tmp"))
+    (spy-on 'projectile--dirconfig-ensure :and-return-value '("keep.log")))
+  (it "cover the same patterns"
+    (let* ((projectile-globally-ignored-directories '("node_modules"))
+           (projectile-globally-unignored-directories nil)
+           (projectile-globally-ignored-files '("TAGS"))
+           (projectile-globally-unignored-files nil)
+           (projectile-globally-ignored-file-suffixes '(".elc"))
+           (patterns (projectile--ignore-patterns "/r/"))
+           (specs (projectile--grep-find-specs patterns)))
+      (expect (car specs) :to-equal '("build" "src/gen"))
+      (expect (cdr specs) :to-equal '("node_modules" "TAGS" "*.elc"
+                                      "*.log" "vendor" "tmp"))
+      ;; nothing indexing knows about is dropped on the way to grep
+      (expect (+ (length (car specs)) (length (cdr specs)))
+              :to-equal (length patterns))))
+  (it "agree on which files a search sees"
+    (let* ((projectile-globally-ignored-directories '("node_modules"))
+           (projectile-globally-unignored-directories nil)
+           (projectile-globally-ignored-files '("TAGS"))
+           (projectile-globally-unignored-files nil)
+           (projectile-globally-ignored-file-suffixes '(".elc"))
+           (files '("a.el" "a.elc" "TAGS" "keep.log" "src/a.log"
+                    "build/out" "vendor/dep/a.el" "src/gen/a.el"
+                    "node_modules/dep/a.js" "deep/tmp/a.el"))
+           (specs (projectile--grep-find-specs (projectile--ignore-patterns "/r/")))
+           (ensure (projectile--grep-find-specs (projectile--ensure-patterns "/r/"))))
+      (spy-on 'projectile-project-root :and-return-value "/r/")
+      (cl-flet* ((path-prefixes (file)
+                   ;; `find' prunes a directory, which takes its whole
+                   ;; subtree with it, so a test hitting any ancestor of
+                   ;; FILE removes FILE too
+                   (let (prefixes current)
+                     (dolist (segment (split-string file "/") (nreverse prefixes))
+                       (setq current (if current (concat current "/" segment) segment))
+                       (push current prefixes))))
+                 (tested-p (specs file)
+                   (let ((globs (append
+                                 (mapcar (lambda (p) (concat "./" p)) (car specs))
+                                 (mapcar (lambda (p) (concat "*/" p)) (cdr specs)))))
+                     (seq-some (lambda (path)
+                                 (seq-some (lambda (glob)
+                                             (string-match-p (wildcard-to-regexp glob)
+                                                             (concat "./" path)))
+                                           globs))
+                               (path-prefixes file))))
+                 (pruned-p (file)
+                   (and (tested-p specs file)
+                        (not (tested-p ensure file)))))
+        (expect (seq-remove #'pruned-p files)
+                :to-equal (projectile-remove-ignored files))))))
+
 (describe "projectile-grep"
   (describe "multi-root grep"
     (after-each
@@ -98,10 +170,14 @@
                 (projectile-globally-ignored-file-suffixes '("IG_SUF"))
                 (projectile-globally-ignored-directories '("GLOB_IG_DIR")))
             (projectile-grep "hi")))
+        ;; the projectile clause carries the gitignore patterns: the
+        ;; globally ignored directory and file names match at any depth,
+        ;; and so do the ignored suffixes
         (expect 'compilation-start :to-have-been-called-with
                 (concat "-type d \\( -path \\*/IG_DIR \\) -prune -o "
-                        "\\! -type d \\( -name \\*IG_SUF -o -name IG_FILE \\) -prune -o "
-                        "\\( -path ./GLOB_IG_DIR -o -path ./GLOB_IG_FILE \\) -prune -o ")
+                        "\\! -type d \\( -name IG_FILE \\) -prune -o "
+                        "\\( -path \\*/GLOB_IG_DIR -o -path \\*/GLOB_IG_FILE "
+                        "-o -path \\*IG_SUF \\) -prune -o ")
                 'grep-mode))))
     (it "excludes project ignores"
       (projectile-test-with-sandbox
@@ -128,10 +204,13 @@
                 projectile-globally-ignored-file-suffixes
                 projectile-globally-ignored-directories)
             (projectile-grep "hi")))
+        ;; the ignore patterns go in as patterns, not as the paths they
+        ;; happened to expand to on disk, and the `!' entries are
+        ;; subtracted from the whole ignore expression
         (expect 'compilation-start :to-have-been-called-with
-                (concat "\\( -path ./baz -o -path ./foo.txt -o -path ./bar/foo.txt \\) -prune -o "
-                        "\\( "
-                        "\\( -path \\*.txt -o -path \\*.text \\) "
+                (concat "\\( "
+                        "\\( -path ./\\*.txt -o -path ./bar/\\*.txt -o -path ./baz "
+                        "-o -path \\*.txt -o -path \\*.text \\) "
                         "-a \\! \\( -path ./abc.txt -o -path ./bar/abc.txt -o -path \\*/def.txt \\) "
                         "\\) -prune -o ")
                 'grep-mode)))))

--- a/test/projectile-ignore-test.el
+++ b/test/projectile-ignore-test.el
@@ -28,17 +28,60 @@
 (require 'projectile-test-helpers)
 
 (describe "projectile-ignored-directory-p"
+  (before-each
+    (spy-on 'projectile-project-root :and-return-value "/path/to/project/")
+    (spy-on 'projectile--dirconfig-ignore :and-return-value '("tmp" "t.ignore"))
+    (spy-on 'projectile--dirconfig-ensure))
   (it "checks if directory should be ignored"
-    (spy-on 'projectile-ignored-directories :and-return-value '("/path/to/project/tmp" "/path/to/project/t.ignore"))
     (expect (projectile-ignored-directory-p "/path/to/project/tmp") :to-be-truthy)
     (expect (projectile-ignored-directory-p "/path/to/project/t.ignore") :to-be-truthy)
-    (expect (projectile-ignored-directory-p "/path/to/project/log") :not :to-be-truthy)))
+    (expect (projectile-ignored-directory-p "/path/to/project/log") :not :to-be-truthy))
+  (it "matches slashless patterns at any depth, like indexing does"
+    (expect (projectile-ignored-directory-p "/path/to/project/src/tmp") :to-be-truthy))
+  (it "lets directory-only patterns match a directory"
+    (spy-on 'projectile--dirconfig-ignore :and-return-value '("vendor/"))
+    (expect (projectile-ignored-directory-p "/path/to/project/vendor") :to-be-truthy)
+    (expect (projectile-ignored-file-p "/path/to/project/vendor") :not :to-be-truthy))
+  (it "accepts an explicit project root"
+    (spy-on 'projectile-project-root :and-throw-error 'error)
+    (expect (projectile-ignored-directory-p "/elsewhere/tmp" "/elsewhere/")
+            :to-be-truthy)))
 
 (describe "projectile-ignored-file-p"
+  (before-each
+    (spy-on 'projectile-project-root :and-return-value "/path/to/project/")
+    (spy-on 'projectile--dirconfig-ignore :and-return-value '("TAGS" "T*.el"))
+    (spy-on 'projectile--dirconfig-ensure))
   (it "checks if file should be ignored"
-    (spy-on 'projectile-ignored-files :and-return-value '("/path/to/project/TAGS" "/path/to/project/T.*"))
     (expect (projectile-ignored-file-p "/path/to/project/TAGS") :to-be-truthy)
-    (expect (projectile-ignored-file-p "/path/to/project/foo.el") :not :to-be-truthy)))
+    (expect (projectile-ignored-file-p "/path/to/project/Tags.el") :to-be-truthy)
+    (expect (projectile-ignored-file-p "/path/to/project/foo.el") :not :to-be-truthy))
+  (it "reports a file inside an ignored directory as ignored"
+    (spy-on 'projectile--dirconfig-ignore :and-return-value '("vendor/"))
+    (expect (projectile-ignored-file-p "/path/to/project/vendor/dep/a.el") :to-be-truthy))
+  (it "lets an ensure pattern rescue an ignored file"
+    (spy-on 'projectile--dirconfig-ensure :and-return-value '("TAGS"))
+    (expect (projectile-ignored-file-p "/path/to/project/TAGS") :not :to-be-truthy))
+  (it "applies projectile-global-ignore-file-patterns to the absolute name"
+    (let ((projectile-global-ignore-file-patterns '("\\.min\\.js\\'")))
+      (expect (projectile-ignored-file-p "/path/to/project/a.min.js") :to-be-truthy)
+      (expect (projectile-ignored-file-p "/path/to/project/a.js") :not :to-be-truthy))))
+
+(describe "the ignore predicates and indexing"
+  (it "agree on the same configuration"
+    (spy-on 'projectile-project-root :and-return-value "/r/")
+    (spy-on 'projectile--dirconfig-ignore :and-return-value '("*.log" "/build" "vendor/"))
+    (spy-on 'projectile--dirconfig-ensure :and-return-value '("keep.log"))
+    (let ((projectile-globally-ignored-directories '("node_modules"))
+          (projectile-globally-ignored-files '("TAGS"))
+          (projectile-globally-ignored-file-suffixes '(".elc"))
+          (projectile-globally-unignored-files nil)
+          (projectile-globally-unignored-directories nil)
+          (files '("a.el" "a.elc" "TAGS" "keep.log" "src/a.log" "build/out"
+                   "vendor/dep/a.el" "node_modules/dep/a.js" "src/build/out")))
+      (expect (seq-remove (lambda (f) (projectile-ignored-file-p (concat "/r/" f)))
+                          files)
+              :to-equal (projectile-remove-ignored files)))))
 
 (describe "projectile-globally-ignored-files"
   (it "includes TAGS file by default"
@@ -46,9 +89,9 @@
   (it "includes cache file by default"
     (expect (member projectile-cache-file projectile-globally-ignored-files) :to-be-truthy))
   (it "causes cache file to be ignored via projectile-ignored-file-p"
-    (spy-on 'projectile-ignored-files :and-return-value
-            (list (concat "/path/to/project/" projectile-cache-file)
-                  (concat "/path/to/project/" projectile-tags-file-name)))
+    (spy-on 'projectile-project-root :and-return-value "/path/to/project/")
+    (spy-on 'projectile--dirconfig-ignore)
+    (spy-on 'projectile--dirconfig-ensure)
     (expect (projectile-ignored-file-p (concat "/path/to/project/" projectile-cache-file)) :to-be-truthy)
     (expect (projectile-ignored-file-p "/path/to/project/source.el") :not :to-be-truthy)))
 
@@ -101,72 +144,6 @@
   (it "rejects non-symbols for projectile-project-type"
     (let ((pred (get 'projectile-project-type 'safe-local-variable)))
       (expect (funcall pred "maven") :not :to-be-truthy))))
-
-(describe "projectile-ignored-files"
-  (it "returns list of ignored files"
-    (spy-on 'projectile-project-root :and-return-value "/path/to/project")
-    (spy-on 'projectile-project-name :and-return-value "project")
-    (spy-on 'projectile-project-ignored-files :and-return-value '("foo.js" "bar.rb"))
-    (let ((files '("/path/to/project/TAGS"
-                   "/path/to/project/foo.js"
-                   "/path/to/project/bar.rb"
-                   "/path/to/project/file1.log"
-                   "/path/to/project/file2.log"))
-          (projectile-ignored-files '("TAGS" "file\d+\\.log")))
-      (expect (projectile-ignored-files) :not :to-equal files)
-      (expect (projectile-ignored-files) :to-equal '("/path/to/project/TAGS"
-                                                     "/path/to/project/.projectile-cache.eld"
-                                                     "/path/to/project/foo.js"
-                                                     "/path/to/project/bar.rb")))))
-
-(describe "projectile-ignored-directories"
-  (it "returns list of ignored directories"
-    (spy-on 'projectile-project-ignored-directories :and-return-value '("tmp" "log"))
-    (spy-on 'projectile-project-root :and-return-value "/path/to/project")
-    (let ((paths '("/path/to/project/compiled/"
-                   "/path/to/project/ignoreme"
-                   "/path/to/project/ignoremetoo"
-                   "/path/to/project/tmp"
-                   "/path/to/project/log"))
-          (projectile-globally-ignored-directories '("compiled" "ignoreme")))
-      (expect (projectile-ignored-directories) :not :to-equal paths)
-      (expect (projectile-ignored-directories) :to-equal '("/path/to/project/compiled/"
-                                                           "/path/to/project/ignoreme/"
-                                                           "/path/to/project/tmp/"
-                                                           "/path/to/project/log/")))))
-
-(describe "projectile-project-ignored-files"
-  (it "returns list of project ignored files"
-    (let ((files '("/path/to/project/foo.el" "/path/to/project/foo.elc")))
-      (spy-on 'projectile-project-ignored :and-return-value files)
-      (spy-on 'file-directory-p :and-return-value nil)
-      (expect (projectile-project-ignored-files) :to-equal files)
-      (spy-on 'file-directory-p :and-return-value t)
-      (expect (projectile-project-ignored-files) :not :to-be-truthy))))
-
-(describe "projectile-project-ignored-directories"
-  (it "returns list of project ignored directories"
-    (let ((directories '("/path/to/project/tmp" "/path/to/project/log")))
-      (spy-on 'projectile-project-ignored :and-return-value directories)
-      (spy-on 'file-directory-p :and-return-value t)
-      (expect (projectile-project-ignored-directories) :to-equal directories)
-      (spy-on 'file-directory-p :and-return-value nil)
-      (expect (projectile-project-ignored-directories) :not :to-be-truthy))))
-
-(describe "projectile-project-ignored"
-  (it "returns list of ignored files/directories"
-    (spy-on 'projectile-project-root :and-return-value "/path/to/project")
-    (spy-on 'projectile-project-name :and-return-value "project")
-    (spy-on 'projectile-paths-to-ignore :and-return-value (list "log" "tmp" "compiled"))
-    (spy-on 'file-expand-wildcards :and-call-fake
-            (lambda (pattern ignored)
-              (cond
-               ((string-equal pattern "log") "/path/to/project/log")
-               ((string-equal pattern "tmp") "/path/to/project/tmp")
-               ((string-equal pattern "compiled") "/path/to/project/compiled"))))
-    (let* ((file-names '("log" "tmp" "compiled"))
-           (files (mapcar 'projectile-expand-root file-names)))
-      (expect (projectile-project-ignored) :to-equal files))))
 
 (describe "projectile-add-unignored"
   (it "requires explicitly unignoring files inside ignored paths"
@@ -597,12 +574,15 @@
             :not :to-be-truthy)))
 
 (describe "projectile-test-ignored-directory-p"
+  (before-each
+    (spy-on 'projectile-project-root :and-return-value "/path/to/project/")
+    (spy-on 'projectile--dirconfig-ensure))
   (it "ignores specified directory values"
-    (spy-on 'projectile-ignored-directories :and-return-value '("/path/to/project/tmp"))
+    (spy-on 'projectile--dirconfig-ignore :and-return-value '("/tmp"))
     (expect (projectile-ignored-directory-p "/path/to/project/tmp") :to-be-truthy)
     (expect (projectile-ignored-directory-p "/path/to/project/log") :not :to-be-truthy))
   (it "ignores specified directory values with characters that need to be escaped"
-    (spy-on 'projectile-ignored-directories :and-return-value '("/path/to/project/.dir"))
+    (spy-on 'projectile--dirconfig-ignore :and-return-value '("/.dir"))
     (expect (projectile-ignored-directory-p "/path/to/project/.dir") :to-be-truthy)
     (expect (projectile-ignored-directory-p "/path/to/project/log") :not :to-be-truthy)))
 

--- a/test/projectile-indexing-test.el
+++ b/test/projectile-indexing-test.el
@@ -46,7 +46,6 @@
   (it "lists the files in directory and sub-directories"
     (spy-on 'file-directory-p :and-call-fake
             (lambda (filename) (equal filename "/my/root/")))
-    (spy-on 'projectile-patterns-to-ignore)
     (spy-on 'projectile-index-directory :and-call-fake (lambda (dir patterns progress-reporter)
                                                          (expect dir :to-equal "/my/root/")
                                                          '("/my/root/a/b/c" "/my/root/a/d/e")))


### PR DESCRIPTION
Indexing moved onto one gitignore pattern language in #2107, but the grep/ag integration and the two ignore predicates didn't come with it - they kept expanding the dirconfig into absolute path lists of their own. So "ignored" could mean two different things depending on whether you were listing files or searching them.

They now derive from `projectile--ignore-patterns`, the same source indexing uses. That fixes a few things along the way: under `rgrep` a pattern is passed as a pattern rather than as whatever it expanded to on disk, `!` ensure entries can rescue root-anchored paths, and the globally ignored suffixes are no longer double-injected into `grep-find-ignored-files`.

`projectile-ignored-file-p` and `projectile-ignored-directory-p` change signature - the second optional argument is now the project root, not a pre-computed path list - and eight functions that existed only to build those lists are gone, all callerless after the change. Both noted in the changelog.

One inexactness I couldn't remove and documented instead: `*` in a `find -path` glob crosses `/`, so a root-anchored pattern like `-/*.txt` over-prunes under plain `rgrep`. Every other tool takes gitignore globs directly.

New specs assert the equivalence directly: grep's exclusion list and indexing's agree for the same config, and the predicates agree with `projectile-remove-ignored`.