### PR TITLE
Add projectile-todos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### New features
 
+- [#2113](https://github.com/bbatsov/projectile/pull/2113): Add `projectile-todos` (`s-p s t`), which collects the project's `TODO`/`FIXME`-style annotations into the reviewable search buffer.
+  - The keywords come from `projectile-todo-keywords`; with a prefix argument you're prompted for which of them to search for.
+  - A keyword only counts as a whole word followed by a colon, by whitespace or by the end of the line, so `TODOS` and `MASTODON` are not hits.
+  - The scan takes the ripgrep fast path when `rg` is available, even though it's not a literal search.
 - [#2112](https://github.com/bbatsov/projectile/pull/2112): Add `projectile-dashboard` (`s-p P`), a buffer summarising the current project that also works as a `projectile-switch-project-action`.
   - Covers the project name, root, type and file count, the branch and how many files are modified or untracked, the files you visit most (ranked by frecency), the project's tasks and its configured lifecycle commands.
   - Every entry is a button: `RET` visits a file, runs a task or a lifecycle command, or opens the VC interface.

--- a/doc/modules/ROOT/pages/cheatsheet.adoc
+++ b/doc/modules/ROOT/pages/cheatsheet.adoc
@@ -76,6 +76,9 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p s X]
 | Reviewable search for an Emacs regexp (the regexp sibling of kbd:[s-p s R]).
 
+| kbd:[s-p s t]
+| Collect the project's `TODO`/`FIXME`-style annotations into the reviewable search buffer. With a prefix argument it prompts for which keywords to search for.
+
 | kbd:[s-p v]
 | Run `vc-dir` on the root directory of the project.
 

--- a/doc/modules/ROOT/pages/configuration_index.adoc
+++ b/doc/modules/ROOT/pages/configuration_index.adoc
@@ -344,6 +344,9 @@ and the other reference pages.
 | `projectile-test-use-comint-mode`
 | Make the output buffer of ‘projectile-test-project’ interactive.
 
+| `projectile-todo-keywords`
+| Annotation keywords ‘projectile-todos’ collects across the project.
+
 | `projectile-track-known-projects-automatically`
 | Controls whether Projectile will automatically register known projects.
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -412,7 +412,40 @@ nil to force the elisp scan, whose result set matches Projectile's ignore
 configuration exactly. The regexp search command always uses the elisp
 scan (ripgrep's regex syntax is not Emacs regexp syntax), and the whole
 replace reviewer always uses the elisp scan (its write-back needs the
-exact buffer positions the elisp scan records).
+exact buffer positions the elisp scan records). The one exception is
+`projectile-todos` below: it builds its own pattern and hands the reviewer
+a ripgrep-syntax spelling of it, so it gets the fast-path despite not
+being a literal search.
+
+=== Collecting the project's TODOs
+
+`projectile-todos` (kbd:[s-p s t]) gathers every `TODO`/`FIXME`-style
+annotation in the project into the same read-only `+*projectile-search*+`
+buffer, so all the keys in the table above apply - navigate them, filter
+them down with kbd:[k]/kbd:[d]/kbd:[K]/kbd:[D], export them to
+`grep-mode`, or hand them to the replace reviewer.
+
+The keywords are `projectile-todo-keywords`, which defaults to:
+
+[source,elisp]
+----
+(setq projectile-todo-keywords '("TODO" "FIXME" "HACK" "XXX" "BUG" "NOTE"))
+----
+
+Add your own conventions to that list (`REVIEW`, `OPTIMIZE`, `DEPRECATED`,
+...). With a prefix argument (kbd:[C-u s-p s t]) Projectile prompts for
+which of the keywords to search for; several can be given, comma
+separated, and you can type in a keyword that isn't in the list for a
+one-off search.
+
+A keyword only counts when it stands as a whole word followed by a colon,
+by a space or tab, or by the end of the line - so `TODO:` and `FIXME ` are
+found while `TODOS` and `MASTODON` are not. Matching is case-sensitive,
+since annotation keywords are uppercase by convention; kbd:[c] in the
+results buffer relaxes that. The keyword does *not* have to sit in a
+comment: neither scan parses the language (and the comment syntax would
+have to be guessed per file type), so an annotation inside a string or in
+prose is reported too - kbd:[d] flushes those you don't care about.
 
 == Customizing Projectile's keybindings
 

--- a/projectile.el
+++ b/projectile.el
@@ -8235,11 +8235,30 @@ Projectile's ignore configuration exactly.
 The regexp search command always uses the elisp scan (ripgrep's regex
 syntax is not Emacs regexp syntax), and the whole replace reviewer always
 uses the elisp scan (its write-back needs the exact buffer positions the
-elisp scan records).  In batch mode (`noninteractive') the elisp scan is
-used so scripted runs stay deterministic."
+elisp scan records).  A command that knows a ripgrep-syntax equivalent of
+its Emacs regexp can opt into the fast-path anyway, which is what
+`projectile-todos' does.  In batch mode (`noninteractive') the elisp scan
+is used so scripted runs stay deterministic."
   :group 'projectile
   :type 'boolean
   :package-version '(projectile . "3.2.0"))
+
+(defcustom projectile-todo-keywords
+  '("TODO" "FIXME" "HACK" "XXX" "BUG" "NOTE")
+  "Annotation keywords `projectile-todos' collects across the project.
+Each keyword is matched as a whole word, case-sensitively, and must be
+followed by a colon, by whitespace or by the end of the line - so `TODO:'
+and `FIXME ' are hits while `TODOS' and `MASTODON' are not.  Add your own
+project's conventions here (`REVIEW', `OPTIMIZE', `DEPRECATED', ...);
+`projectile-todos' with a prefix argument prompts for which of these to
+search for.
+
+The keywords are not required to sit in a comment: neither the pure-elisp
+scan nor the ripgrep fast-path parses the language, so an annotation in a
+string or in prose is reported too."
+  :group 'projectile
+  :type '(repeat string)
+  :package-version '(projectile . "3.3.0"))
 
 (defcustom projectile-replace-scan-chunk-size 24
   "Number of candidate files scanned per async chunk before yielding.
@@ -8327,6 +8346,14 @@ around every (re-)gather so it drives which matches are collected.")
 Initialized from `projectile-search-whole-word' at the first search; the
 scan regexp is fenced with word boundaries (and ripgrep gets
 `--word-regexp') while it holds.")
+(defvar-local projectile-replace--rg-pattern nil
+  "A ripgrep-syntax equivalent of this buffer's search, or nil.
+Set by commands that build a non-literal search from a pattern they can
+also express in ripgrep's regex syntax (`projectile-todos'), so the
+read-only search reviewer's ripgrep fast-path can run for them too.  Nil
+means the fast-path is only available to a literal search.  Cleared when
+the search changes shape (the literal/regexp toggle), since the new
+search has no known ripgrep equivalent.")
 (defvar-local projectile-replace--matches nil
   "List of `projectile-replace--match' structs shown in the results buffer.")
 (defvar-local projectile-replace--truncated nil
@@ -8932,7 +8959,9 @@ refused with a message so the buffer stays usable rather than erroring."
       (setq projectile-replace--literal new-literal
             projectile-replace--search (if new-literal
                                            (regexp-quote projectile-replace--term)
-                                         projectile-replace--term))
+                                         projectile-replace--term)
+            ;; the ripgrep equivalent (if any) described the old search
+            projectile-replace--rg-pattern nil)
       (projectile-replace--regather)
       (message "%s"
                (projectile-prepend-project-name
@@ -9249,11 +9278,12 @@ write back to the files.
   (buffer-disable-undo))
 
 (defun projectile-replace--seed (buf mode root term regexp replacement
-                                     literal case-fold &optional word)
+                                     literal case-fold &optional word
+                                     rg-pattern)
   "Put BUF in MODE and seed its results-buffer state, with no matches yet.
-ROOT, TERM, REGEXP, REPLACEMENT, LITERAL, CASE-FOLD and WORD seed the
-search parameters; the match list starts empty, ready for a (sync or
-async) scan to fill it."
+ROOT, TERM, REGEXP, REPLACEMENT, LITERAL, CASE-FOLD, WORD and RG-PATTERN
+seed the search parameters; the match list starts empty, ready for a
+\(sync or async) scan to fill it."
   (with-current-buffer buf
     (funcall mode)
     (setq projectile-replace--root root
@@ -9263,6 +9293,7 @@ async) scan to fill it."
           projectile-replace--literal literal
           projectile-replace--case-fold case-fold
           projectile-replace--word word
+          projectile-replace--rg-pattern rg-pattern
           projectile-replace--matches nil
           projectile-replace--truncated nil
           projectile-replace--filtered nil
@@ -9280,46 +9311,52 @@ async) scan to fill it."
 ;; search reviewer renders are filled (file, line, character column, matched
 ;; string, context line); the write-back-only fields (`beg'/`end'/`match-data'/
 ;; `groups') stay nil because the search->replace bridge re-gathers via elisp.
-;; This path is deliberately narrow: the regexp search command keeps the elisp
-;; scan (rg's Rust regex is not Emacs regexp) and the whole replace reviewer
-;; keeps the elisp scan (its apply needs exact buffer positions).  The elisp
-;; scan stays the default and the fallback; rg is purely additive.
+;; This path is deliberately narrow: the interactive regexp search command
+;; keeps the elisp scan (rg's Rust regex is not Emacs regexp) and the whole
+;; replace reviewer keeps the elisp scan (its apply needs exact buffer
+;; positions).  A command that builds its own pattern and can also spell it in
+;; rg's syntax may pass that spelling as `projectile-replace--rg-pattern' and
+;; get the fast-path for a non-literal search too - `projectile-todos' does.
+;; The elisp scan stays the default and the fallback; rg is purely additive.
 
 (defun projectile-search--rg-executable ()
   "Return the ripgrep executable name if available, else nil."
   (and (executable-find "rg") "rg"))
 
-(defun projectile-search--rg-fastpath-p (literal)
+(defun projectile-search--rg-fastpath-p (literal &optional rg-pattern)
   "Return non-nil when the search reviewer should use the ripgrep fast-path.
-True for a LITERAL search when `projectile-search-use-ripgrep' is set,
-`rg' is available, and we are interactive; batch (`noninteractive') keeps
-the deterministic elisp scan."
+True for a LITERAL search, or for a non-literal one that supplied
+RG-PATTERN (a ripgrep-syntax equivalent of its Emacs regexp), when
+`projectile-search-use-ripgrep' is set, `rg' is available, and we are
+interactive; batch (`noninteractive') keeps the deterministic elisp scan."
   (and projectile-search-use-ripgrep
-       literal
+       (or literal rg-pattern)
        (not noninteractive)
        (projectile-search--rg-executable)
        t))
 
-(defun projectile-search--rg-command (term case-fold word globs)
+(defun projectile-search--rg-command (term case-fold word globs &optional pattern)
   "Build the `rg --json' command line searching for literal TERM.
-CASE-FOLD selects case-insensitive matching; WORD restricts matches to
-whole words (`--word-regexp'); GLOBS is a list of ignore patterns (from
-`projectile--project-ignore-globs') passed as `--glob' exclusions so
-Projectile's ignores narrow ripgrep's own ignore rules.  They are
-gitignore patterns, which is what ripgrep's globs are, so they need no
-translation - but a root-anchored one only resolves against the project
-root when the searched path is relative, which is why the search path
-below is `./' and the caller must run the process with
-`default-directory' bound to the project root."
+When PATTERN is non-nil it is searched for as a ripgrep-syntax regexp
+instead, and TERM is ignored.  CASE-FOLD selects case-insensitive
+matching; WORD restricts matches to whole words (`--word-regexp'); GLOBS
+is a list of ignore patterns (from `projectile--project-ignore-globs')
+passed as `--glob' exclusions so Projectile's ignores narrow ripgrep's
+own ignore rules.  They are gitignore patterns, which is what ripgrep's
+globs are, so they need no translation - but a root-anchored one only
+resolves against the project root when the searched path is relative,
+which is why the search path below is `./' and the caller must run the
+process with `default-directory' bound to the project root."
   (append
    (list (projectile-search--rg-executable)
-         "--json" "--fixed-strings" "--line-number" "--column"
+         "--json" "--line-number" "--column"
          "--color" "never"
          (if case-fold "--ignore-case" "--case-sensitive"))
+   (unless pattern (list "--fixed-strings"))
    (when word (list "--word-regexp"))
    (mapcan (lambda (g) (list "--glob" (concat "!" g))) globs)
    ;; `--' terminates options so a TERM starting with `-' is not misread.
-   (list "--" term "./")))
+   (list "--" (or pattern term) "./")))
 
 (defun projectile-search--rg-json-get (obj &rest keys)
   "Walk KEYS through nested hash-table OBJ, returning the leaf or nil.
@@ -9417,6 +9454,8 @@ against a killed BUFFER."
 
 (defun projectile-search--gather-rg (buffer term on-done)
   "Scan for literal TERM into BUFFER via `rg --json', then call ON-DONE.
+When BUFFER carries a `projectile-replace--rg-pattern', that
+ripgrep-syntax regexp is searched for instead of the literal TERM.
 Resets BUFFER's match list and scanning state, launches `rg' as a
 subprocess reading ROOT, CASE-FOLD and the ignore globs from BUFFER's
 buffer-locals, and streams parsed matches into the buffer as ripgrep
@@ -9430,8 +9469,10 @@ finishes."
   (let* ((root (buffer-local-value 'projectile-replace--root buffer))
          (case-fold (buffer-local-value 'projectile-replace--case-fold buffer))
          (word (buffer-local-value 'projectile-replace--word buffer))
+         (pattern (buffer-local-value 'projectile-replace--rg-pattern buffer))
          (globs (projectile--project-ignore-globs root))
-         (command (projectile-search--rg-command term case-fold word globs))
+         (command (projectile-search--rg-command term case-fold word globs
+                                                 pattern))
          (pending ""))
     (with-current-buffer buffer
       (setq projectile-replace--matches nil
@@ -9506,15 +9547,17 @@ either way -- only delivery differs.  BUFFER is re-rendered when done and
 ON-DONE (or nil) is called in it.
 
 As an optional accelerator, a read-only search-reviewer BUFFER doing a
-literal search takes the ripgrep fast-path (`projectile-search--gather-rg')
-when `projectile-search--rg-fastpath-p' holds; the replace reviewer and
-the regexp search always take the elisp path below."
+literal search (or one carrying a `projectile-replace--rg-pattern') takes
+the ripgrep fast-path (`projectile-search--gather-rg') when
+`projectile-search--rg-fastpath-p' holds; the replace reviewer and the
+plain regexp search always take the elisp path below."
   (with-current-buffer buffer
     (projectile-replace--cancel-scan))
   (cond
    ((with-current-buffer buffer
       (and (derived-mode-p 'projectile-search-mode)
-           (projectile-search--rg-fastpath-p projectile-replace--literal)))
+           (projectile-search--rg-fastpath-p projectile-replace--literal
+                                             projectile-replace--rg-pattern)))
     (projectile-search--gather-rg
      buffer (buffer-local-value 'projectile-replace--term buffer) on-done))
    ((projectile-replace--async-p)
@@ -9545,14 +9588,15 @@ the regexp search always take the elisp path below."
 
 (defun projectile-replace--open (mode buf-name root term regexp replacement
                                       literal case-fold candidates no-match-msg
-                                      &optional word)
+                                      &optional word rg-pattern)
   "Open BUF-NAME in MODE and scan CANDIDATES for REGEXP into it.
 When scanning is asynchronous the buffer is shown immediately and matches
 stream in; when synchronous (always in batch) the scan completes first
 and, to preserve the pre-async behavior, no buffer is shown when nothing
 matched -- NO-MATCH-MSG is issued instead.  Returns the results buffer,
 or nil on the synchronous no-match path.  ROOT, TERM, REGEXP,
-REPLACEMENT, LITERAL, CASE-FOLD and WORD seed the buffer state."
+REPLACEMENT, LITERAL, CASE-FOLD, WORD and RG-PATTERN seed the buffer
+state."
   ;; re-running the command must not orphan a scan still filling an earlier
   ;; instance of the buffer (re-seeding resets its buffer-locals)
   (when-let* ((existing (get-buffer buf-name)))
@@ -9563,10 +9607,10 @@ REPLACEMENT, LITERAL, CASE-FOLD and WORD seed the buffer state."
           ;; engine is off (`projectile-replace-async' nil); `--start' then
           ;; dispatches it to ripgrep
           (and (eq mode #'projectile-search-mode)
-               (projectile-search--rg-fastpath-p literal)))
+               (projectile-search--rg-fastpath-p literal rg-pattern)))
       (let ((buf (get-buffer-create buf-name)))
         (projectile-replace--seed buf mode root term regexp replacement
-                                  literal case-fold word)
+                                  literal case-fold word rg-pattern)
         (with-current-buffer buf
           (setq projectile-replace--scanning t)
           (funcall projectile-replace--render-function))
@@ -9585,7 +9629,7 @@ REPLACEMENT, LITERAL, CASE-FOLD and WORD seed the buffer state."
           (progn (when no-match-msg (message "%s" no-match-msg)) nil)
         (let ((buf (get-buffer-create buf-name)))
           (projectile-replace--seed buf mode root term regexp replacement
-                                    literal case-fold word)
+                                    literal case-fold word rg-pattern)
           (with-current-buffer buf
             (setq projectile-replace--matches matches
                   projectile-replace--truncated truncated)
@@ -9870,6 +9914,99 @@ so full Emacs regexp syntax (e.g. symbol boundaries like `\\_<foo\\_>')
 is honored."
   (interactive)
   (projectile-search--review nil))
+
+;;; Project-wide TODO/FIXME annotations
+;;
+;; `projectile-todos' is a thin command on top of the read-only search
+;; reviewer above: it builds one regexp out of `projectile-todo-keywords' and
+;; opens the very same `*projectile-search*' buffer, so grouping by file,
+;; navigation, the keep/flush filters, re-search, the grep-mode export and the
+;; hand-off to the replace reviewer all come for free.
+;;
+;; The keyword regexp is fenced the way hl-todo and magit-todos fence theirs:
+;; the keyword must start at a word boundary and be followed by a colon,
+;; whitespace or the end of the line, so `TODO:' and `FIXME ' are hits while
+;; `TODOS' and `MASTODON' are not.  Requiring a comment character in front is
+;; deliberately NOT done: neither scan parses the language, and the comment
+;; syntax would have to be guessed per file type, so an annotation in a string
+;; or in prose is reported too (cheap to filter out with `d' in the buffer).
+;;
+;; Because a big repo is exactly where a pure-elisp scan hurts, the command
+;; also hands the reviewer a ripgrep-syntax spelling of the same pattern
+;; (`projectile-replace--rg-pattern'), which lets the otherwise literal-only
+;; ripgrep fast-path run for this non-literal search.  The two spellings agree
+;; except at underscores (rg's `\b' counts `_' as a word character, Emacs'
+;; word boundaries do not), which only shows up for identifiers like
+;; `TODO_LIST'.
+
+(defun projectile-todos--rg-quote (keyword)
+  "Quote KEYWORD for ripgrep's regex syntax.
+Every character that is not alphanumeric or an underscore is escaped, so
+a keyword carrying punctuation (`@TODO', `TODO?') stays literal in Rust
+regex syntax, where more characters are special than in Emacs'."
+  (replace-regexp-in-string "[^[:alnum:]_]" "\\\\\\&" keyword t))
+
+(defun projectile-todos--regexp (keywords)
+  "Return the Emacs regexp matching any annotation keyword in KEYWORDS.
+The keyword must begin at a word boundary and be followed by a colon, by
+whitespace or by the end of the line."
+  (concat "\\<" (regexp-opt keywords) "\\>\\(?::\\|[[:blank:]]\\|$\\)"))
+
+(defun projectile-todos--rg-pattern (keywords)
+  "Return the ripgrep-syntax equivalent of `projectile-todos--regexp'.
+KEYWORDS is the list of annotation keywords to match."
+  (concat "\\b(?:"
+          (mapconcat #'projectile-todos--rg-quote keywords "|")
+          ")\\b(?::|[[:blank:]]|$)"))
+
+(defun projectile-todos--read-keywords ()
+  "Read which of `projectile-todo-keywords' to search for.
+Several keywords can be given, comma separated, and a keyword that is not
+in the list can be typed in for a one-off search."
+  (let ((keywords (delete "" (completing-read-multiple
+                              (projectile-prepend-project-name
+                               "TODO keywords: ")
+                              projectile-todo-keywords))))
+    (or keywords (user-error "No annotation keywords given"))))
+
+;;;###autoload
+(defun projectile-todos (&optional arg)
+  "Collect the project's TODO-style annotations and review them read-only.
+
+Searches every project file for the annotation keywords in
+`projectile-todo-keywords' (`TODO', `FIXME', `HACK', ... - customize the
+list to match your own conventions) and gathers the hits into the same
+read-only `*projectile-search*' buffer `projectile-search-review' uses,
+grouped by file, so all of its navigation, filtering, re-search, export
+and hand-off commands apply.
+
+A keyword only counts when it stands as a whole word followed by a colon,
+by whitespace or by the end of the line, so `TODO:' and `FIXME ' are
+found while `TODOS' and `MASTODON' are not.  Matching is case-sensitive
+\(annotation keywords are uppercase by convention); toggle that with `c'
+in the results buffer.  The keyword does not have to sit in a comment.
+
+With a prefix argument ARG, prompt for which keywords to search for
+instead of using all of them."
+  (interactive "P")
+  (let* ((root (projectile-acquire-root))
+         (keywords (or (if arg
+                           (projectile-todos--read-keywords)
+                         projectile-todo-keywords)
+                       (user-error "`projectile-todo-keywords' is empty")))
+         (regexp (projectile-todos--regexp keywords))
+         (rg-pattern (projectile-todos--rg-pattern keywords))
+         ;; the term IS the regexp, so the in-buffer toggles keep working
+         (case-fold nil)
+         (candidates (projectile-replace--candidates regexp nil case-fold root)))
+    (projectile-replace--open
+     #'projectile-search-mode projectile-search-buffer-name
+     root regexp regexp nil nil case-fold candidates
+     (projectile-prepend-project-name
+      (format "No %s annotations found" (string-join keywords "/")))
+     ;; The pattern is already word-fenced and ends in a delimiter, so the
+     ;; whole-word fence could never match; whole-word mode is not seeded here.
+     nil rg-pattern)))
 
 (defun projectile--buffer-matches-conditions (buffer conditions)
   "Return non-nil if BUFFER satisfies any condition in CONDITIONS.
@@ -12814,6 +12951,7 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "s x") #'projectile-find-references)
     (define-key map (kbd "s R") #'projectile-search-review)
     (define-key map (kbd "s X") #'projectile-search-regexp-review)
+    (define-key map (kbd "s t") #'projectile-todos)
     (define-key map (kbd "S") #'projectile-save-project-buffers)
     (define-key map (kbd "t") #'projectile-toggle-between-implementation-and-test)
     (define-key map (kbd "T") #'projectile-find-test-file)
@@ -13131,6 +13269,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("sa" "ag" projectile-dispatch-ag)
       ("sx" "references" projectile-find-references)
       ("sR" "search (review)" projectile-dispatch-search-review)
+      ("st" "todos" projectile-todos)
       ("o" "multi-occur" projectile-multi-occur)
       ("r" "replace" projectile-replace)
       ("R" "replace (review)" projectile-dispatch-replace-review)]]
@@ -13252,6 +13391,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
          ["Search with grep" projectile-grep]
          ["Search with ripgrep" projectile-ripgrep]
          ["Search with ag" projectile-ag]
+         ["Project TODOs (review)" projectile-todos]
          ["Replace in project" projectile-replace]
          ["Replace in project (review)" projectile-replace-review]
          ["Replace regexp in project (review)" projectile-replace-regexp-review]

--- a/test/projectile-todos-test.el
+++ b/test/projectile-todos-test.el
@@ -1,0 +1,213 @@
+;;; projectile-todos-test.el --- Tests for the project TODO collector -*- lexical-binding: t -*-
+
+;; Copyright © 2011-2026 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for `projectile-todos', the annotation collector built on top of the
+;; read-only search reviewer.  The keyword regexp gets the closest scrutiny:
+;; a pattern that matches `MASTODON' would make the command useless.
+
+;;; Code:
+
+(require 'projectile-test-helpers)
+(require 'crm)
+
+(defun projectile-todos-test--matches-p (regexp string)
+  "Return non-nil when REGEXP matches STRING case-sensitively."
+  (let ((case-fold-search nil))
+    (and (string-match-p regexp string) t)))
+
+(defun projectile-todos-test--run (&optional arg)
+  "Run `projectile-todos' with ARG and return the results buffer."
+  (cl-letf (((symbol-function 'pop-to-buffer) #'ignore))
+    (projectile-todos arg))
+  (get-buffer projectile-search-buffer-name))
+
+(defun projectile-todos-test--strings (buf)
+  "Return the matched strings collected in BUF, in order."
+  (with-current-buffer buf
+    (mapcar #'projectile-replace--match-string projectile-replace--matches)))
+
+(describe "projectile-todos--regexp"
+  (let ((regexp (projectile-todos--regexp '("TODO" "FIXME"))))
+    (it "matches a keyword followed by a colon"
+      (expect (projectile-todos-test--matches-p regexp ";; TODO: fix this")
+              :to-be-truthy))
+
+    (it "matches a keyword followed by whitespace"
+      (expect (projectile-todos-test--matches-p regexp "# FIXME this is wrong")
+              :to-be-truthy)
+      (expect (projectile-todos-test--matches-p regexp "//\tTODO\tlater")
+              :to-be-truthy))
+
+    (it "matches a keyword at the end of the line"
+      (expect (projectile-todos-test--matches-p regexp ";; TODO")
+              :to-be-truthy))
+
+    (it "matches without a comment character in front"
+      (expect (projectile-todos-test--matches-p regexp "print(\"TODO: soon\")")
+              :to-be-truthy)
+      (expect (projectile-todos-test--matches-p regexp "TODO: at line start")
+              :to-be-truthy))
+
+    (it "does not match a longer word starting with the keyword"
+      (expect (projectile-todos-test--matches-p regexp "my TODOS list")
+              :to-be nil)
+      (expect (projectile-todos-test--matches-p regexp "TODOS: many")
+              :to-be nil))
+
+    (it "does not match a keyword embedded in another word"
+      (expect (projectile-todos-test--matches-p regexp "MASTODON: a bird")
+              :to-be nil)
+      (expect (projectile-todos-test--matches-p regexp "unFIXME: nope")
+              :to-be nil))
+
+    (it "is case-sensitive"
+      (expect (projectile-todos-test--matches-p regexp ";; todo: later")
+              :to-be nil)
+      (expect (projectile-todos-test--matches-p regexp ";; Fixme: later")
+              :to-be nil))
+
+    (it "matches only the keywords it was given"
+      (expect (projectile-todos-test--matches-p regexp ";; HACK: nope")
+              :to-be nil))))
+
+(describe "projectile-todos--rg-pattern"
+  (it "spells the same fencing in ripgrep's syntax"
+    (expect (projectile-todos--rg-pattern '("TODO" "FIXME"))
+            :to-equal "\\b(?:TODO|FIXME)\\b(?::|[[:blank:]]|$)"))
+
+  (it "escapes punctuation that Rust regex would take as syntax"
+    (expect (projectile-todos--rg-pattern '("@TODO" "TODO?"))
+            :to-equal "\\b(?:\\@TODO|TODO\\?)\\b(?::|[[:blank:]]|$)")))
+
+(describe "projectile-todos"
+  (it "collects the default keywords across the project, ignoring near-misses"
+    (projectile-test-with-project
+        (("a.el" . ";; TODO: one\n;; TODOS are not annotations\n;; todo: nor is this\n")
+         ("lib/b.py" . "# FIXME broken\nMASTODON = 1\n# HACK\n")
+         ("c.txt" . "nothing to see here\n"))
+      (let ((buf (projectile-todos-test--run)))
+        ;; file order is the indexer's, so compare as a set
+        (expect (sort (projectile-todos-test--strings buf) #'string<)
+                :to-equal '("FIXME " "HACK" "TODO:"))
+        (with-current-buffer buf
+          (expect major-mode :to-equal 'projectile-search-mode)
+          ;; annotation keywords are uppercase by convention
+          (expect projectile-replace--case-fold :to-be nil)
+          (expect projectile-replace--literal :to-be nil)
+          ;; the whole-word fence would break the already-fenced pattern
+          (expect projectile-replace--word :to-be nil)
+          (expect (buffer-string) :to-match "a\\.el (1)")
+          (expect (buffer-string) :to-match "lib/b\\.py (2)")
+          (expect (buffer-string) :not :to-match "c\\.txt")))))
+
+  (it "reports nothing to review when the project is clean"
+    (projectile-test-with-project
+        (("a.el" . ";; all good here\n"))
+      (spy-on 'message)
+      (expect (projectile-todos-test--run) :to-be nil)))
+
+  (it "seeds the ripgrep-syntax equivalent of the pattern"
+    (projectile-test-with-project
+        (("a.el" . ";; TODO: one\n"))
+      (with-current-buffer (projectile-todos-test--run)
+        (expect projectile-replace--rg-pattern
+                :to-equal (projectile-todos--rg-pattern
+                           projectile-todo-keywords))
+        ;; toggling the search's shape drops the ripgrep spelling, since it
+        ;; describes the old search
+        (projectile-replace--toggle-regexp)
+        (expect projectile-replace--rg-pattern :to-be nil))))
+
+  (it "honors a customized keyword list"
+    (projectile-test-with-project
+        (("a.el" . ";; TODO: one\n;; REVIEW: this\n"))
+      (let* ((projectile-todo-keywords '("REVIEW"))
+             (buf (projectile-todos-test--run)))
+        (expect (projectile-todos-test--strings buf) :to-equal '("REVIEW:")))))
+
+  (it "refuses to search with an empty keyword list"
+    (projectile-test-with-project
+        (("a.el" . ";; TODO: one\n"))
+      (let ((projectile-todo-keywords nil))
+        (expect (projectile-todos-test--run) :to-throw 'user-error)))))
+
+(describe "projectile-todos with a prefix argument"
+  (it "searches only the keywords picked at the prompt"
+    (projectile-test-with-project
+        (("a.el" . ";; TODO: one\n;; FIXME: two\n;; HACK: three\n"))
+      (spy-on 'completing-read-multiple :and-return-value '("FIXME" "HACK"))
+      (let ((buf (projectile-todos-test--run '(4))))
+        (expect (projectile-todos-test--strings buf)
+                :to-equal '("FIXME:" "HACK:"))
+        (expect (spy-calls-count 'completing-read-multiple) :to-equal 1))))
+
+  (it "accepts a keyword that is not in the customized list"
+    (projectile-test-with-project
+        (("a.el" . ";; TODO: one\n;; REVIEW: two\n"))
+      (spy-on 'completing-read-multiple :and-return-value '("REVIEW"))
+      (expect (projectile-todos-test--strings (projectile-todos-test--run '(4)))
+              :to-equal '("REVIEW:"))))
+
+  (it "refuses an empty selection"
+    (projectile-test-with-project
+        (("a.el" . ";; TODO: one\n"))
+      (spy-on 'completing-read-multiple :and-return-value '(""))
+      (expect (projectile-todos-test--run '(4)) :to-throw 'user-error))))
+
+(describe "projectile-todos ripgrep fast-path"
+  (before-each
+    (spy-on 'executable-find :and-call-fake
+            (lambda (command &rest _) (and (equal command "rg") "rg"))))
+
+  (it "opens the fast-path to a non-literal search carrying an rg pattern"
+    (let ((noninteractive nil) (projectile-search-use-ripgrep t))
+      (expect (projectile-search--rg-fastpath-p nil "\\bTODO\\b") :to-be-truthy)
+      ;; ... but not to a plain regexp search
+      (expect (projectile-search--rg-fastpath-p nil) :to-be nil))
+    (let ((noninteractive nil) (projectile-search-use-ripgrep nil))
+      (expect (projectile-search--rg-fastpath-p nil "\\bTODO\\b") :to-be nil)))
+
+  (it "searches the pattern as a regexp rather than a fixed string"
+    (let* ((pattern (projectile-todos--rg-pattern '("TODO")))
+           (cmd (projectile-search--rg-command "ignored" nil nil nil pattern)))
+      (expect (member "--fixed-strings" cmd) :to-be nil)
+      (expect (member "--case-sensitive" cmd) :to-be-truthy)
+      (let ((tail (cdr (member "--" cmd))))
+        (expect (car tail) :to-equal pattern)
+        (expect (cadr tail) :to-equal "./"))))
+
+  (it "routes a todos buffer to the ripgrep gather"
+    (projectile-test-with-project
+        (("a.el" . ";; TODO: one\n"))
+      (spy-on 'projectile-search--gather-rg)
+      (spy-on 'projectile-replace--gather-async)
+      (let ((noninteractive nil) (projectile-search-use-ripgrep t))
+        (cl-letf (((symbol-function 'pop-to-buffer) #'ignore))
+          (projectile-todos))
+        (expect (spy-calls-count 'projectile-search--gather-rg) :to-equal 1)
+        (expect (spy-calls-count 'projectile-replace--gather-async)
+                :to-equal 0)))))
+
+(provide 'projectile-todos-test)
+
+;;; projectile-todos-test.el ends here


### PR DESCRIPTION
`projectile-todos` (`s-p s t`) collects the project's TODO/FIXME/HACK annotations into the existing `*projectile-search*` reviewer, so the grouping, filters, `g` re-search, `r` bridge to replace and `e` grep-mode export all come for free. A prefix argument prompts for which keywords to search; `projectile-todo-keywords` sets the default list.

The regexp matches the keyword as a whole word followed by a colon, blank, or end of line, case-sensitively - so `TODO:` and `FIXME ` hit while `TODOS`, `MASTODON`, `unFIXME` and lowercase `todo` don't. A naive substring match is worse than useless in a real codebase, so the specs pin exactly those cases.

The reviewer's ripgrep fast path was literal-only (`--fixed-strings`), which is a shame precisely here - a TODO scan over a big repo is where the elisp scan hurts most. Rather than fork it, it now carries an optional rg-syntax spelling of the search alongside the Emacs regexp, and drops `--fixed-strings` when one is supplied. The toggle-regexp command clears it, since the old spelling no longer describes the search.

Two documented rough edges: no comment-character requirement, because neither scan parses the language, so a keyword inside a string literal is a hit; and the status header shows the generated regexp rather than a friendly label, because the reviewer's in-buffer `x`/`g` toggles re-use the term and would break if it didn't round-trip.