### PR TITLE
Add project-scoped bookmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### New features
 
+- [#2114](https://github.com/bbatsov/projectile/pull/2114): Add project-scoped bookmarks - `projectile-bookmark-set` (`s-p B s`), `projectile-bookmark-jump` (`s-p B j`) and `projectile-bookmark-delete` (`s-p B d`).
+  - They're plain Emacs bookmarks, so they show up in `list-bookmarks` and are persisted by `bookmark.el` itself; Projectile only scopes the completion to the current project and suggests a project-prefixed name.
+  - A bookmark counts as the project's when its file lives under the project root or its name starts with the project's name - see `projectile-bookmark-scope`.
 - [#2113](https://github.com/bbatsov/projectile/pull/2113): Add `projectile-todos` (`s-p s t`), which collects the project's `TODO`/`FIXME`-style annotations into the reviewable search buffer.
   - The keywords come from `projectile-todo-keywords`; with a prefix argument you're prompted for which of them to search for.
   - A keyword only counts as a whole word followed by a colon, by whitespace or by the end of the line, so `TODOS` and `MASTODON` are not hits.
@@ -31,6 +34,7 @@
 
 ### Changes
 
+- [#2114](https://github.com/bbatsov/projectile/pull/2114): In `projectile-dispatch`, "display buffer" moved from `B` to `C-o` (mirroring its `s-p 4 C-o` binding), so `B` could become the bookmark prefix.
 - [#2110](https://github.com/bbatsov/projectile/pull/2110): The grep/ag search integration and the ignore predicates now derive their exclusions from the same gitignore patterns indexing uses, instead of expanding the dirconfig into absolute paths on their own.
   - `projectile-ignored-file-p` and `projectile-ignored-directory-p` now take an optional project root instead of a pre-computed list of ignored paths, and answer exactly what indexing would (ensure entries included, a file under an ignored directory counted as ignored).
   - Under `rgrep` an ignore pattern is passed as a pattern rather than as whatever it happened to expand to on disk, `!` ensure entries can now rescue root-anchored paths too, and the globally ignored suffixes are no longer also folded into `grep-find-ignored-files`.

--- a/doc/modules/ROOT/pages/cheatsheet.adoc
+++ b/doc/modules/ROOT/pages/cheatsheet.adoc
@@ -247,6 +247,15 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p x G]
 | Start or visit a `ghostel` terminal for the project.
 
+| kbd:[s-p B s]
+| Set a bookmark at point, named after the current project.
+
+| kbd:[s-p B j]
+| Jump to one of the current project's bookmarks.
+
+| kbd:[s-p B d]
+| Delete one of the current project's bookmarks.
+
 | kbd:[s-p w s]
 | Save the current project's session (see `projectile-session-mode`).
 

--- a/doc/modules/ROOT/pages/configuration_index.adoc
+++ b/doc/modules/ROOT/pages/configuration_index.adoc
@@ -32,6 +32,9 @@ and the other reference pages.
 | `projectile-before-switch-project-hook`
 | Hooks run right before project is switched.
 
+| `projectile-bookmark-scope`
+| How a bookmark is recognised as belonging to a project.
+
 | `projectile-buffers-filter-function`
 | A function used to filter the buffers in ‘projectile-project-buffers’.
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -447,6 +447,65 @@ comment: neither scan parses the language (and the comment syntax would
 have to be guessed per file type), so an annotation inside a string or in
 prose is reported too - kbd:[d] flushes those you don't care about.
 
+== Project bookmarks
+
+Emacs bookmarks are global, which makes them awkward for project work: a
+handful of projects and the list you get from `bookmark-jump` is a mess.
+Projectile adds a project scope on top of the built-in `bookmark.el` -
+that's all it adds. There's no separate storage and no separate
+persistence: the bookmarks you set are ordinary Emacs bookmarks, they
+show up in `list-bookmarks` and `bookmark.el` saves them for you.
+
+* `projectile-bookmark-set` (kbd:[s-p B s]) - bookmark the current
+location. The suggested name is the one `bookmark-set` would suggest
+(normally the file name), prefixed with the project's name, e.g.
+`projectile: projectile.el`. Edit it as you please.
+* `projectile-bookmark-jump` (kbd:[s-p B j]) - jump to one of the
+project's bookmarks. Only they are offered for completion.
+* `projectile-bookmark-delete` (kbd:[s-p B d]) - delete one of them.
+
+The completion candidates are advertised under the standard `bookmark`
+completion category, so `marginalia` annotates them and `embark` acts on
+them exactly like on any other bookmark prompt.
+
+NOTE: The bookmarks live wherever `bookmark-default-file` points, like
+all your other bookmarks. They have nothing to do with
+`projectile-bookmarks.eld`, which is the (unfortunately named) file
+Projectile keeps its list of known projects in.
+
+Since the suggested name is derived from the file, bookmarking a second
+spot in the same file and accepting the suggested name again replaces
+the first bookmark - give the second one a name of its own.
+
+=== How a bookmark is scoped to a project
+
+There are two ways to tell whether a bookmark is the project's, and
+neither is perfect:
+
+* the bookmark's *recorded file* lives under the project root. This
+survives renaming the bookmark and catches bookmarks you set with plain
+`bookmark-set` (or with `org-capture`, or from Dired), but it can't see
+bookmarks that record no file at all, like those of Info or Man buffers.
+* the bookmark's *name* starts with the project's name followed by a
+colon and a space, which is how `projectile-bookmark-set` names them.
+That covers the file-less bookmarks, but it breaks the moment the
+bookmark (or the project directory) is renamed.
+
+By default Projectile applies both and a bookmark belongs to the project
+when either test says so. Set `projectile-bookmark-scope` to `file` or
+`name` to use just one of them:
+
+[source,elisp]
+----
+;; only bookmarks whose file is inside the project
+(setq projectile-bookmark-scope 'file)
+----
+
+NOTE: If the file a bookmark points to has been deleted in the meantime,
+`projectile-bookmark-jump` says so and stops, instead of taking you
+through the relocation prompt of `bookmark.el`. Use
+`projectile-bookmark-delete` to get rid of a stale bookmark.
+
 == Customizing Projectile's keybindings
 
 It is possible to add additional commands to

--- a/projectile.el
+++ b/projectile.el
@@ -11704,6 +11704,177 @@ overwriting each other's changes."
     (projectile-save-known-projects)))
 
 
+;;; Project bookmarks
+;;
+;; Project-scoped bookmarks on top of the built-in `bookmark.el'.  There's
+;; no separate storage and no separate persistence: a Projectile bookmark
+;; is an ordinary Emacs bookmark, so it shows up in `list-bookmarks',
+;; survives restarts and honours `bookmark-save-flag' for free.  All
+;; Projectile adds is a project scope - the commands below only ever offer
+;; you the current project's bookmarks - and a project-prefixed default
+;; name, so the entries stay identifiable in the global list.
+
+;; `bookmark' is built in, but only its commands are autoloaded - the
+;; accessors and `bookmark-alist' used below are not.
+(require 'bookmark)
+
+(defcustom projectile-bookmark-scope 'both
+  "How a bookmark is recognised as belonging to a project.
+
+Emacs bookmarks are global, so Projectile has to decide which of them
+belong to the project at hand.  There are two ways to tell, each with a
+different failure mode:
+
+- `file' - the bookmark's recorded file lives under the project root.
+  Robust (it survives renaming the bookmark, and catches bookmarks made
+  with plain `bookmark-set'), but blind to bookmarks that record no
+  file, e.g. those of Info or Man buffers.
+
+- `name' - the bookmark's name starts with the project's name followed
+  by a colon and a space, which is how `projectile-bookmark-set' names
+  bookmarks by default.  Covers bookmarks without a file, but breaks as
+  soon as the bookmark (or the project directory) is renamed.
+
+- `both' - the default: a bookmark belongs to the project when either
+  test says so."
+  :group 'projectile
+  :type '(choice (const :tag "Recorded file lives under the project root" file)
+                 (const :tag "Name starts with the project name" name)
+                 (const :tag "Either of the two" both))
+  :package-version '(projectile . "3.3.0"))
+
+(defun projectile-bookmark--name-prefix (&optional project)
+  "Return the bookmark name prefix for PROJECT.
+PROJECT is a project root and defaults to the current project."
+  (format "%s: " (projectile-project-name project)))
+
+(defun projectile-bookmark--under-root-p (filename root)
+  "Return non-nil when FILENAME is a file under ROOT.
+ROOT is expected to be a true name already; FILENAME is resolved to
+one, so a symlinked path into the project still matches.  FILENAME need
+not exist - a bookmark whose file was deleted still belongs to the
+project that file was in."
+  (and filename
+       ;; A remote file can't be under a local root (and the other way
+       ;; around).  Answer that from the names alone: resolving a remote
+       ;; name would open a TRAMP connection, and a single stale remote
+       ;; bookmark would then stall every bookmark prompt.
+       (equal (file-remote-p filename) (file-remote-p root))
+       (let ((non-essential t))
+         (string-prefix-p root (file-truename (expand-file-name filename))))))
+
+(defun projectile-bookmark--belongs-p (bookmark root)
+  "Return non-nil when BOOKMARK belongs to the project at ROOT.
+BOOKMARK is a bookmark record and ROOT the project root's true name,
+ending in a slash.  Which test is applied is governed by
+`projectile-bookmark-scope'."
+  (or (and (memq projectile-bookmark-scope '(file both))
+           (projectile-bookmark--under-root-p
+            (bookmark-get-filename bookmark) root)
+           t)
+      (and (memq projectile-bookmark-scope '(name both))
+           (string-prefix-p (projectile-bookmark--name-prefix root)
+                            (bookmark-name-from-full-record bookmark)))))
+
+(defun projectile-bookmark-names (&optional root)
+  "Return the names of the bookmarks belonging to the project at ROOT.
+ROOT defaults to the current project.  See `projectile-bookmark-scope'
+for what makes a bookmark the project's."
+  (let ((root (file-name-as-directory
+               (file-truename (or root (projectile-acquire-root))))))
+    (bookmark-maybe-load-default-file)
+    (delq nil (mapcar (lambda (bookmark)
+                        (and (projectile-bookmark--belongs-p bookmark root)
+                             (bookmark-name-from-full-record bookmark)))
+                      bookmark-alist))))
+
+(defun projectile-bookmark--default-name (root)
+  "Return the suggested name for a new bookmark at point in ROOT.
+That's the name `bookmark-make-record' suggests (normally the file or
+buffer name), prefixed with the project's name.  Buffers `bookmark.el'
+cannot record at all (those visiting neither a file nor a directory,
+unless their mode knows how to bookmark itself) are refused with a
+`user-error' rather than with a bare error and a backtrace."
+  (concat (projectile-bookmark--name-prefix root)
+          ;; Without this binding the record's name falls back to that of
+          ;; the bookmark last used, which has nothing to do with the
+          ;; location being bookmarked now.
+          (let ((bookmark-current-bookmark nil))
+            (condition-case err
+                (bookmark-name-from-full-record (bookmark-make-record))
+              (user-error (signal (car err) (cdr err)))
+              (error (user-error "%s" (error-message-string err)))))))
+
+(defun projectile-bookmark--record (name)
+  "Return the bookmark record named NAME.
+Signals a `user-error' when there is no such bookmark - the completion
+prompts don't require a match, and `bookmark.el' answers a name it
+doesn't know with a bare error (or, in the case of `bookmark-delete',
+with a cheerful nothing at all)."
+  (or (bookmark-get-bookmark name t)
+      (user-error "No bookmark named `%s'" name)))
+
+(defun projectile-bookmark--read (prompt &optional root)
+  "Read one of the project's bookmark names with PROMPT.
+ROOT defaults to the current project.  Signals a `user-error' when the
+project has no bookmarks yet."
+  (let* ((root (or root (projectile-acquire-root)))
+         (names (projectile-bookmark-names root)))
+    (unless names
+      (user-error "%s" (projectile-prepend-project-name
+                        "No bookmarks in this project")))
+    (projectile-completing-read prompt names :category 'bookmark)))
+
+;;;###autoload
+(defun projectile-bookmark-set (name)
+  "Set a bookmark named NAME at point, scoped to the current project.
+
+The bookmark is a regular Emacs bookmark - it lands in `bookmark-alist',
+shows up in `list-bookmarks' and is persisted by `bookmark.el' itself.
+The only Projectile touch is the suggested NAME: the name `bookmark-set'
+would suggest, prefixed with the project's name (e.g. \"projectile:
+projectile.el\"), so the project's bookmarks are easy to spot in the
+global list.  You're free to edit the name - a bookmark on a file inside
+the project is recognised as the project's even without the prefix (see
+`projectile-bookmark-scope')."
+  (interactive
+   (let ((default (projectile-bookmark--default-name (projectile-acquire-root))))
+     (list (read-string "Set bookmark: " default 'bookmark-history default))))
+  (bookmark-set name))
+
+;;;###autoload
+(defun projectile-bookmark-jump (name)
+  "Jump to the project bookmark named NAME.
+Only the current project's bookmarks are offered for completion - see
+`projectile-bookmark-scope' for how that's decided.
+
+When the bookmark's file has been deleted in the meantime this refuses
+with a friendly error instead of dragging you through the relocation
+prompt of `bookmark.el'.  Use `projectile-bookmark-delete' to get rid of
+such a stale bookmark."
+  (interactive (list (projectile-bookmark--read "Jump to bookmark: ")))
+  (let* ((record (projectile-bookmark--record name))
+         (file (bookmark-get-filename record)))
+    ;; A bookmark with a handler of its own may keep something else
+    ;; entirely in `filename', so only vet the ones `bookmark.el' will
+    ;; resolve as a file itself.
+    (when (and file
+               (not (bookmark-get-handler record))
+               (not (file-readable-p file)))
+      (user-error "The file of bookmark `%s' is gone (%s)" name file)))
+  (bookmark-jump name))
+
+;;;###autoload
+(defun projectile-bookmark-delete (name)
+  "Delete the project bookmark named NAME.
+Only the current project's bookmarks are offered for completion - see
+`projectile-bookmark-scope' for how that's decided."
+  (interactive (list (projectile-bookmark--read "Delete bookmark: ")))
+  (projectile-bookmark--record name)
+  (bookmark-delete name)
+  (message "Deleted bookmark `%s'" name))
+
+
 ;;; IBuffer integration
 (define-ibuffer-filter projectile-files
     "Show Ibuffer with all buffers in the current project."
@@ -12922,6 +13093,10 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "a") #'projectile-find-other-file)
     (define-key map (kbd "A") #'projectile-add-known-project)
     (define-key map (kbd "b") #'projectile-switch-to-buffer)
+    ;; project-scoped bookmarks (see `projectile-bookmark-set')
+    (define-key map (kbd "B s") #'projectile-bookmark-set)
+    (define-key map (kbd "B j") #'projectile-bookmark-jump)
+    (define-key map (kbd "B d") #'projectile-bookmark-delete)
     (define-key map (kbd "d") #'projectile-find-dir)
     (define-key map (kbd "D") #'projectile-dired)
     (define-key map (kbd "e") #'projectile-recentf)
@@ -13258,10 +13433,14 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("J" "toggle related" projectile-toggle-related-file)]
      ["Buffers"
       ("b" "switch buffer" projectile-dispatch-switch-to-buffer)
-      ("B" "display buffer" projectile-display-buffer)
+      ("C-o" "display buffer" projectile-display-buffer)
       ("I" "ibuffer" projectile-ibuffer)
       ("k" "kill buffers" projectile-kill-buffers)
       ("S" "save buffers" projectile-save-project-buffers)]
+     ["Bookmarks"
+      ("Bs" "set bookmark" projectile-bookmark-set)
+      ("Bj" "jump to bookmark" projectile-bookmark-jump)
+      ("Bd" "delete bookmark" projectile-bookmark-delete)]
      ["Search / Replace"
       ("ss" "search" projectile-dispatch-search)
       ("sg" "grep" projectile-grep)
@@ -13361,6 +13540,10 @@ search/replace case-sensitive, `--word' makes it match whole words,
          ["Recent files" projectile-recentf]
          ["Previous buffer" projectile-previous-project-buffer]
          ["Next buffer" projectile-next-project-buffer])
+        ("Bookmarks"
+         ["Set bookmark" projectile-bookmark-set]
+         ["Jump to bookmark" projectile-bookmark-jump]
+         ["Delete bookmark" projectile-bookmark-delete])
         ("Projects"
          ["Add known project" projectile-add-known-project]
          ["Add and switch to project" projectile-add-and-switch-project]

--- a/test/projectile-bookmarks-test.el
+++ b/test/projectile-bookmarks-test.el
@@ -1,0 +1,253 @@
+;;; projectile-bookmarks-test.el --- Tests for the project bookmarks -*- lexical-binding: t -*-
+
+;; Copyright © 2011-2026 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for the project-scoped bookmark commands, which are a thin project
+;; filter over the built-in `bookmark.el'.  Every spec runs with a private,
+;; empty `bookmark-alist' and saving disabled, so the user's real bookmark
+;; file is never read nor written.
+
+;;; Code:
+
+(require 'projectile-test-helpers)
+(require 'bookmark)
+(require 'cl-lib)
+
+(defmacro projectile-test-with-bookmarks (bookmarks &rest body)
+  "Evaluate BODY with `bookmark-alist' bound to BOOKMARKS.
+Bookmark persistence is neutralised for the duration, so the specs never
+touch `bookmark-default-file'."
+  (declare (indent 1) (debug (form &rest form)))
+  `(let ((bookmark-alist ,bookmarks)
+         ;; never save, never annotate, never fontify
+         (bookmark-save-flag nil)
+         (bookmark-watch-bookmark-file nil)
+         (bookmark-use-annotations nil)
+         (bookmark-fringe-mark nil)
+         (bookmark-current-bookmark nil)
+         (bookmark-history nil)
+         (bookmark-alist-modification-count 0)
+         ;; keep the rebuild that `bookmark-store'/`bookmark-delete' do
+         ;; away from a real `*Bookmark List*' buffer
+         (bookmark-bmenu-buffer " *projectile-test-bookmarks*"))
+     ;; The loader is what would read `bookmark-default-file'; stubbing it
+     ;; out is both the strongest guarantee that no spec ever touches the
+     ;; user's bookmarks and the one thing that works across the Emacs
+     ;; versions we support (the "already loaded" flag was renamed).
+     (cl-letf (((symbol-function 'bookmark-maybe-load-default-file) #'ignore))
+       ,@body)))
+
+(defun projectile-test-bookmark (name file)
+  "Return a bookmark record named NAME recording FILE."
+  `(,name (filename . ,file) (position . 1)))
+
+(describe "projectile-bookmark-set"
+  (it "records a bookmark named after the project"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (projectile-test-with-bookmarks nil
+        (let ((buffer (find-file-noselect "project/foo.el")))
+          (unwind-protect
+              (with-current-buffer buffer
+                (spy-on 'read-string :and-call-fake
+                        (lambda (_prompt initial &rest _) initial))
+                (call-interactively #'projectile-bookmark-set)
+                ;; the suggested name is what the user got offered...
+                (expect (spy-calls-args-for 'read-string 0)
+                        :to-equal '("Set bookmark: " "project: foo.el"
+                                    bookmark-history "project: foo.el"))
+                ;; ...and what ended up in the global bookmark list
+                (expect (bookmark-all-names) :to-equal '("project: foo.el"))
+                (expect (file-truename (bookmark-get-filename "project: foo.el"))
+                        :to-equal (expand-file-name
+                                   "foo.el" (projectile-project-root))))
+            (kill-buffer buffer))))))
+
+  (it "honours a name the user edited"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (projectile-test-with-bookmarks nil
+        (let ((buffer (find-file-noselect "project/foo.el")))
+          (unwind-protect
+              (with-current-buffer buffer
+                (spy-on 'read-string :and-return-value "my own name")
+                (call-interactively #'projectile-bookmark-set)
+                (expect (bookmark-all-names) :to-equal '("my own name"))
+                ;; still the project's, thanks to the recorded file
+                (expect (projectile-bookmark-names (projectile-project-root))
+                        :to-equal '("my own name")))
+            (kill-buffer buffer))))))
+
+  (it "refuses a buffer bookmark.el cannot record"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (projectile-test-with-bookmarks nil
+        (with-temp-buffer
+          (spy-on 'read-string)
+          (expect (call-interactively #'projectile-bookmark-set)
+                  :to-throw 'user-error)
+          (expect 'read-string :not :to-have-been-called))))))
+
+(describe "projectile-bookmark-names"
+  (it "returns only the current project's bookmarks"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (let ((root (projectile-project-root)))
+        (projectile-test-with-bookmarks
+            (list (projectile-test-bookmark
+                   "renamed" (expand-file-name "foo.el" root))
+                  (projectile-test-bookmark
+                   "other: bar.el" (expand-file-name "../other/bar.el" root))
+                  ;; no file, but carries the project's name prefix
+                  `("project: some Info node" (position . 1))
+                  `("elsewhere" (position . 1)))
+          (expect (projectile-bookmark-names root)
+                  :to-have-same-items-as '("renamed" "project: some Info node"))))))
+
+  (it "can be restricted to the recorded file"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (let ((root (projectile-project-root)))
+        (projectile-test-with-bookmarks
+            (list (projectile-test-bookmark
+                   "renamed" (expand-file-name "foo.el" root))
+                  `("project: some Info node" (position . 1)))
+          (let ((projectile-bookmark-scope 'file))
+            (expect (projectile-bookmark-names root) :to-equal '("renamed")))))))
+
+  (it "can be restricted to the name prefix"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (let ((root (projectile-project-root)))
+        (projectile-test-with-bookmarks
+            (list (projectile-test-bookmark
+                   "renamed" (expand-file-name "foo.el" root))
+                  `("project: some Info node" (position . 1)))
+          (let ((projectile-bookmark-scope 'name))
+            (expect (projectile-bookmark-names root)
+                    :to-equal '("project: some Info node"))))))))
+
+(describe "projectile-bookmark-jump"
+  (it "completes over the current project's bookmarks only"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (let ((root (projectile-project-root)))
+        (projectile-test-with-bookmarks
+            (list (projectile-test-bookmark
+                   "project: foo.el" (expand-file-name "foo.el" root))
+                  (projectile-test-bookmark
+                   "other: bar.el" (expand-file-name "../other/bar.el" root)))
+          (spy-on 'projectile-completing-read :and-return-value "project: foo.el")
+          (spy-on 'bookmark-jump)
+          (call-interactively #'projectile-bookmark-jump)
+          (expect (nth 1 (spy-calls-args-for 'projectile-completing-read 0))
+                  :to-equal '("project: foo.el"))
+          (expect 'bookmark-jump :to-have-been-called-with "project: foo.el")))))
+
+  (it "advertises the bookmark completion category"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (let ((root (projectile-project-root)))
+        (projectile-test-with-bookmarks
+            (list (projectile-test-bookmark
+                   "project: foo.el" (expand-file-name "foo.el" root)))
+          (spy-on 'projectile-completing-read :and-return-value "project: foo.el")
+          (spy-on 'bookmark-jump)
+          (call-interactively #'projectile-bookmark-jump)
+          (expect (plist-get (cddr (spy-calls-args-for 'projectile-completing-read 0))
+                             :category)
+                  :to-be 'bookmark)))))
+
+  (it "errors friendly when the project has no bookmarks"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (projectile-test-with-bookmarks nil
+        (expect (call-interactively #'projectile-bookmark-jump)
+                :to-throw 'user-error
+                '("[project] No bookmarks in this project")))))
+
+  (it "refuses to jump to a bookmark whose file is gone"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (let* ((root (projectile-project-root))
+             (gone (expand-file-name "gone.el" root)))
+        (projectile-test-with-bookmarks
+            (list (projectile-test-bookmark "project: gone.el" gone))
+          (spy-on 'projectile-completing-read :and-return-value "project: gone.el")
+          (spy-on 'bookmark-jump)
+          (expect (call-interactively #'projectile-bookmark-jump) :to-throw 'user-error)
+          (expect 'bookmark-jump :not :to-have-been-called)))))
+
+  (it "refuses a name that is not a bookmark"
+    ;; the prompt doesn't require a match, so the user can type anything
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (let ((root (projectile-project-root)))
+        (projectile-test-with-bookmarks
+            (list (projectile-test-bookmark
+                   "project: foo.el" (expand-file-name "foo.el" root)))
+          (spy-on 'projectile-completing-read :and-return-value "typo")
+          (spy-on 'bookmark-jump)
+          (expect (call-interactively #'projectile-bookmark-jump) :to-throw 'user-error)
+          (expect 'bookmark-jump :not :to-have-been-called))))))
+
+(describe "projectile-bookmark-delete"
+  (it "deletes the selected project bookmark"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (let ((root (projectile-project-root)))
+        (projectile-test-with-bookmarks
+            (list (projectile-test-bookmark
+                   "project: foo.el" (expand-file-name "foo.el" root))
+                  (projectile-test-bookmark
+                   "other: bar.el" (expand-file-name "../other/bar.el" root)))
+          (spy-on 'projectile-completing-read :and-return-value "project: foo.el")
+          (call-interactively #'projectile-bookmark-delete)
+          (expect (bookmark-all-names) :to-equal '("other: bar.el"))
+          (expect (projectile-bookmark-names root) :to-equal nil)))))
+
+  (it "refuses a name that is not a bookmark instead of claiming success"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (let ((root (projectile-project-root)))
+        (projectile-test-with-bookmarks
+            (list (projectile-test-bookmark
+                   "project: foo.el" (expand-file-name "foo.el" root)))
+          (spy-on 'projectile-completing-read :and-return-value "typo")
+          (expect (call-interactively #'projectile-bookmark-delete) :to-throw 'user-error)
+          (expect (bookmark-all-names) :to-equal '("project: foo.el"))))))
+
+  (it "errors friendly when the project has no bookmarks"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (projectile-test-with-bookmarks nil
+        (expect (call-interactively #'projectile-bookmark-delete)
+                :to-throw 'user-error
+                '("[project] No bookmarks in this project"))))))
+
+(describe "projectile-bookmark-names with remote bookmarks"
+  (it "keeps a remote bookmark out of a local project without resolving it"
+    (projectile-test-with-stub-root "project" ("foo.el")
+      (let ((root (projectile-project-root)))
+        (projectile-test-with-bookmarks
+            (list (projectile-test-bookmark
+                   "remote" (concat "/ssh:nosuchhost:" root "foo.el"))
+                  (projectile-test-bookmark
+                   "local" (expand-file-name "foo.el" root)))
+          ;; resolving the remote name would open a TRAMP connection
+          (spy-on 'file-truename :and-call-through)
+          (expect (projectile-bookmark-names root) :to-equal '("local"))
+          (dolist (call (spy-calls-all-args 'file-truename))
+            (expect (file-remote-p (car call)) :to-be nil)))))))
+
+;; The "no project at all" errors live in `projectile-friendly-errors-test',
+;; next to every other command's.
+
+(provide 'projectile-bookmarks-test)
+
+;;; projectile-bookmarks-test.el ends here

--- a/test/projectile-friendly-errors-test.el
+++ b/test/projectile-friendly-errors-test.el
@@ -28,6 +28,9 @@
 (require 'projectile-test-helpers)
 
 (assert-friendly-error-when-no-project projectile-project-info)
+(assert-friendly-error-when-no-project projectile-bookmark-set)
+(assert-friendly-error-when-no-project projectile-bookmark-jump)
+(assert-friendly-error-when-no-project projectile-bookmark-delete)
 (assert-friendly-error-when-no-project projectile-display-buffer)
 (assert-friendly-error-when-no-project projectile-find-implementation-or-test-other-frame)
 (assert-friendly-error-when-no-project projectile-find-implementation-or-test-other-window)


### PR DESCRIPTION
`projectile-bookmark-set` / `-jump` / `-delete` (`s-p B s` / `B j` / `B d`), built on `bookmark.el` rather than a new store - so they persist, show up in `list-bookmarks`, and cost no new file format.

A bookmark counts as the project's if its recorded file lives under the project root, or if its name carries the `PROJECT: ` prefix. `projectile-bookmark-scope` picks which test applies; the default does both, since the filename test survives renames and catches bookmarks made outside Projectile, while the name test covers non-file bookmarks. Remote filenames are rejected before any `file-truename` so a stale `/ssh:` bookmark can't stall the prompt.

`B` was free in the command map but taken in the dispatch transient, so "display buffer" moved there from `B` to `C-o`, mirroring its existing `s-p 4 C-o` binding. That's the one visible change to something that already worked - easy to revert if you'd rather the bookmarks live elsewhere.

Several failure modes that previously produced raw errors now give friendly ones: a bookmark whose file is gone (instead of bookmark.el's relocation prompt), a typed name that isn't a bookmark, and a buffer bookmark.el can't record.