### PR TITLE
Add projectile-doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### New features
 
+- [#2111](https://github.com/bbatsov/projectile/pull/2111): Add `projectile-doctor` (`s-p H`), which reports how Projectile sees the current project and what to do about it.
+  - Covers the project root and which root function found it, the type and matching marker, the indexing method and the exact command that will run, the available external tools, the file count and cache state, and the effective ignore rules.
+  - Ends with a list of findings - each either `ok` or a concrete suggestion.
+  - The report is plain text meant to be pasted into a bug report, and the doctor never populates or invalidates the file cache.
 - [#2104](https://github.com/bbatsov/projectile/pull/2104): Alien indexing now honors Projectile's ignore rules, which it previously skipped entirely.
   - The rules are pushed into the external tool (`git ls-files` exclude pathspecs, `fd --exclude`), so the filtering still happens outside Emacs.
   - Tools that can't express exclusions (svn, fossil, bzr, darcs, pijul, plain `find`) have their output filtered in Emacs Lisp instead.

--- a/doc/modules/ROOT/pages/cheatsheet.adoc
+++ b/doc/modules/ROOT/pages/cheatsheet.adoc
@@ -211,6 +211,9 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p m]
 | Open the Projectile dispatch menu (a `transient` interface to Projectile's commands).
 
+| kbd:[s-p H]
+| Run `projectile-doctor` - a diagnostic report on how Projectile sees the current project (see xref:troubleshooting.adoc#doctor[Troubleshooting]).
+
 | kbd:[s-p x r]
 | Start or visit a shell/REPL/terminal for the project, using the configured backend (`projectile-run`, see below).
 

--- a/doc/modules/ROOT/pages/contributing.adoc
+++ b/doc/modules/ROOT/pages/contributing.adoc
@@ -8,7 +8,10 @@ and https://github.com/bbatsov/projectile/discussions[our discussions board].
 
 If you want to file a bug, please provide all the necessary info listed in
 our issue reporting template (it's loaded automatically when you create a
-new GitHub issue).
+new GitHub issue). Pasting the output of kbd:[M-x] `projectile-doctor` is a
+great start - it describes how Projectile sees your project (root, type,
+indexing, cache, ignore rules) and saves us a round of questions. See
+xref:troubleshooting.adoc#doctor[Troubleshooting] for the details.
 
 It's usually a good idea to try to reproduce (obscure) bugs in isolation. You
 can do this by cloning Projectile's GitHub repo and running `eldev emacs` inside

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -7,6 +7,57 @@ Generally, it's not a bad idea to configure Emacs to spit the backtrace on error
 (instead of just logging the error in the `+*Messages*+` buffer). You can toggle
 this behavior by using kbd:[M-x] `toggle-debug-on-error`.
 
+[[doctor]]
+== Start with the doctor
+
+Before you reach for the debugger, ask Projectile what it thinks is going on:
+
+----
+M-x projectile-doctor
+----
+
+(bound to kbd:[s-p H], and available from the dispatch menu and the Projectile
+menu)
+
+This opens a plain-text report in a `+*projectile-doctor*+` buffer describing
+the project around `default-directory`:
+
+* *Project* - the project root and, crucially, *which* entry of
+`projectile-project-root-functions` found it and off which marker file, the
+project name and where it came from, and whether the root is remote (TRAMP).
+* *Type* - the detected project type and the marker that matched, or an
+explanation of what to do when nothing matched.
+* *Indexing* - the indexing method, whether async indexing is on, the actual
+command Projectile will shell out to (ignore rules and all), and which of
+`git`, `fd` and `rg` are installed.
+* *Files* - how many files are indexed and how long a fresh index took, plus
+the cache state (cached or not, how old, when it expires, whether the cache is
+persistent).
+* *Ignores* - the dirconfig and its parsed `+` / `-` / `!` entries, the
+effective ignore patterns, and which entries in the project root those
+patterns are hiding.  Handy when files you expect to see are missing.
+* *Findings* - a short list of observations, each either `ok` or a concrete
+suggestion (fd not installed, caching off on a large project, a dirconfig
+using the deprecated prefix-less syntax, a remote project indexed
+synchronously, and so on).
+
+Outside a project the report says so and lists the root functions that were
+tried, which is usually enough to figure out why a directory isn't recognized.
+
+The doctor is careful not to change what it measures: it never populates and
+never invalidates the file cache.  When a project isn't cached yet, the doctor
+indexes it with caching switched off and labels that as a fresh index, so
+running it can't turn a cold project warm behind your back.  On remote
+projects, indexing and program lookups are skipped rather than risking a hang,
+and the report marks them as skipped.
+
+kbd:[g] regenerates the report, kbd:[q] buries it.
+
+TIP: The report is plain, copy-pasteable text on purpose.  When you file an
+ issue on the https://github.com/bbatsov/projectile/issues[issue tracker],
+ pasting the output of `projectile-doctor` answers most of the questions we'd
+ otherwise have to ask you.
+
 == Debugging Projectile commands
 
 Emacs features a super powerful built-in
@@ -69,6 +120,10 @@ Note that Projectile caches the operation of checking which project
 (if any) a file belongs to. If you have already opened a file, then
 later added a marker file like `.projectile`, run `M-x
 projectile-invalidate-cache` to reset the cache.
+
+`M-x projectile-doctor` tells you exactly which of the
+`projectile-project-root-functions` claimed the directory and off which marker
+file, which usually settles the "why *this* root?" question on the spot.
 
 === I upgraded Projectile using `package.el` and nothing changed
 

--- a/projectile.el
+++ b/projectile.el
@@ -11671,6 +11671,526 @@ entered, keeping the entries made so far."
       (save-buffer))))
 
 
+;;; Project diagnostics (the doctor)
+;;
+;; `projectile-doctor' renders what Projectile thinks is going on in the
+;; current project - and why - into a plain, copy-pasteable buffer.  It
+;; computes nothing new: every value shown comes from the same accessor
+;; the rest of Projectile uses.
+;;
+;; A note on side effects, since a diagnostic that changes what it
+;; diagnoses is worse than useless.  The doctor reports the caches as it
+;; finds them: it never populates and never invalidates
+;; `projectile-projects-cache'.  When a project's file list isn't cached
+;; yet, the doctor indexes it with caching bound off, times that run and
+;; labels it a fresh index in the report - so running the doctor can't
+;; turn a cold project warm (or a warm one cold) behind your back.  The
+;; dirconfig is read with the uncached parser for the same reason.  The
+;; project root and VCS caches are the exception: those are populated by
+;; merely asking, exactly as any other command would.
+;;
+;; Anything whose cost is unknown - indexing, `executable-find', listing
+;; the project root - is skipped for remote (TRAMP) projects and marked
+;; as skipped in the report, so the doctor can't hang on a slow host.
+
+(defconst projectile-doctor-buffer-name "*projectile-doctor*"
+  "The name of the buffer `projectile-doctor' renders its report in.")
+
+(defconst projectile-doctor--large-project 10000
+  "File count above which a project is considered large by the doctor.")
+
+(defconst projectile-doctor--huge-project 50000
+  "File count above which the doctor suspects the ignore rules.")
+
+(defconst projectile-doctor--label-width 22
+  "Column width of the labels in a doctor report.")
+
+(defvar-local projectile-doctor--directory nil
+  "The directory a doctor report was generated from.
+Used by the report buffer's `revert-buffer' to regenerate it.")
+
+(defun projectile-doctor--root-function (dir)
+  "Return the `projectile-project-root-functions' entry that roots DIR.
+That is the first function in the list to return a project root for
+DIR, which is the one whose answer function `projectile-project-root'
+used.  Returns nil when no function claims DIR."
+  (let ((true-dir (ignore-errors (file-truename dir))))
+    (seq-find (lambda (func)
+                (ignore-errors
+                  (funcall func (if (eq func 'projectile-root-local)
+                                    dir
+                                  (or true-dir dir)))))
+              projectile-project-root-functions)))
+
+(defun projectile-doctor--root-marker (func root)
+  "Return the marker file in ROOT that made FUNC report it as a root.
+Returns nil for a root function with no marker list of its own (e.g.
+`projectile-root-local', which reads a buffer-local variable) or when
+no marker can be pinned down."
+  (when-let* ((markers (pcase func
+                         ('projectile-root-marked
+                          (list projectile-dirconfig-file))
+                         ('projectile-root-bottom-up
+                          projectile-project-root-files-bottom-up)
+                         ('projectile-root-top-down
+                          projectile-project-root-files)
+                         ('projectile-root-top-down-recurring
+                          projectile-project-root-files-top-down-recurring))))
+    (seq-find (lambda (marker)
+                (ignore-errors
+                  (projectile-file-exists-p
+                   (projectile-expand-file-name-wildcard marker root))))
+              markers)))
+
+(defun projectile-doctor--type-marker (type)
+  "Return the registered marker files of the project TYPE, or nil."
+  (when-let* ((record (assq type projectile-project-types)))
+    (plist-get (cdr record) 'marker-files)))
+
+(defun projectile-doctor--executable (name remote)
+  "Report the availability of the NAME executable.
+Returns `present', `missing', or `skipped' when the project is REMOTE
+and looking the program up would mean a TRAMP round-trip."
+  (cond (remote 'skipped)
+        ((and name (executable-find name)) 'present)
+        (t 'missing)))
+
+(defun projectile-doctor--index-command (root vcs)
+  "Return the external indexing command Projectile would run in ROOT.
+VCS is the project's version-control system.  Returns nil under the
+`native' indexing method, which shells out to nothing."
+  (unless (eq projectile-indexing-method 'native)
+    (let ((default-directory root))
+      (ignore-errors (projectile--alien-ext-command vcs root)))))
+
+(defun projectile-doctor--file-info (root remote)
+  "Return a plist describing ROOT's file list and how it was obtained.
+The cached list is used when there is one.  Otherwise the project is
+indexed with caching bound off, so the doctor doesn't warm a cache the
+user didn't ask it to warm, and the timing of that run is reported.
+Indexing is skipped altogether when the project is REMOTE."
+  (let ((cached (gethash root projectile-projects-cache)))
+    (cond
+     (cached (list :file-count (length cached) :files-source 'cache))
+     (remote (list :files-source 'skipped))
+     (t (let* ((start (float-time))
+               (files (condition-case err
+                          ;; Index without touching the cache: no entry is
+                          ;; stored, no stale entry is evicted, no file
+                          ;; watch is armed.
+                          (let ((projectile-enable-caching nil)
+                                (projectile-files-cache-expire nil))
+                            (projectile-project-files root))
+                        (error (cons 'error (error-message-string err))))))
+          (if (eq (car-safe files) 'error)
+              (list :files-source 'error :files-error (cdr files))
+            (list :file-count (length files)
+                  :index-time (- (float-time) start)
+                  :files-source 'fresh)))))))
+
+(defun projectile-doctor--excluded-entries (root patterns)
+  "Return ROOT's immediate entries excluded by the ignore PATTERNS.
+Directories are returned with a trailing slash, the way the patterns
+match them."
+  (when-let* ((re (projectile--compile-ignore-patterns patterns))
+              (entries (ignore-errors
+                         (directory-files
+                          root t directory-files-no-dot-files-regexp))))
+    (let ((case-fold-search nil))
+      (delq nil
+            (mapcar (lambda (entry)
+                      (let ((rel (concat (file-name-nondirectory entry)
+                                         (if (file-directory-p entry) "/" ""))))
+                        (and (string-match-p re rel) rel)))
+                    entries)))))
+
+(defun projectile-doctor--collect (&optional dir)
+  "Collect the diagnostic data for DIR's project as a plist.
+DIR defaults to `default-directory'.  Outside a project the plist has
+a nil `:root' and the rendering degrades to saying so."
+  (let* ((dir (or dir default-directory))
+         (root (ignore-errors (projectile-project-root dir))))
+    (if (null root)
+        (list :dir dir :root nil)
+      (let* ((remote (file-remote-p root))
+             ;; The doctor reports prefix-less dirconfig lines as a
+             ;; finding; it shouldn't also pop up the warning buffer over
+             ;; the report it's about to show.
+             (projectile-warn-on-prefixless-dirconfig-lines nil)
+             (default-directory root)
+             (vcs (ignore-errors (projectile-project-vcs root)))
+             (type (ignore-errors (projectile-project-type)))
+             (root-func (projectile-doctor--root-function dir))
+             (ignore-patterns (ignore-errors (projectile--ignore-patterns root)))
+             (cache-time (gethash root projectile-projects-cache-time)))
+        (append
+         (list :dir dir
+               :root root
+               :remote remote
+               :root-function root-func
+               :root-marker (and root-func
+                                 (projectile-doctor--root-marker root-func root))
+               :name (ignore-errors (projectile-project-name root))
+               :name-source (if projectile-project-name
+                                'local-variable
+                              projectile-project-name-function)
+               :type type
+               :type-source (if projectile-project-type 'local-variable 'detected)
+               :type-marker (unless projectile-project-type
+                              (projectile-doctor--type-marker type))
+               :vcs vcs
+               :indexing-method projectile-indexing-method
+               :async-indexing projectile-async-indexing
+               :index-command (projectile-doctor--index-command root vcs)
+               :git (projectile-doctor--executable "git" remote)
+               :fd (projectile-doctor--executable
+                    (ignore-errors (projectile-fd-executable-for root)) remote)
+               :rg (projectile-doctor--executable "rg" remote)
+               :git-use-fd projectile-git-use-fd
+               :caching projectile-enable-caching
+               :cache-time cache-time
+               :cache-age (and cache-time
+                               (- (projectile-time-seconds) cache-time))
+               :cache-expire projectile-files-cache-expire
+               :cache-file (and (projectile-persistent-cache-p)
+                                (not remote)
+                                (let ((file (projectile-project-cache-file root)))
+                                  (and (file-exists-p file) file)))
+               :dirconfig-file (projectile-dirconfig-file)
+               ;; The uncached parser, so the doctor doesn't seed the
+               ;; dirconfig cache as a side effect of looking.
+               :dirconfig (ignore-errors
+                            (projectile--parse-dirconfig-file-uncached))
+               :ignore-patterns ignore-patterns
+               :ensure-patterns (ignore-errors (projectile--ensure-patterns root))
+               :excluded-entries (unless remote
+                                   (projectile-doctor--excluded-entries
+                                    root ignore-patterns))
+               :projectile-mode (bound-and-true-p projectile-mode))
+         (projectile-doctor--file-info root remote))))))
+
+
+;;;; Doctor findings
+
+(defun projectile-doctor--findings (data)
+  "Return the list of findings for the report DATA.
+Each finding is a cons of a status symbol (`ok', `warn' or `info') and
+a one-line description."
+  (let* ((remote (plist-get data :remote))
+         (method (plist-get data :indexing-method))
+         (external (memq method '(alien hybrid)))
+         (count (plist-get data :file-count))
+         (cfg (plist-get data :dirconfig))
+         (findings nil))
+    (push (if (eq (plist-get data :type) 'generic)
+              (cons 'warn (concat "Project type not detected (generic).  "
+                                  "Register a type with "
+                                  "`projectile-register-project-type', or set "
+                                  "`projectile-project-type' in .dir-locals.el."))
+            (cons 'ok (format "Project type detected: %s."
+                              (plist-get data :type))))
+          findings)
+    (when (and external (eq (plist-get data :vcs) 'git))
+      (push (pcase (plist-get data :git)
+              ('present (cons 'ok "git is installed and lists the project files."))
+              ('skipped (cons 'info "git availability not checked (remote project)."))
+              (_ (cons 'warn (concat "git is not installed, but this is a git "
+                                     "project - indexing falls back to `find'."))))
+            findings))
+    (when external
+      (push (pcase (plist-get data :fd)
+              ('present (cons 'ok "fd is installed and used for fast indexing."))
+              ('skipped (cons 'info "fd availability not checked (remote project)."))
+              (_ (cons 'warn (concat "fd is not installed.  Installing it speeds "
+                                     "up indexing noticeably on large projects "
+                                     "(see `projectile-git-use-fd')."))))
+            findings))
+    (when (and (eq (plist-get data :rg) 'missing) (not remote))
+      (push (cons 'info (concat "ripgrep (rg) is not installed; "
+                                "`projectile-ripgrep' and the fast path of the "
+                                "search reviewer need it."))
+            findings))
+    (when (integerp count)
+      (cond
+       ((>= count projectile-doctor--huge-project)
+        (push (cons 'warn (format (concat "%d files indexed.  That's a lot - "
+                                          "check the ignore rules above, a "
+                                          "build or vendor directory may be "
+                                          "sneaking in.")
+                                  count))
+              findings))
+       ((and (>= count projectile-doctor--large-project)
+             (not (plist-get data :caching)))
+        (push (cons 'warn (format (concat "%d files indexed with caching "
+                                          "disabled.  Set "
+                                          "`projectile-enable-caching' to t "
+                                          "(or `persistent').")
+                                  count))
+              findings))
+       (t (push (cons 'ok (format "%d files indexed." count)) findings))))
+    (when (and remote (not (plist-get data :async-indexing)))
+      (push (cons 'warn (concat "Remote project with `projectile-async-indexing' "
+                                "off - indexing will block Emacs for as long as "
+                                "the remote takes."))
+            findings))
+    (when cfg
+      (when (projectile-dirconfig-keep cfg)
+        (push (cons 'info (format (concat "The dirconfig has %d `+' keep "
+                                          "entries, so the project is "
+                                          "restricted to those subdirectories "
+                                          "- everything else is invisible to "
+                                          "Projectile.")
+                                  (length (projectile-dirconfig-keep cfg))))
+              findings))
+      (when (projectile-dirconfig-prefixless-ignore cfg)
+        (push (cons 'warn (concat "The dirconfig has lines without a "
+                                  "`+'/`-'/`!' prefix.  They are treated as "
+                                  "ignore rules for now, but the implicit form "
+                                  "is being phased out - prefix them with `-'."))
+              findings)))
+    (unless (plist-get data :projectile-mode)
+      (push (cons 'warn (concat "`projectile-mode' is not enabled; "
+                                "Projectile's keymap and mode line are "
+                                "inactive."))
+            findings))
+    (nreverse findings)))
+
+
+;;;; Doctor report rendering
+
+(defun projectile-doctor--field (label value)
+  "Insert a LABEL/VALUE line into the report.
+VALUE is rendered with `%s'; a nil or empty one reads as \"n/a\"."
+  (insert label
+          (make-string (max 1 (- projectile-doctor--label-width (length label)))
+                       ?\s)
+          (if (or (null value) (equal value "")) "n/a" (format "%s" value))
+          "\n"))
+
+(defun projectile-doctor--section (title)
+  "Insert the header of a report section titled TITLE."
+  (insert "\n" title "\n" (make-string (length title) ?-) "\n"))
+
+(defun projectile-doctor--list-field (label items)
+  "Insert LABEL followed by ITEMS, one per line."
+  (if (null items)
+      (projectile-doctor--field label "none")
+    (projectile-doctor--field label (car items))
+    (dolist (item (cdr items))
+      (insert (make-string projectile-doctor--label-width ?\s) item "\n"))))
+
+(defun projectile-doctor--executable-string (status)
+  "Return the human-readable rendering of an executable STATUS."
+  (pcase status
+    ('present "present")
+    ('missing "missing")
+    (_ "not checked (remote)")))
+
+(defun projectile-doctor--files-string (data)
+  "Return the file-count line of the report DATA."
+  (pcase (plist-get data :files-source)
+    ('cache (format "%d (from the cache)" (plist-get data :file-count)))
+    ('fresh (format "%d (fresh index, %.2fs - not cached by the doctor)"
+                    (plist-get data :file-count)
+                    (plist-get data :index-time)))
+    ('skipped "not indexed (skipped for a remote project)")
+    ('error (format "indexing failed: %s" (plist-get data :files-error)))
+    (_ "n/a")))
+
+(defun projectile-doctor--cache-string (data)
+  "Return the cache-state line of the report DATA."
+  (let ((age (plist-get data :cache-age))
+        (expire (plist-get data :cache-expire)))
+    (cond
+     ((null age) "not cached")
+     (expire (format "cached %ds ago (expires after %ds)" age expire))
+     (t (format "cached %ds ago (never expires)" age)))))
+
+(defun projectile-doctor--render-no-project (data)
+  "Render the no-project report for DATA."
+  (projectile-doctor--section "Project")
+  (projectile-doctor--field "directory" (plist-get data :dir))
+  (projectile-doctor--field "root" "none - not inside a project")
+  (projectile-doctor--list-field
+   "root functions tried"
+   (mapcar #'symbol-name projectile-project-root-functions))
+  (insert (format "
+None of the functions above found a project marker at or above that
+directory.  To make it a project, create a `%s' file in it (an
+empty one will do) or put it under version control.
+
+If you did that already and nothing changed, run
+`projectile-invalidate-cache' first - the \"not a project\" answer is
+cached too.
+" projectile-dirconfig-file)))
+
+(defun projectile-doctor--render (data)
+  "Render the report described by DATA into the current buffer."
+  (insert "Projectile doctor report\n"
+          "========================\n"
+          (format "projectile %s, Emacs %s, %s\n"
+                  projectile-version emacs-version system-type))
+  (if (null (plist-get data :root))
+      (projectile-doctor--render-no-project data)
+    (projectile-doctor--section "Project")
+    (projectile-doctor--field "root" (plist-get data :root))
+    (projectile-doctor--field
+     "detected by"
+     (when-let* ((func (plist-get data :root-function)))
+       (concat (symbol-name func)
+               (if-let* ((marker (plist-get data :root-marker)))
+                   (format " (marker: %s)" marker)
+                 ""))))
+    (projectile-doctor--field
+     "name"
+     (format "%s (%s)" (plist-get data :name)
+             (if (eq (plist-get data :name-source) 'local-variable)
+                 "from the `projectile-project-name' variable"
+               (format "via %s" (plist-get data :name-source)))))
+    (projectile-doctor--field "remote" (or (plist-get data :remote)
+                                           "no (local project)"))
+    (projectile-doctor--field "projectile-mode"
+                              (if (plist-get data :projectile-mode) "on" "off"))
+
+    (projectile-doctor--section "Type")
+    (projectile-doctor--field
+     "type"
+     (format "%s (%s)" (plist-get data :type)
+             (if (eq (plist-get data :type-source) 'local-variable)
+                 "from the `projectile-project-type' variable"
+               "auto-detected")))
+    (projectile-doctor--field
+     "marker"
+     (when-let* ((marker (plist-get data :type-marker)))
+       (if (functionp marker)
+           (format "%s (predicate)" marker)
+         (string-join (ensure-list marker) " "))))
+    (projectile-doctor--field "vcs" (plist-get data :vcs))
+    (when (eq (plist-get data :type) 'generic)
+      (insert "
+No registered project type matched this project's files.  That only
+affects the type-specific commands (compile, test, run, related files);
+file listing and search work regardless.  Set `projectile-project-type'
+in .dir-locals.el to pin a type, or register one with
+`projectile-register-project-type'.
+"))
+
+    (projectile-doctor--section "Indexing")
+    (projectile-doctor--field "method" (plist-get data :indexing-method))
+    (projectile-doctor--field "async indexing"
+                              (if (plist-get data :async-indexing) "on" "off"))
+    (projectile-doctor--field "command"
+                              (or (plist-get data :index-command)
+                                  "none (native indexing walks the tree in Lisp)"))
+    (projectile-doctor--field "git" (projectile-doctor--executable-string
+                                     (plist-get data :git)))
+    (projectile-doctor--field
+     "fd" (concat (projectile-doctor--executable-string (plist-get data :fd))
+                  (unless (plist-get data :git-use-fd)
+                    " (not used - projectile-git-use-fd is nil)")))
+    (projectile-doctor--field "rg" (projectile-doctor--executable-string
+                                    (plist-get data :rg)))
+
+    (projectile-doctor--section "Files")
+    (projectile-doctor--field "files" (projectile-doctor--files-string data))
+    (projectile-doctor--field "caching" (pcase (plist-get data :caching)
+                                          ('nil "disabled")
+                                          ('persistent "persistent")
+                                          (_ "enabled (this session)")))
+    (projectile-doctor--field "cache state" (projectile-doctor--cache-string data))
+    (projectile-doctor--field "cache file" (plist-get data :cache-file))
+
+    (projectile-doctor--section "Ignores")
+    (let ((cfg (plist-get data :dirconfig)))
+      (projectile-doctor--field
+       "dirconfig"
+       (if cfg
+           (format "%s (keep %d, ignore %d, ensure %d)"
+                   (plist-get data :dirconfig-file)
+                   (length (projectile-dirconfig-keep cfg))
+                   (length (projectile-dirconfig-ignore cfg))
+                   (length (projectile-dirconfig-ensure cfg)))
+         (format "%s (absent)" (plist-get data :dirconfig-file))))
+      (when cfg
+        (projectile-doctor--list-field "keep (+)"
+                                       (projectile-dirconfig-keep cfg))
+        (projectile-doctor--list-field "ignore (-)"
+                                       (projectile-dirconfig-ignore cfg))
+        (projectile-doctor--list-field "ensure (!)"
+                                       (projectile-dirconfig-ensure cfg))))
+    (projectile-doctor--list-field "ignore patterns"
+                                   (plist-get data :ignore-patterns))
+    (projectile-doctor--list-field "ensure patterns"
+                                   (plist-get data :ensure-patterns))
+    (projectile-doctor--list-field "ignored in root"
+                                   (if (plist-get data :remote)
+                                       (list "not checked (remote)")
+                                     (plist-get data :excluded-entries)))
+
+    (projectile-doctor--section "Findings")
+    (dolist (finding (projectile-doctor--findings data))
+      (insert (format "%-6s%s\n"
+                      (pcase (car finding)
+                        ('ok "ok")
+                        ('warn "warn")
+                        (_ "info"))
+                      (cdr finding))))))
+
+(defvar projectile-doctor-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "q") #'quit-window)
+    map)
+  "Keymap for `projectile-doctor-mode'.")
+
+(define-derived-mode projectile-doctor-mode special-mode "Projectile-Doctor"
+  "Major mode for the `projectile-doctor' report, read-only.
+
+The report is deliberately plain text, so it can be pasted verbatim into
+a bug report.  \\<projectile-doctor-mode-map>\\[revert-buffer] regenerates it for the same directory
+and \\[quit-window] buries it.
+
+\\{projectile-doctor-mode-map}"
+  (setq-local revert-buffer-function
+              (lambda (&rest _)
+                (projectile-doctor--report projectile-doctor--directory))))
+
+(defun projectile-doctor--report (dir)
+  "Render a doctor report for DIR into the report buffer and return it."
+  (let ((data (projectile-doctor--collect dir))
+        (buffer (get-buffer-create projectile-doctor-buffer-name)))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (projectile-doctor-mode)
+        (setq-local projectile-doctor--directory dir)
+        (projectile-doctor--render data)
+        (goto-char (point-min))))
+    buffer))
+
+;;;###autoload
+(defun projectile-doctor ()
+  "Diagnose Projectile's view of the current project.
+
+Open a read-only report describing the project Projectile sees around
+`default-directory': its root and which of
+`projectile-project-root-functions' found it, the detected project type
+and the marker that matched, the indexing method and the very command
+that will be run, which external tools are available, the file count and
+the cache state, the ignore rules in effect, and a list of findings -
+things that look fine and things worth changing.  Outside a project the
+report says so and explains how to mark the directory as one.
+
+The report is plain text, meant to be pasted into a bug report.
+
+The doctor doesn't change what it measures: it never populates and never
+invalidates the file cache.  A project that isn't cached yet is indexed
+with caching switched off and that run is reported as a fresh index.  On
+remote projects indexing and program lookups are skipped rather than
+risking a hang, and the report says so."
+  (interactive)
+  (pop-to-buffer (projectile-doctor--report default-directory)))
+
+
 ;;; Projectile Minor mode
 
 (defcustom projectile-mode-line-prefix
@@ -11811,6 +12331,7 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "x G") #'projectile-run-ghostel)
     (define-key map (kbd "x 4 G") #'projectile-run-ghostel-other-window)
     ;; misc
+    (define-key map (kbd "H") #'projectile-doctor)
     (define-key map (kbd "z") #'projectile-cache-current-file)
     (define-key map (kbd "<left>") #'projectile-previous-project-buffer)
     (define-key map (kbd "<right>") #'projectile-next-project-buffer)
@@ -12096,7 +12617,8 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("p" "switch project" projectile-dispatch-switch-project)
       ("q" "switch open project" projectile-switch-open-project)
       ("A" "add known project" projectile-add-known-project)
-      ("v" "vc" projectile-vc)]
+      ("v" "vc" projectile-vc)
+      ("H" "doctor" projectile-doctor)]
      ["Lifecycle"
       ("cc" "compile" projectile-compile-project)
       ("ct" "test" projectile-test-project)
@@ -12200,7 +12722,8 @@ search/replace case-sensitive, `--word' makes it match whole words,
          "--"
          ["Toggle project wide read-only" projectile-toggle-project-read-only]
          ["Edit .dir-locals.el" projectile-edit-dir-locals]
-         ["Project info" projectile-project-info])
+         ["Project info" projectile-project-info]
+         ["Project diagnostics (doctor)" projectile-doctor])
         ("Search"
          ["Search (default backend)" projectile-search]
          ["Search with grep" projectile-grep]

--- a/test/projectile-doctor-test.el
+++ b/test/projectile-doctor-test.el
@@ -1,0 +1,164 @@
+;;; projectile-doctor-test.el --- Tests for projectile-doctor -*- lexical-binding: t -*-
+
+;; Copyright © 2011-2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for `projectile-doctor' - the report rendering, its behavior
+;; outside a project, its hands-off treatment of the file cache, and the
+;; findings logic (which is driven off a plain plist and so can be tested
+;; without a project at all).
+
+;;; Code:
+
+(require 'projectile-test-helpers)
+
+(defun projectile-doctor-test--render (data)
+  "Render DATA and return the report as a string."
+  (with-temp-buffer
+    (projectile-doctor--render data)
+    (buffer-string)))
+
+(describe "projectile-doctor"
+  (it "renders a report for the current project"
+    (projectile-test-with-stub-root "project/" ("src/a.el" ".projectile")
+      (let ((projectile-indexing-method 'native)
+            (projectile-enable-caching nil))
+        (unwind-protect
+            (progn
+              (projectile-doctor)
+              (with-current-buffer projectile-doctor-buffer-name
+                (expect major-mode :to-be 'projectile-doctor-mode)
+                (expect buffer-read-only :to-be t)
+                (let ((report (buffer-string)))
+                  (dolist (section '("Project" "Type" "Indexing"
+                                     "Files" "Ignores" "Findings"))
+                    (expect report :to-match section))
+                  (expect report :to-match (projectile-project-root))
+                  (expect report :to-match "detected by")
+                  (expect report :to-match "fresh index"))))
+          (kill-buffer projectile-doctor-buffer-name)))))
+
+  (it "reports which root function found the project"
+    (projectile-test-with-sandbox
+      (projectile-test-with-files ("project/.projectile" "project/src/a.el")
+        (let* ((dir (file-truename (expand-file-name "project/src/")))
+               (data (projectile-doctor--collect dir)))
+          (expect (plist-get data :root-function) :to-be 'projectile-root-marked)
+          (expect (plist-get data :root-marker) :to-equal ".projectile")))))
+
+  (it "degrades gracefully outside a project"
+    (projectile-test-with-sandbox
+      (projectile-test-with-files ("nothing/a.el")
+        (spy-on 'projectile-project-root :and-return-value nil)
+        (let ((report (projectile-doctor-test--render
+                       (projectile-doctor--collect
+                        (expand-file-name "nothing/")))))
+          (expect report :to-match "not inside a project")
+          (expect report :to-match "projectile-root-bottom-up")
+          (expect report :to-match "\\.projectile")))))
+
+  (it "leaves the file cache exactly as it found it"
+    (projectile-test-with-stub-root "project/" ("src/a.el")
+      (let ((projectile-indexing-method 'native)
+            (projectile-enable-caching t))
+        (projectile-doctor--collect (projectile-project-root))
+        (expect (gethash (projectile-project-root) projectile-projects-cache)
+                :to-be nil)
+        (expect (gethash (projectile-project-root) projectile-projects-cache-time)
+                :to-be nil))))
+
+  (it "uses the cached file list when there is one"
+    (projectile-test-with-stub-root "project/" ("src/a.el")
+      (puthash (projectile-project-root) '("one" "two" "three")
+               projectile-projects-cache)
+      (let ((data (projectile-doctor--collect (projectile-project-root))))
+        (expect (plist-get data :files-source) :to-be 'cache)
+        (expect (plist-get data :file-count) :to-equal 3)))))
+
+(defun projectile-doctor-test--finding (data pattern)
+  "Return DATA's finding whose text matches PATTERN, if any."
+  (seq-find (lambda (finding) (string-match-p pattern (cdr finding)))
+            (projectile-doctor--findings data)))
+
+(describe "projectile-doctor findings"
+  (it "suggests installing fd when it's missing under alien indexing"
+    (let ((finding (projectile-doctor-test--finding
+                    '(:indexing-method alien :fd missing :projectile-mode t)
+                    "fd is not installed")))
+      (expect (car finding) :to-be 'warn))
+    (let ((finding (projectile-doctor-test--finding
+                    '(:indexing-method alien :fd present :projectile-mode t)
+                    "fd is installed")))
+      (expect (car finding) :to-be 'ok)))
+
+  (it "flags a large project with caching disabled"
+    (let ((finding (projectile-doctor-test--finding
+                    '(:indexing-method native :file-count 20000
+                      :caching nil :projectile-mode t)
+                    "caching")))
+      (expect (car finding) :to-be 'warn))
+    (expect (projectile-doctor-test--finding
+             '(:indexing-method native :file-count 20000
+               :caching t :projectile-mode t)
+             "caching")
+            :to-be nil))
+
+  (it "flags a huge project regardless of caching"
+    (let ((finding (projectile-doctor-test--finding
+                    '(:indexing-method alien :file-count 100000
+                      :caching t :projectile-mode t)
+                    "That's a lot")))
+      (expect (car finding) :to-be 'warn)))
+
+  (it "flags a remote project indexed synchronously"
+    (let ((finding (projectile-doctor-test--finding
+                    '(:indexing-method alien :remote "/ssh:host:"
+                      :async-indexing nil :projectile-mode t)
+                    "Remote project")))
+      (expect (car finding) :to-be 'warn))
+    (expect (projectile-doctor-test--finding
+             '(:indexing-method alien :remote "/ssh:host:"
+               :async-indexing t :projectile-mode t)
+             "Remote project")
+            :to-be nil))
+
+  (it "flags prefix-less dirconfig entries and reports keep entries"
+    (let* ((cfg (make-projectile-dirconfig :keep '("src/")
+                                           :ignore '("tmp")
+                                           :prefixless-ignore '("tmp")))
+           (data (list :indexing-method 'native :projectile-mode t
+                       :dirconfig cfg)))
+      (expect (car (projectile-doctor-test--finding data "without a"))
+              :to-be 'warn)
+      (expect (car (projectile-doctor-test--finding data "keep"))
+              :to-be 'info)))
+
+  (it "warns when the project type wasn't detected"
+    (expect (car (projectile-doctor-test--finding
+                  '(:type generic :indexing-method native :projectile-mode t)
+                  "type not detected"))
+            :to-be 'warn)
+    (expect (car (projectile-doctor-test--finding
+                  '(:type emacs-eldev :indexing-method native :projectile-mode t)
+                  "type detected"))
+            :to-be 'ok)))
+
+(provide 'projectile-doctor-test)
+
+;;; projectile-doctor-test.el ends here


### PR DESCRIPTION
`M-x projectile-doctor` (`s-p H`) opens a report explaining what Projectile thinks is going on in the current project: which root function found the root and via which marker, the detected type and the marker that matched, the actual indexing command that will run, which external tools are present, file count and cache state, the effective ignore patterns, and a short list of findings.

The attribution is the part I care about - "detected by projectile-root-bottom-up (marker: .git)" answers "why is my root wrong" directly, and outside a project it lists every root function tried and points at `.projectile`, including the reminder that the negative answer is cached too. The intent is that "not detected" and "why is this slow" become self-serve, and that issue reports can start with this output.

It reports the cache as found and never populates or invalidates it - a diagnostic that warms your cache changes the thing you are diagnosing. An uncached project is indexed with caching bound off and the line says so. Remote roots skip the expensive probes and are marked as skipped.

Almost all of it is presentation of values Projectile already computes, through the real accessors rather than reimplemented.