### PR TITLE
Add a project dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### New features
 
+- [#2112](https://github.com/bbatsov/projectile/pull/2112): Add `projectile-dashboard` (`s-p P`), a buffer summarising the current project that also works as a `projectile-switch-project-action`.
+  - Covers the project name, root, type and file count, the branch and how many files are modified or untracked, the files you visit most (ranked by frecency), the project's tasks and its configured lifecycle commands.
+  - Every entry is a button: `RET` visits a file, runs a task or a lifecycle command, or opens the VC interface.
+  - It never indexes the project and only queries git on a local git project, so it stays cheap enough for a project switch; `projectile-dashboard-sections` controls what's shown.
 - [#2111](https://github.com/bbatsov/projectile/pull/2111): Add `projectile-doctor` (`s-p H`), which reports how Projectile sees the current project and what to do about it.
   - Covers the project root and which root function found it, the type and matching marker, the indexing method and the exact command that will run, the available external tools, the file count and cache state, and the effective ignore rules.
   - Ends with a list of findings - each either `ok` or a concrete suggestion.

--- a/doc/modules/ROOT/pages/cheatsheet.adoc
+++ b/doc/modules/ROOT/pages/cheatsheet.adoc
@@ -211,6 +211,9 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p m]
 | Open the Projectile dispatch menu (a `transient` interface to Projectile's commands).
 
+| kbd:[s-p P]
+| Open `projectile-dashboard` - a summary of the current project (branch, recent files, tasks, lifecycle commands), with every entry actionable (see xref:usage.adoc#dashboard[Project dashboard]).
+
 | kbd:[s-p H]
 | Run `projectile-doctor` - a diagnostic report on how Projectile sees the current project (see xref:troubleshooting.adoc#doctor[Troubleshooting]).
 

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -73,6 +73,24 @@ menu so you can choose what to do in it.
 NOTE: This requires the optional `transient` dependency. Without it the prefix
 argument is ignored and the usual `projectile-switch-project-action` runs.
 
+[[dashboard-switch-action]]
+=== `projectile-dashboard`
+
+[source,elisp]
+----
+(setq projectile-switch-project-action #'projectile-dashboard)
+----
+
+With this setting you land in a summary of the project you just switched to -
+its type and file count, the branch and how dirty the working tree is, the
+files you were last working on, and the tasks and lifecycle commands you can
+run - all of it actionable with kbd:[RET]. It's the closest thing Projectile
+has to `project.el`'s command menu, except it also tells you where you are.
+
+The dashboard is built to be cheap enough for this: it never indexes the
+project (a cold project simply reports "not indexed yet") and it skips the VCS
+query on remote projects. See xref:usage.adoc#dashboard[Project dashboard].
+
 === `projectile-find-file-in-known-projects`
 
 Similar to `projectile-find-file` but lists all files in all known projects. Since

--- a/doc/modules/ROOT/pages/configuration_index.adoc
+++ b/doc/modules/ROOT/pages/configuration_index.adoc
@@ -62,6 +62,12 @@ and the other reference pages.
 | `projectile-darcs-command`
 | Command used by projectile to get the files in a darcs project.
 
+| `projectile-dashboard-recent-files`
+| How many recently visited files ‘projectile-dashboard’ lists.
+
+| `projectile-dashboard-sections`
+| The sections ‘projectile-dashboard’ renders, in order.
+
 | `projectile-default-src-directory`
 | The default value of a project’s src-dir property.
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -489,6 +489,46 @@ NOTE: `projectile-dispatch` is powered by `transient`, which is bundled with
 Emacs 28.1+ (Projectile's minimum), so the menu is always available. It's bound
 to kbd:[s-p m], and kbd:[C-u s-p p] opens it when switching projects.
 
+[[dashboard]]
+== Project dashboard
+
+`projectile-dashboard` (kbd:[s-p P]) opens a buffer that sums up the project
+you're in:
+
+* the project's name, root, type and file count
+* the version control system, the current branch and how many files are
+modified or untracked
+* the project files you visit most, ranked by frecency - the same ranking
+`projectile-find-file`'s completion uses
+* the project's xref:tasks.adoc[tasks]
+* the lifecycle commands (compile, test, run, ...) that are configured for it
+
+Everything worth acting on is a button, so the dashboard doubles as a launcher.
+kbd:[RET] on a file visits it, on a task or a lifecycle command runs it, on the
+branch opens the project's VC interface (Magit, if you have it), and on the
+root opens it in Dired. kbd:[TAB] moves to the next button, kbd:[g] refreshes
+and kbd:[q] buries the buffer.
+
+`projectile-dashboard-sections` picks which sections show up and in what order,
+and `projectile-dashboard-recent-files` how many recent files are listed:
+
+[source,elisp]
+----
+(setq projectile-dashboard-sections '(project vcs recent))
+(setq projectile-dashboard-recent-files 20)
+----
+
+The dashboard is deliberately cheap, so that it works as a
+`projectile-switch-project-action` (see
+xref:configuration.adoc#dashboard-switch-action[Configuration]). It never
+indexes the project and never touches the file cache: a project that isn't
+cached yet is reported as "not indexed yet" rather than indexed on the spot.
+The branch and status come from two short `git` commands, and only on a local
+git project - on a remote (TRAMP) project, or under any other VCS, the section
+says so instead of reaching over the wire. Lifecycle commands and tasks whose
+command is a function are listed but not resolved, since resolving one can pop
+up a prompt.
+
 == Using Projectile with project.el
 
 Starting with version 2.7 Projectile bundles some integration with

--- a/projectile.el
+++ b/projectile.el
@@ -12190,6 +12190,526 @@ risking a hang, and the report says so."
   (interactive)
   (pop-to-buffer (projectile-doctor--report default-directory)))
 
+;;; Project dashboard
+;;
+;; `projectile-dashboard' summarises a project in one buffer: what the
+;; project is, what its VCS thinks of it, the files you keep coming back
+;; to, and what you can run in it.  Every interesting entry is a button,
+;; so the dashboard doubles as a launcher - which is what makes it a
+;; usable `projectile-switch-project-action'.
+;;
+;; Being a switch action is what shapes the whole thing.  It runs right
+;; after a switch, on a project that is very likely cold, and it must not
+;; make the switch feel slow.  So it reports only what is already there:
+;; it never indexes, and an uncached project is shown as "not indexed
+;; yet" rather than indexed on the spot, which would both cost seconds
+;; and warm a cache the user didn't ask for.  Like the doctor, it neither
+;; populates nor invalidates `projectile-projects-cache'.
+;;
+;; The only external process it runs is git - two short commands, and
+;; only on a local git project.  `git rev-parse' is constant time, and
+;; `git status --porcelain' rides the index stat cache and doesn't
+;; recurse into untracked directories.  On a remote (TRAMP) project the
+;; VCS section is skipped outright: even `rev-parse' means a round-trip
+;; over the wire, and the frecency history isn't tracked for remote
+;; projects anyway, so the recent files list is empty there too.  Every
+;; other VCS degrades to its bare name.
+;;
+;; Lifecycle commands and tasks whose command is a function (the CMake
+;; preset pickers, say) are listed but never resolved - resolving one can
+;; pop up a prompt, and a dashboard that opens a minibuffer on project
+;; switch would be intolerable.
+
+(defcustom projectile-dashboard-sections
+  '(project vcs recent tasks commands)
+  "The sections `projectile-dashboard' renders, in order.
+
+Each element is one of the symbols `project' (name, root, type and file
+count), `vcs' (version-control system, branch and working tree status),
+`recent' (the project files you visit most, ranked by frecency), `tasks'
+\(the project's named tasks) and `commands' (the configured lifecycle
+commands).  Dropping a section skips both its rendering and the work
+needed to fill it in."
+  :group 'projectile
+  :type '(repeat (choice (const :tag "Project summary" project)
+                         (const :tag "Version control" vcs)
+                         (const :tag "Recently visited files" recent)
+                         (const :tag "Tasks" tasks)
+                         (const :tag "Lifecycle commands" commands)))
+  :package-version '(projectile . "3.3.0"))
+
+(defcustom projectile-dashboard-recent-files 10
+  "How many recently visited files `projectile-dashboard' lists.
+The files are ranked by frecency, so this is the length of the \"what
+was I working on\" list, not a history limit - that's
+`projectile-frecency-max-files'."
+  :group 'projectile
+  :type 'natnum
+  :package-version '(projectile . "3.3.0"))
+
+(defconst projectile-dashboard-buffer-name "*projectile-dashboard*"
+  "The name of the buffer `projectile-dashboard' renders into.")
+
+(defconst projectile-dashboard--label-width 16
+  "Column width of the labels in the dashboard.")
+
+(defvar-local projectile-dashboard--directory nil
+  "The directory the dashboard in this buffer was generated from.
+Used by the buffer's `revert-buffer' to regenerate it.")
+
+(defun projectile-dashboard--section-p (section)
+  "Return non-nil when SECTION is enabled in `projectile-dashboard-sections'."
+  (memq section projectile-dashboard-sections))
+
+
+;;;; Dashboard data collection
+
+(defun projectile-dashboard--git (root &rest args)
+  "Run git with ARGS in ROOT and return its output, or nil when it fails.
+No shell is involved, and the call would go through TRAMP for a remote
+ROOT - which is why the callers make sure never to reach here with one.
+
+`--no-optional-locks' keeps a dashboard opened on project switch from
+taking the index lock and rewriting the index behind the user's back."
+  (let ((default-directory root))
+    (with-temp-buffer
+      (when (eql 0 (ignore-errors
+                     (apply #'process-file "git" nil '(t nil) nil
+                            "--no-optional-locks" args)))
+        (buffer-string)))))
+
+(defun projectile-dashboard--git-status (root)
+  "Return the git branch and working tree counts for ROOT as a plist.
+
+The branch comes from a single `git rev-parse' and the counts from a
+single `git status --porcelain', which rides git's index stat cache and
+reports an untracked directory as one entry instead of recursing into
+it - that's what keeps this cheap enough to run on a project switch.
+The status is scoped to ROOT, since a project can sit below the git root
+\(see `projectile-project-vcs') and the whole repository's counts would
+be meaningless for it.
+
+The plist's `:vcs-state' is `ok' when both answered, `partial' when only
+the branch could be determined and `unavailable' when git couldn't
+answer at all (not installed, no commits yet, a broken repository)."
+  (if-let* ((branch (projectile-dashboard--git
+                     root "rev-parse" "--abbrev-ref" "HEAD")))
+      (let ((status (projectile-dashboard--git
+                     root "status" "--porcelain" "--untracked-files=normal"
+                     "--" "."))
+            (modified 0)
+            (untracked 0))
+        (dolist (line (and status (split-string status "\n" t)))
+          (if (string-prefix-p "??" line)
+              (setq untracked (1+ untracked))
+            (setq modified (1+ modified))))
+        (list :vcs-state (if status 'ok 'partial)
+              ;; `--abbrev-ref' prints "HEAD" itself when the head is
+              ;; detached, which would read as a branch named HEAD.
+              :branch (let ((branch (string-trim branch)))
+                        (if (equal branch "HEAD") "detached HEAD" branch))
+              :modified modified
+              :untracked untracked))
+    (list :vcs-state 'unavailable)))
+
+(defun projectile-dashboard--vcs-info (root vcs remote)
+  "Return the version control data for the project at ROOT as a plist.
+VCS is the project's version-control system and REMOTE is non-nil for a
+TRAMP root.  Only git is queried, and only locally, so the dashboard
+never blocks on a network round-trip or on a status command whose cost
+we can't vouch for; everything else degrades to the bare VCS name."
+  (cond
+   ((not (eq vcs 'git)) (list :vcs-state 'unsupported))
+   (remote (list :vcs-state 'skipped))
+   (t (projectile-dashboard--git-status root))))
+
+(defun projectile-dashboard--recent-files (root)
+  "Return ROOT's most frecent files, best first.
+This is the ranking `projectile-find-file' completion uses (see
+`projectile--frecency-score'), capped at
+`projectile-dashboard-recent-files'.
+
+The history outlives the files it tracks, so candidates are checked for
+existence as they are taken - which normally means one check per file
+shown, and never more than the tracked history.  The check is skipped
+for a remote ROOT, where each one would be a round-trip (nothing is
+tracked for remote projects in the first place)."
+  (when projectile-enable-frecency
+    (when-let* ((files (gethash root (projectile--frecency-data))))
+      (let ((now (projectile-time-seconds))
+            entries)
+        (maphash (lambda (file entry)
+                   (push (cons file (projectile--frecency-score entry now))
+                         entries))
+                 files)
+        (let ((ranked (seq-sort-by #'cdr #'> entries))
+              (remote (file-remote-p root))
+              (taken 0)
+              recent)
+          (while (and ranked (< taken projectile-dashboard-recent-files))
+            (let ((entry (pop ranked)))
+              (when (or remote
+                        (file-exists-p (expand-file-name (car entry) root)))
+                (push entry recent)
+                (setq taken (1+ taken)))))
+          (nreverse recent))))))
+
+(defun projectile-dashboard--commands (root)
+  "Return the configured lifecycle commands of the project at ROOT.
+Each element is a cons of the phase symbol and the shell command that
+would run, or nil for a phase whose command is a function.  Those are
+listed but never resolved: resolving one can pop up a prompt, which is
+the last thing to do in somebody's project-switch action."
+  (let ((compile-dir (or (ignore-errors (projectile-compilation-dir)) root)))
+    (delq nil
+          (mapcar
+           (lambda (descriptor)
+             (let ((phase (plist-get descriptor :name)))
+               (if (projectile--phase-command-dynamic-p phase)
+                   (cons phase nil)
+                 (when-let* ((command
+                              (ignore-errors
+                                (funcall (plist-get descriptor :command-fn)
+                                         compile-dir))))
+                   (cons phase command)))))
+           projectile--lifecycle-phases))))
+
+(defun projectile-dashboard--collect-in-project (dir root)
+  "Collect the dashboard data for the project at ROOT, reached from DIR.
+Must run in a buffer that has ROOT's directory-local variables applied -
+see `projectile-dashboard--collect', which arranges that."
+  (let* ((remote (file-remote-p root))
+         (vcs (ignore-errors (projectile-project-vcs root)))
+         (cached (gethash root projectile-projects-cache 'uncached))
+         (project (projectile-dashboard--section-p 'project)))
+    (append
+     (list :dir dir
+           :root root
+           :remote remote
+           :vcs vcs
+           :frecency projectile-enable-frecency
+           :name (when project (ignore-errors (projectile-project-name root)))
+           :type (when project (ignore-errors (projectile-project-type)))
+           :file-count (unless (eq cached 'uncached) (length cached))
+           :recent-files (when (projectile-dashboard--section-p 'recent)
+                           (projectile-dashboard--recent-files root))
+           :tasks (when (projectile-dashboard--section-p 'tasks)
+                    (ignore-errors (projectile-project-tasks)))
+           :commands (when (projectile-dashboard--section-p 'commands)
+                       (ignore-errors (projectile-dashboard--commands root))))
+     (when (projectile-dashboard--section-p 'vcs)
+       (projectile-dashboard--vcs-info root vcs remote)))))
+
+(defun projectile-dashboard--collect (&optional dir)
+  "Collect the dashboard data for DIR's project as a plist.
+DIR defaults to `default-directory'.  Outside a project the plist has a
+nil `:root' and the rendering degrades to saying so.
+
+The data is collected in a temporary buffer with the project's
+directory-local variables applied, the way
+`projectile-switch-project-by-name' runs the switch action.  The project
+type, its tasks and its lifecycle commands can all come from
+.dir-locals.el, and the dashboard buffer has none of them - without this
+a refresh would quietly render a different project than the first pass.
+
+Nothing here indexes the project or touches the file cache: an uncached
+project is reported as not indexed rather than indexed on the spot, so
+that the dashboard stays cheap enough to be a
+`projectile-switch-project-action'."
+  (let* ((dir (or dir default-directory))
+         (root (ignore-errors (projectile-project-root dir))))
+    (if (null root)
+        (list :dir dir :root nil)
+      (with-temp-buffer
+        (setq default-directory root)
+        (hack-dir-local-variables-non-file-buffer)
+        (projectile-dashboard--collect-in-project dir root)))))
+
+
+;;;; Dashboard buttons
+
+(defun projectile-dashboard--visit-file (button)
+  "Visit the project file BUTTON stands for."
+  (find-file (expand-file-name (button-get button 'projectile-file)
+                               (button-get button 'projectile-root))))
+
+(defun projectile-dashboard--run-task (button)
+  "Run the project task BUTTON stands for."
+  (let ((default-directory (button-get button 'projectile-root)))
+    (projectile--run-task (button-get button 'projectile-task)
+                          (button-get button 'projectile-command)
+                          nil)))
+
+(defun projectile-dashboard--run-command (button)
+  "Run the lifecycle command BUTTON stands for."
+  (let ((default-directory (button-get button 'projectile-root)))
+    (call-interactively (button-get button 'projectile-command))))
+
+(defun projectile-dashboard--open-vc (button)
+  "Open the VC interface of the project BUTTON stands for."
+  (projectile-vc (button-get button 'projectile-root)))
+
+(defun projectile-dashboard--open-dired (button)
+  "Open the root of the project BUTTON stands for in Dired."
+  (dired (button-get button 'projectile-root)))
+
+(define-button-type 'projectile-dashboard-file
+  'action #'projectile-dashboard--visit-file
+  'follow-link t
+  'help-echo "mouse-1, RET: visit this file")
+
+(define-button-type 'projectile-dashboard-task
+  'action #'projectile-dashboard--run-task
+  'follow-link t
+  'help-echo "mouse-1, RET: run this task")
+
+(define-button-type 'projectile-dashboard-command
+  'action #'projectile-dashboard--run-command
+  'follow-link t
+  'help-echo "mouse-1, RET: run this command")
+
+(define-button-type 'projectile-dashboard-vc
+  'action #'projectile-dashboard--open-vc
+  'follow-link t
+  'help-echo "mouse-1, RET: open the project's VC interface")
+
+(define-button-type 'projectile-dashboard-dired
+  'action #'projectile-dashboard--open-dired
+  'follow-link t
+  'help-echo "mouse-1, RET: open the project root in Dired")
+
+
+;;;; Dashboard rendering
+
+(defun projectile-dashboard--label (label)
+  "Insert LABEL padded out to the dashboard's label column."
+  (insert label
+          (make-string (max 1 (- projectile-dashboard--label-width
+                                 (length label)))
+                       ?\s)))
+
+(defun projectile-dashboard--field (label value)
+  "Insert a LABEL/VALUE line into the dashboard.
+VALUE is rendered with `%s'; a nil or empty one reads as \"n/a\"."
+  (projectile-dashboard--label label)
+  (insert (if (or (null value) (equal value "")) "n/a" (format "%s" value))
+          "\n"))
+
+(defun projectile-dashboard--section (title)
+  "Insert the header of a dashboard section titled TITLE."
+  (insert "\n" title "\n" (make-string (length title) ?-) "\n"))
+
+(defun projectile-dashboard--button (label type root &rest properties)
+  "Insert a button labelled LABEL of button TYPE for the project at ROOT.
+PROPERTIES are any additional button properties, as a plist."
+  (apply #'insert-text-button label
+         'type type 'projectile-root root properties))
+
+(defun projectile-dashboard--entry (label type root &rest properties)
+  "Insert an indented list entry button, padded to the value column.
+LABEL, TYPE, ROOT and PROPERTIES are as in `projectile-dashboard--button'."
+  (insert "  ")
+  (apply #'projectile-dashboard--button label type root properties)
+  (insert (make-string (max 1 (- projectile-dashboard--label-width
+                                 2 (length label)))
+                       ?\s)))
+
+(defun projectile-dashboard--phase-command (phase)
+  "Return the interactive command running lifecycle PHASE.
+The lifecycle commands are named after their phase by construction (see
+`projectile--lifecycle-phases')."
+  (intern (format "projectile-%s-project" phase)))
+
+(defun projectile-dashboard--render-project (data)
+  "Render DATA's project summary."
+  (let ((root (plist-get data :root)))
+    (projectile-dashboard--section "Project")
+    (projectile-dashboard--field "name" (plist-get data :name))
+    (projectile-dashboard--label "root")
+    (projectile-dashboard--button root 'projectile-dashboard-dired root)
+    (insert "\n")
+    (projectile-dashboard--field "type" (plist-get data :type))
+    (projectile-dashboard--field
+     "files"
+     (if-let* ((count (plist-get data :file-count)))
+         (format "%d (cached)" count)
+       "not indexed yet"))
+    (when (plist-get data :remote)
+      (projectile-dashboard--field "remote" (plist-get data :remote)))))
+
+(defun projectile-dashboard--render-vcs (data)
+  "Render DATA's version control summary."
+  (let ((root (plist-get data :root))
+        (vcs (plist-get data :vcs)))
+    (projectile-dashboard--section "Version control")
+    (projectile-dashboard--field "vcs" vcs)
+    (pcase (plist-get data :vcs-state)
+      ((and (or 'ok 'partial) state)
+       (projectile-dashboard--label "branch")
+       (projectile-dashboard--button (plist-get data :branch)
+                                     'projectile-dashboard-vc root)
+       (insert "\n")
+       (projectile-dashboard--field
+        "status"
+        (if (eq state 'partial)
+            "unavailable"
+          (format "%d modified, %d untracked"
+                  (plist-get data :modified)
+                  (plist-get data :untracked)))))
+      ('skipped
+       (projectile-dashboard--field "status" "not checked (remote project)"))
+      ('unavailable
+       (projectile-dashboard--field "status" "unavailable (no commits yet?)"))
+      (_
+       (unless (memq vcs '(nil none))
+         (projectile-dashboard--label "vc")
+         (projectile-dashboard--button "open the VC interface"
+                                       'projectile-dashboard-vc root)
+         (insert "\n"))))))
+
+(defun projectile-dashboard--render-recent (data)
+  "Render DATA's recently visited files."
+  (let ((root (plist-get data :root))
+        (files (plist-get data :recent-files)))
+    (projectile-dashboard--section "Recent files")
+    (if (null files)
+        (insert (if (plist-get data :frecency)
+                    "Nothing visited in this project yet.\n"
+                  "Frecency tracking is off (`projectile-enable-frecency').\n"))
+      (dolist (entry files)
+        (insert "  ")
+        (projectile-dashboard--button (car entry) 'projectile-dashboard-file
+                                      root 'projectile-file (car entry))
+        (insert "\n")))))
+
+(defun projectile-dashboard--render-tasks (data)
+  "Render DATA's project tasks."
+  (let ((root (plist-get data :root))
+        (tasks (plist-get data :tasks)))
+    (projectile-dashboard--section "Tasks")
+    (if (null tasks)
+        (insert "No tasks defined for this project (see `projectile-tasks').\n")
+      (dolist (task tasks)
+        (projectile-dashboard--entry (car task) 'projectile-dashboard-task root
+                                     'projectile-task (car task)
+                                     'projectile-command (cdr task))
+        (insert (if (stringp (cdr task)) (cdr task) "computed at run time")
+                "\n")))))
+
+(defun projectile-dashboard--render-commands (data)
+  "Render DATA's configured lifecycle commands."
+  (let ((root (plist-get data :root))
+        (commands (plist-get data :commands)))
+    (projectile-dashboard--section "Lifecycle commands")
+    (if (null commands)
+        (insert "No lifecycle commands configured for this project type.\n")
+      (dolist (entry commands)
+        (projectile-dashboard--entry
+         (symbol-name (car entry)) 'projectile-dashboard-command root
+         'projectile-command (projectile-dashboard--phase-command (car entry)))
+        (insert (or (cdr entry) "computed at run time") "\n")))))
+
+(defun projectile-dashboard--render-no-project (data)
+  "Render the no-project dashboard for DATA."
+  (projectile-dashboard--section "Project")
+  (projectile-dashboard--field "directory" (plist-get data :dir))
+  (projectile-dashboard--field "root" "none - not inside a project")
+  (insert (format "
+There's no project around that directory, so there's nothing to show.
+Create a `%s' file in it (an empty one will do) or put it under version
+control, then press `g' to try again.
+
+`M-x projectile-doctor' lists the root functions that were tried and
+explains why none of them claimed the directory.
+" projectile-dirconfig-file)))
+
+(defun projectile-dashboard--render (data)
+  "Render the dashboard described by DATA into the current buffer."
+  (insert "Projectile project dashboard\n"
+          "============================\n")
+  (if (null (plist-get data :root))
+      (projectile-dashboard--render-no-project data)
+    (dolist (section projectile-dashboard-sections)
+      (pcase section
+        ('project (projectile-dashboard--render-project data))
+        ('vcs (projectile-dashboard--render-vcs data))
+        ('recent (projectile-dashboard--render-recent data))
+        ('tasks (projectile-dashboard--render-tasks data))
+        ('commands (projectile-dashboard--render-commands data))))
+    (insert "\nRET acts on the entry at point, TAB moves to the next one, "
+            "g refreshes, q buries.\n")))
+
+
+;;;; The dashboard buffer
+
+(defvar projectile-dashboard-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "TAB") #'forward-button)
+    (define-key map (kbd "<backtab>") #'backward-button)
+    ;; The buffer is a list of entries, so moving by entry is more useful
+    ;; here than the `next-line'/`previous-line' these shadow.
+    (define-key map (kbd "n") #'forward-button)
+    (define-key map (kbd "p") #'backward-button)
+    map)
+  "Keymap for `projectile-dashboard-mode'.")
+
+(define-derived-mode projectile-dashboard-mode special-mode "Projectile-Dashboard"
+  "Major mode for the `projectile-dashboard' buffer, read-only.
+
+The files, tasks, lifecycle commands and the current branch are buttons.
+RET acts on the one at point; \\<projectile-dashboard-mode-map>\\[forward-button] and \\[backward-button] (also `n' and `p')
+move between them.  \\[revert-buffer] refreshes the dashboard and \\[quit-window] buries it.
+
+\\{projectile-dashboard-mode-map}"
+  (setq-local revert-buffer-function
+              (lambda (&rest _)
+                (projectile-dashboard--refresh
+                 projectile-dashboard--directory))))
+
+(defun projectile-dashboard--refresh (dir)
+  "Render the dashboard for DIR into the dashboard buffer and return it."
+  (let ((data (projectile-dashboard--collect dir))
+        (buffer (get-buffer-create projectile-dashboard-buffer-name)))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (projectile-dashboard-mode)
+        (setq-local projectile-dashboard--directory dir)
+        ;; The buffer is reused across projects, so point it at the one it
+        ;; currently shows - otherwise commands invoked in it (and the mode
+        ;; line) would keep targeting whichever project opened it first.
+        (setq-local default-directory (or (plist-get data :root) dir))
+        (projectile-dashboard--render data)
+        (goto-char (point-min))))
+    buffer))
+
+;;;###autoload
+(defun projectile-dashboard ()
+  "Show a dashboard summarising the project around `default-directory'.
+
+The dashboard covers the project's name, root, type and file count, the
+version control system with the current branch and how many files are
+modified or untracked, the project files you visit most (ranked by
+frecency, the same ranking `projectile-find-file' uses), the project's
+tasks and its configured lifecycle commands.
+
+Everything worth acting on is a button, so the buffer doubles as a
+launcher: RET on a file visits it, on a task or a lifecycle command runs
+it, on the branch opens the project's VC interface, and on the root
+opens it in Dired.  TAB moves to the next button, `g' refreshes the
+dashboard and `q' buries it.
+
+The command is cheap on purpose, so that it can serve as a
+`projectile-switch-project-action'.  It never indexes the project and
+never touches the file cache - an uncached project is reported as not
+indexed rather than indexed on the spot.  The branch and status come
+from two short git commands, run only on a local git project; on a
+remote project, or under any other VCS, that section says so instead.
+
+`projectile-dashboard-sections' controls which sections are shown."
+  (interactive)
+  (pop-to-buffer (projectile-dashboard--refresh default-directory)))
+
 
 ;;; Projectile Minor mode
 
@@ -12332,6 +12852,7 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "x 4 G") #'projectile-run-ghostel-other-window)
     ;; misc
     (define-key map (kbd "H") #'projectile-doctor)
+    (define-key map (kbd "P") #'projectile-dashboard)
     (define-key map (kbd "z") #'projectile-cache-current-file)
     (define-key map (kbd "<left>") #'projectile-previous-project-buffer)
     (define-key map (kbd "<right>") #'projectile-next-project-buffer)
@@ -12618,6 +13139,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("q" "switch open project" projectile-switch-open-project)
       ("A" "add known project" projectile-add-known-project)
       ("v" "vc" projectile-vc)
+      ("P" "dashboard" projectile-dashboard)
       ("H" "doctor" projectile-doctor)]
      ["Lifecycle"
       ("cc" "compile" projectile-compile-project)
@@ -12723,6 +13245,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
          ["Toggle project wide read-only" projectile-toggle-project-read-only]
          ["Edit .dir-locals.el" projectile-edit-dir-locals]
          ["Project info" projectile-project-info]
+         ["Project dashboard" projectile-dashboard]
          ["Project diagnostics (doctor)" projectile-doctor])
         ("Search"
          ["Search (default backend)" projectile-search]

--- a/test/projectile-dashboard-test.el
+++ b/test/projectile-dashboard-test.el
@@ -1,0 +1,388 @@
+;;; projectile-dashboard-test.el --- Tests for projectile-dashboard -*- lexical-binding: t -*-
+
+;; Copyright © 2011-2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for `projectile-dashboard' - the rendering, the buttons the
+;; entries carry, its behavior outside a project, its hands-off
+;; treatment of the file cache, and its use as a
+;; `projectile-switch-project-action'.  The rendering is driven off a
+;; plain plist, so most of it can be tested without a project at all.
+
+;;; Code:
+
+(require 'projectile-test-helpers)
+
+(defun projectile-dashboard-test--render (data)
+  "Render DATA and return the dashboard as a string."
+  (with-temp-buffer
+    (projectile-dashboard--render data)
+    (buffer-string)))
+
+(defmacro projectile-dashboard-test--with-render (data &rest body)
+  "Render DATA into a temp buffer and evaluate BODY there."
+  (declare (indent 1) (debug (form &rest form)))
+  `(with-temp-buffer
+     (projectile-dashboard--render ,data)
+     (goto-char (point-min))
+     ,@body))
+
+(defun projectile-dashboard-test--button (label)
+  "Return the button labelled LABEL in the current buffer, if any."
+  (goto-char (point-min))
+  (when (search-forward label nil t)
+    (button-at (match-beginning 0))))
+
+(describe "projectile-dashboard"
+  (it "renders a dashboard for the current project"
+    (projectile-test-with-stub-root "project/" ("src/a.el" ".projectile")
+      (let ((projectile-dashboard-sections '(project recent tasks commands)))
+        (unwind-protect
+            (progn
+              (save-window-excursion (projectile-dashboard))
+              (with-current-buffer projectile-dashboard-buffer-name
+                (expect major-mode :to-be 'projectile-dashboard-mode)
+                (expect buffer-read-only :to-be t)
+                (expect (file-equal-p default-directory
+                                      (projectile-project-root))
+                        :to-be-truthy)
+                (let ((dashboard (buffer-string)))
+                  (dolist (section '("Project" "Recent files" "Tasks"
+                                     "Lifecycle commands"))
+                    (expect dashboard :to-match section))
+                  (expect dashboard
+                          :to-match (regexp-quote (projectile-project-root))))))
+          (kill-buffer projectile-dashboard-buffer-name)))))
+
+  (it "renders the same thing again on revert"
+    (projectile-test-with-stub-root "project/"
+        (".projectile"
+         ".dir-locals.el")
+      (with-temp-file "project/.dir-locals.el"
+        (insert "((nil . ((projectile-tasks . ((\"lint\" . \"make lint\"))))))"))
+      (let ((projectile-dashboard-sections '(tasks))
+            (enable-local-variables :all))
+        (unwind-protect
+            (let (initial)
+              (save-window-excursion (projectile-dashboard))
+              (with-current-buffer projectile-dashboard-buffer-name
+                (setq initial (buffer-string))
+                (expect initial :to-match "make lint")
+                ;; The dashboard buffer has none of the project's
+                ;; directory-local variables, so a naive refresh would
+                ;; quietly lose the tasks defined there.
+                (revert-buffer)
+                (expect (buffer-string) :to-equal initial)))
+          (kill-buffer projectile-dashboard-buffer-name)))))
+
+  (it "renders only the enabled sections, in order"
+    (let ((projectile-dashboard-sections '(tasks project))
+          (data '(:root "/tmp/p/" :name "p" :type generic)))
+      (let ((dashboard (projectile-dashboard-test--render data)))
+        (expect dashboard :to-match "Tasks")
+        (expect dashboard :to-match "Project")
+        (expect dashboard :not :to-match "Recent files")
+        (expect dashboard :not :to-match "Version control")
+        (expect (string-match-p "^Tasks$" dashboard)
+                :to-be-less-than (string-match-p "^Project$" dashboard)))))
+
+  (it "degrades gracefully outside a project"
+    (projectile-test-with-sandbox
+      (projectile-test-with-files ("nothing/a.el")
+        (spy-on 'projectile-project-root :and-return-value nil)
+        (let* ((dir (expand-file-name "nothing/"))
+               (data (projectile-dashboard--collect dir)))
+          (expect (plist-get data :root) :to-be nil)
+          (let ((dashboard (projectile-dashboard-test--render data)))
+            (expect dashboard :to-match "not inside a project")
+            (expect dashboard :to-match "\\.projectile")
+            (expect dashboard :to-match "projectile-doctor"))))))
+
+  (it "never indexes an uncached project"
+    (projectile-test-with-stub-root "project/" ("src/a.el" "src/b.el")
+      (let ((projectile-indexing-method 'native)
+            (projectile-enable-caching t)
+            (projectile-dashboard-sections '(project)))
+        (spy-on 'projectile-project-files :and-call-through)
+        (let ((data (projectile-dashboard--collect (projectile-project-root))))
+          (expect 'projectile-project-files :not :to-have-been-called)
+          (expect (plist-get data :file-count) :to-be nil)
+          (expect (projectile-dashboard-test--render data)
+                  :to-match "not indexed yet"))
+        ;; and the caches are exactly as we found them
+        (expect (gethash (projectile-project-root) projectile-projects-cache)
+                :to-be nil)
+        (expect (gethash (projectile-project-root)
+                         projectile-projects-cache-time)
+                :to-be nil))))
+
+  (it "reports the file count when the project is cached"
+    (projectile-test-with-stub-root "project/" ("src/a.el")
+      (puthash (projectile-project-root) '("one" "two" "three")
+               projectile-projects-cache)
+      (let ((projectile-dashboard-sections '(project))
+            (data (projectile-dashboard--collect (projectile-project-root))))
+        (expect (plist-get data :file-count) :to-equal 3)
+        (expect (projectile-dashboard-test--render data)
+                :to-match (regexp-quote "3 (cached)")))))
+
+  (it "skips the git query on a remote project"
+    (spy-on 'projectile-project-root :and-return-value "/ssh:host:/p/")
+    (spy-on 'projectile-project-vcs :and-return-value 'git)
+    ;; Reaching the remote host at all is the thing under test.
+    (spy-on 'hack-dir-local-variables-non-file-buffer)
+    (spy-on 'projectile-dashboard--git :and-call-fake
+            (lambda (&rest _) (error "Must not shell out on a remote project")))
+    (let* ((projectile--frecency-table (make-hash-table :test 'equal))
+           (projectile-dashboard-sections '(vcs recent))
+           (data (projectile-dashboard--collect "/ssh:host:/p/")))
+      (expect (plist-get data :vcs-state) :to-be 'skipped)
+      (expect (plist-get data :recent-files) :to-be nil))))
+
+(describe "projectile-dashboard recent files"
+  (it "ranks the project's files by frecency"
+    (projectile-test-with-stub-root "project/" ("a.el" "b.el" "c.el")
+      (let* ((root (projectile-project-root))
+             (now (projectile-time-seconds))
+             (files (make-hash-table :test 'equal))
+             (projectile--frecency-table (make-hash-table :test 'equal))
+             (projectile-enable-frecency t))
+        (puthash root files projectile--frecency-table)
+        (puthash "a.el" (cons 1 (- now 86400)) files)
+        (puthash "b.el" (cons 50 now) files)
+        (puthash "c.el" (cons 5 now) files)
+        (expect (mapcar #'car (projectile-dashboard--recent-files root))
+                :to-equal '("b.el" "c.el" "a.el")))))
+
+  (it "drops files that no longer exist and honors the cap"
+    (projectile-test-with-stub-root "project/" ("a.el" "b.el")
+      (let* ((root (projectile-project-root))
+             (now (projectile-time-seconds))
+             (files (make-hash-table :test 'equal))
+             (projectile--frecency-table (make-hash-table :test 'equal))
+             (projectile-enable-frecency t)
+             (projectile-dashboard-recent-files 2))
+        (puthash root files projectile--frecency-table)
+        ;; The top-ranked file is gone, so it has to be filtered out
+        ;; rather than merely fall off the end of the cap.
+        (puthash "gone.el" (cons 99 now) files)
+        (puthash "a.el" (cons 9 now) files)
+        (puthash "b.el" (cons 8 now) files)
+        (expect (mapcar #'car (projectile-dashboard--recent-files root))
+                :to-equal '("a.el" "b.el")))))
+
+  (it "says so when frecency tracking is off"
+    (let ((projectile-dashboard-sections '(recent)))
+      (expect (projectile-dashboard-test--render
+               '(:root "/tmp/p/" :frecency nil :recent-files nil))
+              :to-match "Frecency tracking is off")
+      (expect (projectile-dashboard-test--render
+               '(:root "/tmp/p/" :frecency t :recent-files nil))
+              :to-match "Nothing visited"))))
+
+(describe "projectile-dashboard version control"
+  (it "shows the branch and the working tree counts"
+    (let ((projectile-dashboard-sections '(vcs))
+          (data '(:root "/tmp/p/" :vcs git :vcs-state ok :branch "feature/x"
+                  :modified 3 :untracked 1)))
+      (let ((dashboard (projectile-dashboard-test--render data)))
+        (expect dashboard :to-match "feature/x")
+        (expect dashboard :to-match "3 modified, 1 untracked"))))
+
+  (it "shows the branch alone when the status query failed"
+    (spy-on 'projectile-dashboard--git :and-call-fake
+            (lambda (_root &rest args)
+              (when (equal (car args) "rev-parse") "main\n")))
+    (let ((status (projectile-dashboard--git-status "/tmp/p/")))
+      (expect (plist-get status :vcs-state) :to-be 'partial)
+      (let ((projectile-dashboard-sections '(vcs))
+            (data (append '(:root "/tmp/p/" :vcs git) status)))
+        (let ((dashboard (projectile-dashboard-test--render data)))
+          (expect dashboard :to-match "main")
+          (expect dashboard :to-match "unavailable")))))
+
+  (it "does not pass off a detached HEAD as a branch"
+    (spy-on 'projectile-dashboard--git :and-call-fake
+            (lambda (_root &rest args)
+              (if (equal (car args) "rev-parse") "HEAD\n" "")))
+    (expect (plist-get (projectile-dashboard--git-status "/tmp/p/") :branch)
+            :to-equal "detached HEAD"))
+
+  (it "scopes the status query to the project and takes no index lock"
+    (spy-on 'process-file :and-return-value 0)
+    (projectile-dashboard--git "/tmp/p/" "status" "--porcelain")
+    (expect (spy-calls-args-for 'process-file 0)
+            :to-equal '("git" nil (t nil) nil "--no-optional-locks"
+                        "status" "--porcelain"))
+    (spy-on 'projectile-dashboard--git :and-return-value "main\n")
+    (projectile-dashboard--git-status "/tmp/p/")
+    (expect (spy-calls-args-for 'projectile-dashboard--git 1)
+            :to-equal '("/tmp/p/" "status" "--porcelain"
+                        "--untracked-files=normal" "--" ".")))
+
+  (it "skips the VCS query on a remote project"
+    (expect (projectile-dashboard--vcs-info "/ssh:host:/p/" 'git "/ssh:host:")
+            :to-equal '(:vcs-state skipped))
+    (let ((projectile-dashboard-sections '(vcs)))
+      (expect (projectile-dashboard-test--render
+               '(:root "/ssh:host:/p/" :vcs git :vcs-state skipped))
+              :to-match "not checked (remote project)")))
+
+  (it "degrades to the bare VCS name for anything but git"
+    (expect (projectile-dashboard--vcs-info "/tmp/p/" 'hg nil)
+            :to-equal '(:vcs-state unsupported))
+    (let ((projectile-dashboard-sections '(vcs)))
+      (let ((dashboard (projectile-dashboard-test--render
+                        '(:root "/tmp/p/" :vcs hg :vcs-state unsupported))))
+        (expect dashboard :to-match "hg")
+        (expect dashboard :not :to-match "branch"))))
+
+  (it "counts modified and untracked entries out of the porcelain output"
+    (spy-on 'projectile-dashboard--git :and-call-fake
+            (lambda (_root &rest args)
+              (if (equal (car args) "rev-parse")
+                  "main\n"
+                " M projectile.el\nA  new.el\n?? scratch/\n")))
+    (let ((status (projectile-dashboard--git-status "/tmp/p/")))
+      (expect (plist-get status :vcs-state) :to-be 'ok)
+      (expect (plist-get status :branch) :to-equal "main")
+      (expect (plist-get status :modified) :to-equal 2)
+      (expect (plist-get status :untracked) :to-equal 1)))
+
+  (it "reports git being unable to answer"
+    (spy-on 'projectile-dashboard--git :and-return-value nil)
+    (expect (projectile-dashboard--git-status "/tmp/p/")
+            :to-equal '(:vcs-state unavailable))
+    (let ((projectile-dashboard-sections '(vcs)))
+      (expect (projectile-dashboard-test--render
+               '(:root "/tmp/p/" :vcs git :vcs-state unavailable))
+              :to-match "unavailable"))))
+
+(describe "projectile-dashboard lifecycle commands"
+  (it "lists the configured commands without resolving dynamic ones"
+    (projectile-test-with-stub-root "project/" ("a.el")
+      (spy-on 'projectile-project-type :and-return-value 'test-dashboard-type)
+      (spy-on 'projectile--phase-command-dynamic-p :and-call-fake
+              (lambda (phase) (eq phase 'run)))
+      (spy-on 'projectile-compilation-command :and-return-value "make")
+      (spy-on 'projectile-test-command :and-return-value nil)
+      (spy-on 'projectile-configure-command :and-return-value nil)
+      (spy-on 'projectile-install-command :and-return-value nil)
+      (spy-on 'projectile-package-command :and-return-value nil)
+      (spy-on 'projectile-run-command :and-call-fake
+              (lambda (&rest _) (error "Must not resolve a dynamic command")))
+      (let ((commands (projectile-dashboard--commands
+                       (projectile-project-root))))
+        (expect commands :to-equal '((compile . "make") (run . nil))))))
+
+  (it "names the command that runs each phase"
+    (expect (projectile-dashboard--phase-command 'compile)
+            :to-be 'projectile-compile-project)
+    (expect (projectile-dashboard--phase-command 'test)
+            :to-be 'projectile-test-project)
+    (dolist (phase '(configure compile test install package run))
+      (expect (commandp (projectile-dashboard--phase-command phase))
+              :to-be-truthy))))
+
+(describe "projectile-dashboard buttons"
+  (it "visits the file a file entry stands for"
+    (let ((projectile-dashboard-sections '(recent))
+          (data '(:root "/tmp/p/" :recent-files (("src/a.el" . 1.0)))))
+      (projectile-dashboard-test--with-render data
+        (spy-on 'find-file)
+        (let ((button (projectile-dashboard-test--button "src/a.el")))
+          (expect button :to-be-truthy)
+          (push-button (button-start button))
+          (expect 'find-file :to-have-been-called-with "/tmp/p/src/a.el")))))
+
+  (it "runs the task a task entry stands for"
+    (let ((projectile-dashboard-sections '(tasks))
+          (data '(:root "/tmp/p/" :tasks (("lint" . "make lint")))))
+      (projectile-dashboard-test--with-render data
+        (spy-on 'projectile--run-task)
+        (let ((button (projectile-dashboard-test--button "lint")))
+          (expect button :to-be-truthy)
+          (push-button (button-start button))
+          (expect 'projectile--run-task
+                  :to-have-been-called-with "lint" "make lint" nil)))))
+
+  (it "labels a task with a function command instead of resolving it"
+    (let ((projectile-dashboard-sections '(tasks)))
+      (expect (projectile-dashboard-test--render
+               (list :root "/tmp/p/" :tasks (list (cons "gen" #'ignore))))
+              :to-match "computed at run time")))
+
+  (it "runs the lifecycle command a command entry stands for"
+    (let ((projectile-dashboard-sections '(commands))
+          (data '(:root "/tmp/p/" :commands ((compile . "make")))))
+      (projectile-dashboard-test--with-render data
+        (spy-on 'projectile-compile-project)
+        (let ((button (projectile-dashboard-test--button "compile")))
+          (expect button :to-be-truthy)
+          (push-button (button-start button))
+          (expect 'projectile-compile-project :to-have-been-called)))))
+
+  (it "opens the VC interface from the branch entry"
+    (let ((projectile-dashboard-sections '(vcs))
+          (data '(:root "/tmp/p/" :vcs git :vcs-state ok :branch "main"
+                  :modified 0 :untracked 0)))
+      (projectile-dashboard-test--with-render data
+        (spy-on 'projectile-vc)
+        (let ((button (projectile-dashboard-test--button "main")))
+          (expect button :to-be-truthy)
+          (push-button (button-start button))
+          (expect 'projectile-vc :to-have-been-called-with "/tmp/p/")))))
+
+  (it "opens the project root in Dired"
+    (let ((projectile-dashboard-sections '(project))
+          (data '(:root "/tmp/p/" :name "p" :type generic)))
+      (projectile-dashboard-test--with-render data
+        (spy-on 'dired)
+        (let ((button (projectile-dashboard-test--button "/tmp/p/")))
+          (expect button :to-be-truthy)
+          (push-button (button-start button))
+          (expect 'dired :to-have-been-called-with "/tmp/p/"))))))
+
+(describe "projectile-dashboard as a switch-project action"
+  (it "renders the project that was just switched to"
+    (projectile-test-with-sandbox
+      (projectile-test-with-files ("project-a/" "project-a/.projectile")
+        (let* ((a (file-name-as-directory
+                   (file-truename (expand-file-name "project-a"))))
+               (projectile-known-projects-file (projectile-test-tmp-file-path))
+               (projectile-known-projects nil)
+               (projectile-switch-project-action #'projectile-dashboard)
+               (projectile-dashboard-sections '(project)))
+          (projectile-add-known-project a)
+          (unwind-protect
+              (progn
+                (save-window-excursion (projectile-switch-project-by-name a))
+                (with-current-buffer projectile-dashboard-buffer-name
+                  (expect major-mode :to-be 'projectile-dashboard-mode)
+                  (expect (buffer-string) :to-match "project-a")))
+            (kill-buffer projectile-dashboard-buffer-name)))))))
+
+(describe "projectile-dashboard keybinding"
+  (it "is bound to P in projectile-command-map"
+    (expect (lookup-key projectile-command-map (kbd "P"))
+            :to-be 'projectile-dashboard)))
+
+(provide 'projectile-dashboard-test)
+
+;;; projectile-dashboard-test.el ends here


### PR DESCRIPTION
`projectile-dashboard` (`s-p P`) summarises the current project in one buffer: name, root, type, file count, branch and dirty-file counts, frecency-ranked recent files, the project's tasks and its configured lifecycle commands. Entries are buttons - RET opens the file, runs the task, or opens the VCS interface - and it's usable as a `projectile-switch-project-action`, which is what it was designed around.

Being a switch action drove most of the decisions. It never indexes: the file count is a cache lookup and an uncached project reads "not indexed yet", so switching into a cold project stays instant. Lifecycle commands and tasks whose command is a function are listed as "computed at run time" rather than resolved, because resolving a CMake preset picker would pop a minibuffer at you on every project switch. The git queries pass `--no-optional-locks` so a switch can't rewrite the index, and they're scoped with `-- .` because `projectile-project-vcs` walks upwards, which would otherwise make a sub-project report the parent repo's status.

Follows the doctor's shape - collect into a plist, render from it, `special-mode` buffer with `g` and `q` - since the two sit next to each other.

A review pass caught three real bugs before this landed: `g` rendered a different project than the first pass because dir-locals weren't hacked on refresh, sub-projects reported whole-repo status, and a detached HEAD rendered as a branch named `HEAD`. All three have specs.