### PR TITLE
Discover the tasks a project's tooling already defines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### New features
 
+- [#2120](https://github.com/bbatsov/projectile/pull/2120): `projectile-run-task` now also offers the tasks a project's own tooling defines, so it's useful in a fresh checkout without any configuration.
+  - npm scripts (run through whichever package manager the lock file points at), Deno tasks, Composer scripts, just recipes, go-task tasks and Make targets.
+  - Discovered tasks are named after the tool that defines them (`npm:build`, `make:test`), so they never collide with the tasks you configure yourself.
+  - Turn it off with `projectile-discover-tasks`, or add your own reader to `projectile-task-providers`.
 - [#2119](https://github.com/bbatsov/projectile/pull/2119): Add 34 project types Projectile had no support for, which used to come out as generic projects.
   - JavaScript: `node` (a `package.json` with no lock file next to it), `bun`, `deno`, `nx` and `turborepo`.
   - Python: `python-uv` and `python-pdm`.

--- a/doc/modules/ROOT/pages/tasks.adoc
+++ b/doc/modules/ROOT/pages/tasks.adoc
@@ -77,10 +77,13 @@ Tasks can be defined in three places:
 * per project, by setting `projectile-tasks` in `.dir-locals.el`, which makes
   the tasks shareable with your team through your VCS
 
+On top of those, Projectile discovers the tasks your project's own tooling
+already defines - see <<discovered-tasks,Discovered tasks>> below.
+
 The effective tasks for a project are the project type's tasks merged with
-`projectile-tasks`; when both define a task with the same name, the
-`projectile-tasks` entry wins. Use `projectile-project-tasks` if you need the
-merged alist programmatically.
+`projectile-tasks` and the discovered ones; when several define a task with the
+same name, the `projectile-tasks` entry wins, then the project type's. Use
+`projectile-project-tasks` if you need the merged alist programmatically.
 
 Here's a `.dir-locals.el` example:
 
@@ -121,6 +124,57 @@ arguments. Each task keeps its own command history at that prompt.
 in the current project, including any ad-hoc edits you made to its command,
 without asking again (you confirmed it the first time). It survives Emacs
 restarts when `savehist-mode` is enabled.
+
+[#discovered-tasks]
+=== Discovered tasks
+
+Most projects already list their tasks somewhere - npm scripts, Makefile
+targets, justfile recipes - and retyping those into `projectile-tasks` is
+busy-work. Projectile reads them straight out of the project instead, so
+`projectile-run-task` is useful in a fresh checkout without any configuration.
+
+Out of the box it knows about:
+
+|===
+| Source | File | Tasks named
+
+| npm scripts
+| `package.json`
+| `npm:build`, or `pnpm:` / `yarn:` / `bun:` depending on the lock file
+
+| Deno tasks
+| `deno.json`, `deno.jsonc`
+| `deno:dev`
+
+| Composer scripts
+| `composer.json`
+| `composer:lint`
+
+| just recipes
+| `justfile`, `.justfile`, `Justfile`
+| `just:build`
+
+| go-task tasks
+| `Taskfile.yml` and friends
+| `task:build`
+
+| Make targets
+| `Makefile`, `makefile`, `GNUmakefile`
+| `make:test`
+|===
+
+Discovered tasks carry the name of the tool that defines them, so they never
+collide with the tasks you configure yourself, and you can tell at the prompt
+where a task came from. Only plain named Make targets are offered - pattern
+rules, file targets and the dot-targets aren't things you'd run by hand.
+
+Set `projectile-discover-tasks` to nil to turn this off, or customize
+`projectile-task-providers` to add your own. A provider is a function taking
+the project root and returning an alist of `(TASK-NAME . COMMAND)`; one that
+signals an error is skipped, so a malformed manifest can't break the command.
+
+The manifests are read on each invocation rather than cached, and providers
+never shell out, so nothing has to be re-indexed when you add a script.
 
 == Running the test at point
 

--- a/projectile.el
+++ b/projectile.el
@@ -10864,18 +10864,221 @@ project type."
   :safe #'projectile-tasks-safe-p
   :package-version '(projectile . "3.1.0"))
 
-(defun projectile-project-tasks (&optional project-type)
+;;;; Task discovery
+;;
+;; Most projects already describe their tasks somewhere - npm scripts,
+;; Makefile targets, justfile recipes - and retyping those into
+;; `projectile-tasks' is busy-work.  A provider reads one such file and
+;; turns it into tasks, which are offered alongside the configured ones.
+;;
+;; Providers are deliberately simple readers rather than full parsers:
+;; they only need the task names, and they must not shell out (that
+;; would make `projectile-run-task' pay for a process launch, and go
+;; wrong over TRAMP).
+
+(defcustom projectile-discover-tasks t
+  "Whether to offer the tasks a project's own tooling defines.
+
+When non-nil `projectile-run-task' also lists the tasks found by
+`projectile-task-providers' - npm scripts, Makefile targets and so on -
+in addition to the tasks configured via `projectile-tasks' and the
+project type.  Discovered tasks are named after the tool that defines
+them (e.g. `npm:build'), so they never collide with configured ones."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "3.3.0"))
+
+(defcustom projectile-task-providers
+  '(projectile-tasks-from-npm
+    projectile-tasks-from-deno
+    projectile-tasks-from-composer
+    projectile-tasks-from-just
+    projectile-tasks-from-taskfile
+    projectile-tasks-from-make)
+  "Functions that discover the tasks a project's tooling defines.
+
+Each function is called with the project root and should return an
+alist of (TASK-NAME . COMMAND), both strings, or nil when the project
+has nothing it recognizes.  A function that signals is ignored, so a
+malformed manifest can't break `projectile-run-task'.
+
+Task names should carry a tool prefix (`npm:build', `make:test'), which
+is what keeps the providers from colliding with each other and with the
+configured tasks."
+  :group 'projectile
+  :type '(repeat function)
+  :package-version '(projectile . "3.3.0"))
+
+(defun projectile--task-file (project-root name)
+  "Return NAME under PROJECT-ROOT when it exists as a readable file."
+  (let ((file (expand-file-name name project-root)))
+    (and (file-readable-p file)
+         (not (file-directory-p file))
+         file)))
+
+(defun projectile--first-task-file (project-root names)
+  "Return the first of NAMES that exists under PROJECT-ROOT."
+  (seq-some (lambda (name) (projectile--task-file project-root name)) names))
+
+(defun projectile--read-json-object (file)
+  "Read FILE as JSON and return its top-level object as an alist.
+Returns nil when FILE doesn't hold a JSON object, or when this Emacs was
+built without native JSON support."
+  (when (functionp 'json-parse-buffer)
+    (with-temp-buffer
+      (insert-file-contents file)
+      (goto-char (point-min))
+      (let ((json (json-parse-buffer :object-type 'alist
+                                     :array-type 'list
+                                     :null-object nil
+                                     :false-object nil)))
+        (and (consp json) json)))))
+
+(defun projectile--json-tasks (file key prefix command-format)
+  "Return the tasks under KEY in the JSON object in FILE.
+Each key of that object becomes a task named `PREFIX:KEY', running
+COMMAND-FORMAT with the key substituted for its `%s'."
+  (when-let* ((json (projectile--read-json-object file))
+              (entries (alist-get key json)))
+    ;; `seq-keep' would read better, but it's Emacs 29.1 and compat
+    ;; doesn't back it up.
+    (delq nil
+          (mapcar (lambda (entry)
+                    (when-let* ((name (and (consp entry) (car entry)))
+                                (name (if (symbolp name) (symbol-name name) name)))
+                      (cons (format "%s:%s" prefix name)
+                            (format command-format name))))
+                  entries))))
+
+(defun projectile--npm-runner (project-root)
+  "Return the package manager command to use in PROJECT-ROOT.
+Derived from the lock file present, so it holds regardless of which
+project type won detection."
+  (cond ((projectile--task-file project-root "pnpm-lock.yaml") "pnpm")
+        ((projectile--task-file project-root "yarn.lock") "yarn")
+        ((projectile--first-task-file project-root '("bun.lock" "bun.lockb")) "bun")
+        (t "npm")))
+
+(defun projectile-tasks-from-npm (project-root)
+  "Return the npm scripts of the project in PROJECT-ROOT as tasks.
+The scripts run through whichever package manager the project's lock
+file points at."
+  (when-let* ((file (projectile--task-file project-root "package.json"))
+              (runner (projectile--npm-runner project-root)))
+    (projectile--json-tasks file 'scripts runner (concat runner " run %s"))))
+
+(defun projectile-tasks-from-deno (project-root)
+  "Return the Deno tasks of the project in PROJECT-ROOT."
+  (when-let* ((file (projectile--first-task-file
+                     project-root '("deno.json" "deno.jsonc"))))
+    (projectile--json-tasks file 'tasks "deno" "deno task %s")))
+
+(defun projectile-tasks-from-composer (project-root)
+  "Return the Composer scripts of the project in PROJECT-ROOT."
+  (when-let* ((file (projectile--task-file project-root "composer.json")))
+    (projectile--json-tasks file 'scripts "composer" "composer run-script %s")))
+
+(defun projectile--matches-in-file (file regexp)
+  "Return the first capture group of every match of REGEXP in FILE.
+Matching is case-sensitive and the results keep their order, with
+duplicates dropped."
+  (let (names)
+    (with-temp-buffer
+      (insert-file-contents file)
+      (goto-char (point-min))
+      (let ((case-fold-search nil))
+        (while (re-search-forward regexp nil t)
+          (let ((name (match-string 1)))
+            (unless (member name names)
+              (push name names))))))
+    (nreverse names)))
+
+(defun projectile-tasks-from-just (project-root)
+  "Return the recipes of the justfile in PROJECT-ROOT as tasks."
+  (when-let* ((file (projectile--first-task-file
+                     project-root '("justfile" ".justfile" "Justfile"))))
+    (mapcar (lambda (name) (cons (format "just:%s" name) (format "just %s" name)))
+            ;; A recipe starts in column zero, may be marked quiet with
+            ;; `@' and may take parameters.  The lookahead keeps `:=',
+            ;; which is an assignment, from reading as a recipe.
+            (projectile--matches-in-file
+             file "^@?\\([a-zA-Z_][a-zA-Z0-9_-]*\\)[^:\n]*:\\(?:[^=\n]\\|$\\)"))))
+
+(defun projectile-tasks-from-taskfile (project-root)
+  "Return the tasks of the go-task Taskfile in PROJECT-ROOT."
+  (when-let* ((file (projectile--first-task-file
+                     project-root '("Taskfile.yml" "Taskfile.yaml"
+                                    "Taskfile.dist.yml" "Taskfile.dist.yaml"))))
+    (mapcar (lambda (name) (cons (format "task:%s" name) (format "task %s" name)))
+            ;; The keys of the top-level `tasks:' mapping, i.e. the lines
+            ;; indented exactly one level under it.
+            (with-temp-buffer
+              (insert-file-contents file)
+              (goto-char (point-min))
+              (let ((case-fold-search nil)
+                    names)
+                (when (re-search-forward "^tasks:[ \t]*$" nil t)
+                  (forward-line 1)
+                  (let ((indent (current-indentation)))
+                    (while (and (not (eobp))
+                                (or (looking-at-p "^[ \t]*$")
+                                    (< 0 (current-indentation))))
+                      (when (and (= (current-indentation) indent)
+                                 (looking-at "[ \t]+\\([a-zA-Z0-9_.:-]+\\):"))
+                        (let ((name (match-string 1)))
+                          (unless (member name names)
+                            (push name names))))
+                      (forward-line 1))))
+                (nreverse names))))))
+
+(defun projectile-tasks-from-make (project-root)
+  "Return the targets of the Makefile in PROJECT-ROOT as tasks.
+Only plain named targets are offered - pattern rules, file targets and
+the special dot-targets aren't things you'd run by hand."
+  (when-let* ((file (projectile--first-task-file
+                     project-root '("Makefile" "makefile" "GNUmakefile"))))
+    (mapcar (lambda (name) (cons (format "make:%s" name) (format "make %s" name)))
+            (projectile--matches-in-file
+             file "^\\([a-zA-Z0-9][a-zA-Z0-9_-]*\\)[ \t]*:\\(?:[^=\n]\\|$\\)"))))
+
+(defun projectile-discovered-tasks (&optional project-root)
+  "Return the tasks discovered in the project at PROJECT-ROOT.
+PROJECT-ROOT defaults to the current project's root.  The tasks come
+from `projectile-task-providers'; a provider that signals is skipped."
+  (when projectile-discover-tasks
+    (when-let* ((root (or project-root (projectile-project-root))))
+      (seq-mapcat (lambda (provider)
+                    (condition-case err
+                        (funcall provider root)
+                      (error
+                       (when projectile-verbose
+                         (message "Projectile task provider %s failed: %s"
+                                  provider (error-message-string err)))
+                       nil)))
+                  projectile-task-providers))))
+
+(defun projectile--merge-tasks (&rest task-lists)
+  "Merge TASK-LISTS into one alist, earlier lists winning on name."
+  (let (merged)
+    (dolist (tasks task-lists)
+      (dolist (task tasks)
+        (unless (assoc (car task) merged)
+          (push task merged))))
+    (nreverse merged)))
+
+(defun projectile-project-tasks (&optional project-type project-root)
   "Return the effective tasks alist for the current project.
 
 That's the PROJECT-TYPE's `:tasks' table (PROJECT-TYPE defaults to the
 current project's type) merged with `projectile-tasks', whose entries -
 set globally or per project via .dir-locals.el - override same-named
-project-type tasks."
+project-type tasks, and with the tasks discovered in PROJECT-ROOT by
+`projectile-task-providers', which lose to both."
   (let ((type-tasks (projectile-project-type-attribute
                      (or project-type (projectile-project-type)) 'tasks)))
-    (append projectile-tasks
-            (seq-remove (lambda (task) (assoc (car task) projectile-tasks))
-                        type-tasks))))
+    (projectile--merge-tasks projectile-tasks
+                             type-tasks
+                             (projectile-discovered-tasks project-root))))
 
 (defun projectile-default-generic-command (project-type command-type)
   "Generic retrieval of COMMAND-TYPEs default cmd-value for PROJECT-TYPE.
@@ -11632,10 +11835,12 @@ the `%p' placeholder still intact."
   "Run one of the current project's named tasks.
 
 The task is picked with completion among the tasks of the project's
-type and those in `projectile-tasks', which win for same-named tasks
-\(see `projectile-project-tasks').  With a prefix ARG the task's
-command can be edited before it's run, e.g. to pass it ad-hoc
-arguments.
+type, those in `projectile-tasks' (which win for same-named tasks) and
+the ones discovered in the project's own tooling - npm scripts, Makefile
+targets and the like, named after the tool that defines them (see
+`projectile-project-tasks' and `projectile-task-providers').  With a
+prefix ARG the task's command can be edited before it's run, e.g. to
+pass it ad-hoc arguments.
 
 The command runs through the same machinery as
 `projectile-compile-project' - in `projectile-compilation-dir', with
@@ -11644,8 +11849,7 @@ compilation buffer named after the task."
   (interactive "P")
   ;; Establish we're in a project before prompting, so the task menu
   ;; doesn't pop up (with globally-defined tasks) outside one.
-  (projectile-acquire-root)
-  (let ((tasks (projectile-project-tasks)))
+  (let ((tasks (projectile-project-tasks nil (projectile-acquire-root))))
     (unless tasks
       (user-error "No tasks defined for the current project"))
     (let* ((task-name (projectile-completing-read "Run task: " (mapcar #'car tasks)))
@@ -13194,7 +13398,7 @@ see `projectile-dashboard--collect', which arranges that."
            :recent-files (when (projectile-dashboard--section-p 'recent)
                            (projectile-dashboard--recent-files root))
            :tasks (when (projectile-dashboard--section-p 'tasks)
-                    (ignore-errors (projectile-project-tasks)))
+                    (ignore-errors (projectile-project-tasks nil root)))
            :commands (when (projectile-dashboard--section-p 'commands)
                        (ignore-errors (projectile-dashboard--commands root))))
      (when (projectile-dashboard--section-p 'vcs)

--- a/test/projectile-tasks-test.el
+++ b/test/projectile-tasks-test.el
@@ -56,6 +56,7 @@
   (it "merges the project type's tasks with projectile-tasks, the latter winning"
     (let ((projectile-project-types projectile-project-types)
           (projectile-project-root-files projectile-project-root-files)
+          (projectile-discover-tasks nil)
           (projectile-tasks '(("lint" . "make custom-lint")
                               ("docs" . "make docs"))))
       (projectile-register-project-type 'tasked-project '("Taskedfile")
@@ -70,6 +71,7 @@
   (it "returns just the project type's tasks when projectile-tasks is nil"
     (let ((projectile-project-types projectile-project-types)
           (projectile-project-root-files projectile-project-root-files)
+          (projectile-discover-tasks nil)
           (projectile-tasks nil))
       (projectile-register-project-type 'tasked-project '("Taskedfile")
                                         :tasks '(("bench" . "make bench")))
@@ -77,19 +79,182 @@
               :to-equal '(("bench" . "make bench")))))
 
   (it "returns just projectile-tasks for a type without tasks"
-    (let ((projectile-tasks '(("lint" . "make lint"))))
+    (let ((projectile-tasks '(("lint" . "make lint")))
+          (projectile-discover-tasks nil))
       (expect (projectile-project-tasks 'generic)
               :to-equal '(("lint" . "make lint")))))
 
   (it "picks up tasks added via projectile-update-project-type"
     (let ((projectile-project-types projectile-project-types)
           (projectile-project-root-files projectile-project-root-files)
+          (projectile-discover-tasks nil)
           (projectile-tasks nil))
       (projectile-register-project-type 'tasked-project '("Taskedfile"))
       (projectile-update-project-type 'tasked-project
                                       :tasks '(("bench" . "make bench")))
       (expect (projectile-project-tasks 'tasked-project)
               :to-equal '(("bench" . "make bench"))))))
+
+(describe "task discovery"
+  (describe "projectile-tasks-from-npm"
+    (it "reads the scripts of a package.json"
+      (projectile-test-with-project
+          (("package.json" . "{\"name\": \"demo\",
+  \"scripts\": {\"build\": \"tsc\", \"test\": \"vitest run\"}}"))
+        (expect (projectile-tasks-from-npm (projectile-project-root))
+                :to-equal '(("npm:build" . "npm run build")
+                            ("npm:test" . "npm run test")))))
+
+    (it "runs the scripts through the package manager the lock file points at"
+      (projectile-test-with-project
+          (("package.json" . "{\"scripts\": {\"build\": \"tsc\"}}")
+           ("pnpm-lock.yaml" . "lockfileVersion: '9.0'\n"))
+        (expect (projectile-tasks-from-npm (projectile-project-root))
+                :to-equal '(("pnpm:build" . "pnpm run build"))))
+      (projectile-test-with-project
+          (("package.json" . "{\"scripts\": {\"build\": \"tsc\"}}")
+           ("bun.lock" . "{}"))
+        (expect (projectile-tasks-from-npm (projectile-project-root))
+                :to-equal '(("bun:build" . "bun run build")))))
+
+    (it "returns nothing for a package.json without scripts"
+      (projectile-test-with-project (("package.json" . "{\"name\": \"demo\"}"))
+        (expect (projectile-tasks-from-npm (projectile-project-root)) :to-be nil)))
+
+    (it "returns nothing when there is no package.json"
+      (projectile-test-with-project (("README" . "hi"))
+        (expect (projectile-tasks-from-npm (projectile-project-root)) :to-be nil))))
+
+  (describe "projectile-tasks-from-deno"
+    (it "reads the tasks of a deno.json"
+      (projectile-test-with-project
+          (("deno.json" . "{\"tasks\": {\"dev\": \"deno run -A main.ts\"}}"))
+        (expect (projectile-tasks-from-deno (projectile-project-root))
+                :to-equal '(("deno:dev" . "deno task dev"))))))
+
+  (describe "projectile-tasks-from-composer"
+    (it "reads the scripts of a composer.json"
+      (projectile-test-with-project
+          (("composer.json" . "{\"scripts\": {\"lint\": \"php-cs-fixer fix\"}}"))
+        (expect (projectile-tasks-from-composer (projectile-project-root))
+                :to-equal '(("composer:lint" . "composer run-script lint"))))))
+
+  (describe "projectile-tasks-from-just"
+    (it "reads the recipes of a justfile, including quiet ones and ones with parameters"
+      (projectile-test-with-project
+          (("justfile" . "set shell := [\"bash\", \"-c\"]
+version := \"1.0\"
+
+# build everything
+build:
+    cargo build
+
+@fmt:
+    cargo fmt
+
+test filter=\"\":
+    cargo test {{filter}}
+"))
+        (expect (projectile-tasks-from-just (projectile-project-root))
+                :to-equal '(("just:build" . "just build")
+                            ("just:fmt" . "just fmt")
+                            ("just:test" . "just test")))))
+
+    (it "does not mistake an assignment for a recipe"
+      (projectile-test-with-project (("justfile" . "export FOO := \"bar\"\n"))
+        (expect (projectile-tasks-from-just (projectile-project-root)) :to-be nil))))
+
+  (describe "projectile-tasks-from-taskfile"
+    (it "reads the keys of the tasks mapping"
+      (projectile-test-with-project
+          (("Taskfile.yml" . "version: '3'
+
+vars:
+  GREETING: hello
+
+tasks:
+  build:
+    cmds:
+      - go build ./...
+  test:
+    cmds:
+      - go test ./...
+"))
+        (expect (projectile-tasks-from-taskfile (projectile-project-root))
+                :to-equal '(("task:build" . "task build")
+                            ("task:test" . "task test")))))
+
+    (it "does not pick up the keys nested inside a task"
+      (projectile-test-with-project
+          (("Taskfile.yml" . "tasks:
+  build:
+    desc: Build it
+    cmds:
+      - go build ./...
+"))
+        (expect (projectile-tasks-from-taskfile (projectile-project-root))
+                :to-equal '(("task:build" . "task build"))))))
+
+  (describe "projectile-tasks-from-make"
+    (it "reads the named targets of a Makefile"
+      (projectile-test-with-project
+          (("Makefile" . "CC := gcc
+.PHONY: all test
+
+all: main.o
+\t$(CC) -o demo main.o
+
+test:
+\t./run-tests
+
+main.o: main.c
+\t$(CC) -c main.c
+
+%.o: %.c
+\t$(CC) -c $<
+"))
+        (expect (projectile-tasks-from-make (projectile-project-root))
+                :to-equal '(("make:all" . "make all")
+                            ("make:test" . "make test")))))
+
+    (it "does not mistake a variable assignment for a target"
+      (projectile-test-with-project (("Makefile" . "CFLAGS := -O2\n"))
+        (expect (projectile-tasks-from-make (projectile-project-root)) :to-be nil))))
+
+  (describe "projectile-discovered-tasks"
+    (it "collects the tasks of every provider"
+      (projectile-test-with-project
+          (("package.json" . "{\"scripts\": {\"build\": \"tsc\"}}")
+           ("Makefile" . "test:\n\t./run-tests\n"))
+        (expect (projectile-discovered-tasks (projectile-project-root))
+                :to-equal '(("npm:build" . "npm run build")
+                            ("make:test" . "make test")))))
+
+    (it "returns nothing when discovery is off"
+      (projectile-test-with-project (("package.json" . "{\"scripts\": {\"build\": \"tsc\"}}"))
+        (let ((projectile-discover-tasks nil))
+          (expect (projectile-discovered-tasks (projectile-project-root)) :to-be nil))))
+
+    (it "skips a provider that signals instead of failing outright"
+      (projectile-test-with-project (("Makefile" . "test:\n\t./run-tests\n"))
+        (let ((projectile-task-providers
+               (list (lambda (_root) (error "Boom")) #'projectile-tasks-from-make))
+              (projectile-verbose nil))
+          (expect (projectile-discovered-tasks (projectile-project-root))
+                  :to-equal '(("make:test" . "make test"))))))
+
+    (it "survives a malformed manifest"
+      (projectile-test-with-project (("package.json" . "{not json at all"))
+        (let ((projectile-verbose nil))
+          (expect (projectile-discovered-tasks (projectile-project-root)) :to-be nil)))))
+
+  (describe "projectile-project-tasks"
+    (it "offers the discovered tasks after the configured ones"
+      (projectile-test-with-project (("Makefile" . "test:\n\t./run-tests\n"))
+        (let ((projectile-tasks '(("lint" . "make lint"))))
+          (expect (projectile-project-tasks 'generic (projectile-project-root))
+                  :to-equal '(("lint" . "make lint")
+                              ("make:test" . "make test"))))))))
 
 (describe "projectile-run-task"
   (before-each
@@ -203,7 +368,8 @@
   (it "errors when the selected task doesn't exist"
     (spy-on 'projectile-run-compilation)
     (spy-on 'projectile-completing-read :and-return-value "nope")
-    (let ((projectile-tasks '(("lint" . "make lint"))))
+    (let ((projectile-tasks '(("lint" . "make lint")))
+          (projectile-discover-tasks nil))
       (expect (projectile-run-task nil) :to-throw 'user-error)
       (expect 'projectile-run-compilation :not :to-have-been-called)))
 


### PR DESCRIPTION
`projectile-tasks` starts out empty, so `projectile-run-task` did nothing at
all until you'd configured it - even though nearly every project already lists
its tasks somewhere. This reads them out of the project: npm scripts (through
whichever package manager the lock file names), Deno tasks, Composer scripts,
just recipes, go-task tasks and Make targets.

Discovered tasks are named after the tool that defines them (`npm:build`,
`make:test`), which keeps them from colliding with the ones you configure and
makes it obvious at the prompt where a task came from.

The providers read the manifests directly rather than shelling out to the tools,
so a task list doesn't cost a process launch and behaves the same over TRAMP.
They're a plain hook (`projectile-task-providers`) if you want to add your own,
and `projectile-discover-tasks` turns the whole thing off.

Second of three stacked PRs, on top of #2119.