### PR TITLE
Make the subproject commands work in any monorepo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### New features
 
+- [#2121](https://github.com/bbatsov/projectile/pull/2121): Projectile now recognizes the subprojects of a monorepo - any directory below the root holding a manifest of its own.
+  - `projectile-find-file-in-subproject` (`s-p c m f`) prompts for a subproject and completes over just its files; `projectile-project-subprojects` lists them, scanning the project's file listing so the ignore rules apply.
+  - `projectile-run-subproject` (`s-p c m r`) joins the existing `projectile-compile-subproject` and `projectile-test-subproject`, which now share the lifecycle machinery rather than reimplementing it.
+  - What counts as a subproject manifest comes from `projectile-subproject-markers`, derived by default from every registered project type - so a polyglot repository works out of the box, where `projectile-subproject-root` previously only looked for the marker of the project's own type (and errored outright for a type without one, e.g. Go).
 - [#2120](https://github.com/bbatsov/projectile/pull/2120): `projectile-run-task` now also offers the tasks a project's own tooling defines, so it's useful in a fresh checkout without any configuration.
   - npm scripts (run through whichever package manager the lock file points at), Deno tasks, Composer scripts, just recipes, go-task tasks and Make targets.
   - Discovered tasks are named after the tool that defines them (`npm:build`, `make:test`), so they never collide with the tasks you configure yourself.
@@ -56,6 +60,7 @@
 - [#2119](https://github.com/bbatsov/projectile/pull/2119): Rails and Django had their development server wired to the compile command, leaving the run command empty; the server is now the run command and compile is `bundle exec rake` / `manage.py collectstatic`.
 - [#2119](https://github.com/bbatsov/projectile/pull/2119): The PHP types are now registered after the JavaScript ones, so a PHP application isn't detected as a Node project because of the `package.json` its asset pipeline ships.
 - [#2119](https://github.com/bbatsov/projectile/pull/2119): The supported project types table in the manual is now generated from the registry, which had drifted well behind it.
+- [#2121](https://github.com/bbatsov/projectile/pull/2121): `go.mod` is now registered as the Go type's project file, so it can anchor the root of a Go project outside version control and mark a module inside a larger repository. The type itself is still detected by predicate, since a directory of `.go` files is a Go project with or without modules.
 - [#2114](https://github.com/bbatsov/projectile/pull/2114): In `projectile-dispatch`, "display buffer" moved from `B` to `C-o` (mirroring its `s-p 4 C-o` binding), so `B` could become the bookmark prefix.
 - [#2110](https://github.com/bbatsov/projectile/pull/2110): The grep/ag search integration and the ignore predicates now derive their exclusions from the same gitignore patterns indexing uses, instead of expanding the dirconfig into absolute paths on their own.
   - `projectile-ignored-file-p` and `projectile-ignored-directory-p` now take an optional project root instead of a pre-computed list of ignored paths, and answer exactly what indexing would (ensure entries included, a file under an ignored directory counted as ignored).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Here are some of Projectile's essential features:
 * [search a project](https://docs.projectile.mx/projectile/usage.html#reviewing-search-matches) (grep/ripgrep, plus a native reviewable results UI)
 * [replace in a project](https://docs.projectile.mx/projectile/usage.html#reviewing-and-applying-replacements), with a reviewable before/after preview
 * find references in a project (using `xref` internally)
-* run [project commands and custom tasks](https://docs.projectile.mx/projectile/tasks.html#project-tasks) (build/test/run, `make`, `lein`, and your own named tasks)
+* run [project commands and tasks](https://docs.projectile.mx/projectile/tasks.html#project-tasks) (build/test/run, your own named tasks, and the npm scripts, Make targets and justfile recipes a project already defines)
+* [work on one part of a monorepo](https://docs.projectile.mx/projectile/tasks.html#subprojects) - find files in a subproject, build or test just the module you're in
 * [run the test at point](https://docs.projectile.mx/projectile/tasks.html#running-the-test-at-point) (tree-sitter, Emacs 29+)
 * works with any `completing-read`-based completion UI (Vertico, Consult, Fido, Ido, etc.)
 * automatic project discovery (see `projectile-project-search-path`)

--- a/doc/modules/ROOT/pages/cheatsheet.adoc
+++ b/doc/modules/ROOT/pages/cheatsheet.adoc
@@ -175,6 +175,18 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p c X]
 | Re-runs the last task executed in the project.
 
+| kbd:[s-p c m f]
+| Finds a file in one of the project's subprojects, prompting for the subproject first.
+
+| kbd:[s-p c m c]
+| Runs the compile command in the nearest subproject instead of at the project root.
+
+| kbd:[s-p c m t]
+| Runs the test command in the nearest subproject.
+
+| kbd:[s-p c m r]
+| Runs the run command in the nearest subproject.
+
 | kbd:[s-p t]
 | Toggle between an implementation file and its test file.
 

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -50,7 +50,8 @@ Here are some of Projectile's features in no particular order:
 * xref:usage.adoc#reviewing-search-matches[grep (search) in project] (multiple back-ends like `ag`, `rg`, and a native reviewable results UI)
 * find references in project (using `xref` internally)
 * visit project in `dired`
-* run xref:tasks.adoc#project-tasks[project commands and tasks] (build/test/run, `make`, and your own named tasks)
+* run xref:tasks.adoc#project-tasks[project commands and tasks] (build/test/run, your own named tasks, and the npm scripts, Make targets and justfile recipes a project already defines)
+* xref:tasks.adoc#subprojects[work on one part of a monorepo] - find files in a subproject, build or test just the module you're in
 * xref:tasks.adoc#running-the-test-at-point[run the test at point] (tree-sitter, Emacs 29+)
 * works with any `completing-read`-based minibuffer completion UI (Vertico, Consult, `fido-mode`, etc.)
 * automatic project discovery (see `projectile-project-search-path`)

--- a/doc/modules/ROOT/pages/tasks.adoc
+++ b/doc/modules/ROOT/pages/tasks.adoc
@@ -176,6 +176,40 @@ signals an error is skipped, so a malformed manifest can't break the command.
 The manifests are read on each invocation rather than cached, and providers
 never shell out, so nothing has to be re-indexed when you add a script.
 
+[#subprojects]
+== Monorepos and subprojects
+
+A monorepo is a single project as far as version control is concerned, and
+that's how Projectile treats it too - the repository is the project, and
+finding files or searching covers all of it. But its parts usually have
+manifests of their own (a crate, a package, a Maven module), and building or
+testing the whole repository when you're working on one of them is wasteful.
+
+Projectile calls those parts *subprojects*: any directory below the project
+root that holds a project manifest. What counts as a manifest comes from
+`projectile-subproject-markers`, which by default is derived from the
+registered project types, so every type Projectile knows about - including the
+ones you register yourself - is recognized inside a monorepo. A polyglot
+repository works out of the box: a `Cargo.toml` under a `package.json` project
+is still a subproject.
+
+`projectile-project-subprojects` returns them, scanning the project's own file
+listing (so the xref:ignoring.adoc[ignore rules] apply, and a vendored
+dependency's manifest doesn't count as a subproject).
+
+* `projectile-find-file-in-subproject` (kbd:[s-p c m f]) prompts for a
+  subproject and then completes over just its files.
+* `projectile-compile-subproject` (kbd:[s-p c m c]),
+  `projectile-test-subproject` (kbd:[s-p c m t]) and
+  `projectile-run-subproject` (kbd:[s-p c m r]) run the project's compile,
+  test and run commands in the *nearest* subproject - the one containing the
+  file you're visiting - rather than at the project root. The command itself is
+  the project's, only the directory changes, which is what workspace-aware
+  tools like Cargo, npm and Maven need to scope their work.
+
+If there's no manifest between the current file and the project root, those
+three commands say so rather than silently building the whole repository.
+
 == Running the test at point
 
 While `projectile-test-project` runs a project's whole test suite,

--- a/projectile.el
+++ b/projectile.el
@@ -2546,6 +2546,48 @@ setup."
       (dolist (entry entries) (puthash entry t set))
       set)))
 
+(defun projectile--wildcard-p (name)
+  "Return non-nil if NAME has a shell wildcard character in it."
+  (string-match-p "[][*?]" name))
+
+(defun projectile--read-json-file (file &rest args)
+  "Read FILE as JSON, passing ARGS to `json-parse-buffer'.
+Returns nil when FILE doesn't exist, or when this Emacs was built
+without native JSON support."
+  (when (and (functionp 'json-parse-buffer) (file-exists-p file))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (goto-char (point-min))
+      (apply #'json-parse-buffer args))))
+
+(defun projectile--directory-marker (directory markers &optional files-only)
+  "Return the first of MARKERS present in DIRECTORY, or nil.
+
+DIRECTORY is listed once with `projectile--directory-entry-set' and the
+plain-name markers are answered from that listing, so probing N
+candidates costs one round-trip instead of N - which matters both for
+long marker lists and for remote projects.  A marker carrying a path
+separator or a wildcard can't be answered from a basename listing and is
+probed directly.  With FILES-ONLY non-nil a marker naming a directory
+doesn't count as present."
+  (let ((entries nil) (listed nil))
+    (seq-find
+     (lambda (marker)
+       (cond
+        ((not (stringp marker)) nil)
+        ((or (string-search "/" marker) (projectile--wildcard-p marker))
+         (let ((expanded (projectile-expand-file-name-wildcard marker directory)))
+           (and (projectile-file-exists-p expanded)
+                (or (not files-only) (not (file-directory-p expanded))))))
+        (t (unless listed
+             (setq entries (projectile--directory-entry-set directory)
+                   listed t))
+           (and entries
+                (gethash marker entries)
+                (or (not files-only)
+                    (not (file-directory-p (expand-file-name marker directory))))))))
+     markers)))
+
 (defun projectile--locate-dominating-file (file name first-match-only)
   "Walk up from FILE looking for NAME and return the matching directory.
 NAME is either a filename (matched via `projectile-file-exists-p' in
@@ -2602,14 +2644,12 @@ This is intended to be used as a file local variable.")
   "Identify a project root in DIR by top-down search for files in LIST.
 If LIST is nil, use `projectile-project-root-files' instead.
 Return the first (topmost) matched directory or nil if not found."
-  (projectile-locate-dominating-file-top-down
-   dir
-   (lambda (dir)
-     (seq-find (lambda (f)
-                    (let ((expanded (projectile-expand-file-name-wildcard f dir)))
-                      (and (projectile-file-exists-p expanded)
-                           (not (file-directory-p expanded)))))
-                 (or list projectile-project-root-files)))))
+  (let ((markers (or list projectile-project-root-files)))
+    (projectile-locate-dominating-file-top-down
+     dir
+     ;; A root file has to be a file, not a directory - `src' being a
+     ;; marker of some project type mustn't make every `src' a root.
+     (lambda (dir) (projectile--directory-marker dir markers 'files-only)))))
 
 (defun projectile-root-marked (dir)
   "Identify a project root in DIR by search for `projectile-dirconfig-file`."
@@ -2630,26 +2670,10 @@ Return the first (bottommost) matched directory or nil if not found."
          ;; (which runs on every root resolution) is this case.
          (lambda (directory)
            (projectile-file-exists-p (expand-file-name (car markers) directory)))
-       (lambda (directory)
-         ;; Probe each level with a single `directory-files' listing rather
-         ;; than one `file-exists-p' per marker.  The default markers are all
-         ;; plain names sitting directly in the directory, so membership in
-         ;; the listing is equivalent; markers carrying a path separator
-         ;; (a user customization) can't be answered from the basename listing
-         ;; and fall back to `projectile-file-exists-p'.  The listing is
-         ;; fetched lazily, once, and only if a plain-name marker is reached.
-         (let ((entries nil) (listed nil))
-           (seq-some
-            (lambda (marker)
-              (cond
-               ((not marker) nil)
-               ((string-match-p "/" marker)
-                (projectile-file-exists-p (expand-file-name marker directory)))
-               (t (unless listed
-                    (setq entries (projectile--directory-entry-set directory)
-                          listed t))
-                  (and entries (gethash marker entries)))))
-            markers)))))))
+       ;; Probe each level with a single `directory-files' listing rather
+       ;; than one `file-exists-p' per marker.  A VCS marker is a directory,
+       ;; so unlike the top-down search this one doesn't filter those out.
+       (lambda (directory) (projectile--directory-marker directory markers))))))
 
 (defun projectile-root-top-down-recurring (dir &optional list)
   "Identify a project root in DIR by recurring top-down search for files in LIST.
@@ -5752,6 +5776,11 @@ TASKS an alist of named tasks of the form (TASK-NAME . COMMAND); see
   ;; seeding below, for types (e.g. bloop) whose only marker also shows
   ;; up outside real projects and so must not anchor a project root.
   (let* ((project-file (cond ((eq project-file 'none) nil)
+                             ;; An alternatives clause is a marker shape, so
+                             ;; accept it here too and keep the plain list of
+                             ;; file names the rest of the code expects.
+                             ((projectile--any-marker-p project-file)
+                              (cdr project-file))
                              (project-file project-file)
                              ((not (consp marker-files)) nil)
                              ;; An alternatives clause contributes all of
@@ -6089,10 +6118,7 @@ it acts on the current project."
 
 (defun projectile--cmake-read-preset (filename)
   "Read CMake preset from FILENAME."
-  (when (file-exists-p filename)
-    (with-temp-buffer
-      (insert-file-contents filename)
-      (json-parse-buffer :array-type 'list))))
+  (projectile--read-json-file filename :array-type 'list))
 
 (defconst projectile--cmake-command-preset-array-id-alist
   '((:configure-command . "configurePresets")
@@ -6235,6 +6261,22 @@ a manual COMMAND-TYPE command is created with
   "CMake package command."
   (projectile--cmake-command :package-command))
 
+(defconst projectile--justfile-names '("justfile" ".justfile" "Justfile")
+  "The file names `just' reads its recipes from.")
+
+(defconst projectile--taskfile-names
+  '("Taskfile.yml" "Taskfile.yaml" "Taskfile.dist.yml" "Taskfile.dist.yaml")
+  "The file names go-task reads its tasks from.")
+
+(defconst projectile--makefile-names '("Makefile" "makefile" "GNUmakefile")
+  "The file names GNU make reads its targets from.")
+
+(defconst projectile--deno-config-names '("deno.json" "deno.jsonc")
+  "The file names Deno reads its configuration from.")
+
+(defconst projectile--bun-lock-names '("bun.lock" "bun.lockb")
+  "The lock file names Bun writes - the text one and the older binary one.")
+
 ;;; Project type registration
 ;;
 ;; Project type detection happens in a reverse order with respect to
@@ -6310,7 +6352,7 @@ a manual COMMAND-TYPE command is created with
 (projectile-register-project-type 'mise '((:any "mise.toml" ".mise.toml"))
                                   :compile "mise run build"
                                   :test "mise run test")
-(projectile-register-project-type 'just '((:any "justfile" ".justfile" "Justfile"))
+(projectile-register-project-type 'just `((:any ,@projectile--justfile-names))
                                   :compile "just build"
                                   :test "just test")
 
@@ -6352,8 +6394,9 @@ a manual COMMAND-TYPE command is created with
                                   :compile "debuild -uc -us")
 
 ;; Make & CMake
-;; Marker lists mean AND, so the Makefile/makefile alternatives go
-;; through a predicate.  The explicit :project-file keeps "Makefile"
+;; The Makefile/makefile alternatives predate the `(:any ...)' marker
+;; clause and still go through a predicate, since that predicate is part
+;; of the public API.  The explicit :project-file keeps "Makefile"
 ;; registered as a root file, as the marker list used to do.
 (projectile-register-project-type 'make #'projectile-make-project-p
                                   :project-file "Makefile"
@@ -6371,8 +6414,7 @@ a manual COMMAND-TYPE command is created with
                                   :install #'projectile--cmake-install-command
                                   :package #'projectile--cmake-package-command)
 ;; go-task/task
-(projectile-register-project-type 'go-task '((:any "Taskfile.yml" "Taskfile.yaml"
-                                                   "Taskfile.dist.yml" "Taskfile.dist.yaml"))
+(projectile-register-project-type 'go-task `((:any ,@projectile--taskfile-names))
                                   :compile "task build"
                                   :test "task test"
                                   :install "task install")
@@ -6432,12 +6474,12 @@ a manual COMMAND-TYPE command is created with
                                   :test-suffix ".test")
 ;; `bun.lockb' is the binary lock file Bun used before 1.2, `bun.lock' the
 ;; text one it writes now.
-(projectile-register-project-type 'bun '("package.json" (:any "bun.lock" "bun.lockb"))
+(projectile-register-project-type 'bun `("package.json" (:any ,@projectile--bun-lock-names))
                                   :compile "bun install"
                                   :test "bun test"
                                   :run "bun run start"
                                   :test-suffix ".test")
-(projectile-register-project-type 'deno '((:any "deno.json" "deno.jsonc"))
+(projectile-register-project-type 'deno `((:any ,@projectile--deno-config-names))
                                   :compile "deno check ."
                                   :test "deno test"
                                   :run "deno task start"
@@ -10914,46 +10956,47 @@ configured tasks."
   :type '(repeat function)
   :package-version '(projectile . "3.3.0"))
 
+(defvar projectile--task-entry-set nil
+  "Entries of the project root being scanned for tasks, or nil.
+Bound by `projectile-discovered-tasks' so the providers can answer
+\"is this manifest here?\" from a single directory listing instead of
+stat-ing every candidate name (see `projectile--directory-entry-set').")
+
 (defun projectile--task-file (project-root name)
   "Return NAME under PROJECT-ROOT when it exists as a readable file."
-  (let ((file (expand-file-name name project-root)))
-    (and (file-readable-p file)
-         (not (file-directory-p file))
-         file)))
+  (when (or (null projectile--task-entry-set)
+            (gethash name projectile--task-entry-set))
+    (let ((file (expand-file-name name project-root)))
+      (and (file-readable-p file)
+           (not (file-directory-p file))
+           file))))
 
 (defun projectile--first-task-file (project-root names)
   "Return the first of NAMES that exists under PROJECT-ROOT."
   (seq-some (lambda (name) (projectile--task-file project-root name)) names))
 
-(defun projectile--read-json-object (file)
-  "Read FILE as JSON and return its top-level object as an alist.
-Returns nil when FILE doesn't hold a JSON object, or when this Emacs was
-built without native JSON support."
-  (when (functionp 'json-parse-buffer)
-    (with-temp-buffer
-      (insert-file-contents file)
-      (goto-char (point-min))
-      (let ((json (json-parse-buffer :object-type 'alist
-                                     :array-type 'list
-                                     :null-object nil
-                                     :false-object nil)))
-        (and (consp json) json)))))
+(defun projectile--tasks-named (names prefix command-format)
+  "Turn NAMES into tasks called `PREFIX:NAME'.
+Each task runs COMMAND-FORMAT with the name substituted for its `%s'."
+  (mapcar (lambda (name)
+            (cons (format "%s:%s" prefix name) (format command-format name)))
+          names))
 
 (defun projectile--json-tasks (file key prefix command-format)
   "Return the tasks under KEY in the JSON object in FILE.
 Each key of that object becomes a task named `PREFIX:KEY', running
 COMMAND-FORMAT with the key substituted for its `%s'."
-  (when-let* ((json (projectile--read-json-object file))
-              (entries (alist-get key json)))
-    ;; `seq-keep' would read better, but it's Emacs 29.1 and compat
-    ;; doesn't back it up.
-    (delq nil
-          (mapcar (lambda (entry)
-                    (when-let* ((name (and (consp entry) (car entry)))
-                                (name (if (symbolp name) (symbol-name name) name)))
-                      (cons (format "%s:%s" prefix name)
-                            (format command-format name))))
-                  entries))))
+  (when-let* ((json (projectile--read-json-file file
+                                                :object-type 'alist
+                                                :array-type 'list
+                                                :null-object nil
+                                                :false-object nil))
+              ;; A JSON document that isn't an object parses to something
+              ;; `alist-get' would choke on.
+              (object (and (consp json) json))
+              (entries (alist-get key object)))
+    (projectile--tasks-named (mapcar (lambda (entry) (symbol-name (car entry))) entries)
+                             prefix command-format)))
 
 (defun projectile--npm-runner (project-root)
   "Return the package manager command to use in PROJECT-ROOT.
@@ -10961,21 +11004,21 @@ Derived from the lock file present, so it holds regardless of which
 project type won detection."
   (cond ((projectile--task-file project-root "pnpm-lock.yaml") "pnpm")
         ((projectile--task-file project-root "yarn.lock") "yarn")
-        ((projectile--first-task-file project-root '("bun.lock" "bun.lockb")) "bun")
+        ((projectile--first-task-file project-root projectile--bun-lock-names) "bun")
         (t "npm")))
 
 (defun projectile-tasks-from-npm (project-root)
   "Return the npm scripts of the project in PROJECT-ROOT as tasks.
 The scripts run through whichever package manager the project's lock
 file points at."
-  (when-let* ((file (projectile--task-file project-root "package.json"))
-              (runner (projectile--npm-runner project-root)))
-    (projectile--json-tasks file 'scripts runner (concat runner " run %s"))))
+  (when-let* ((file (projectile--task-file project-root "package.json")))
+    (let ((runner (projectile--npm-runner project-root)))
+      (projectile--json-tasks file 'scripts runner (concat runner " run %s")))))
 
 (defun projectile-tasks-from-deno (project-root)
   "Return the Deno tasks of the project in PROJECT-ROOT."
   (when-let* ((file (projectile--first-task-file
-                     project-root '("deno.json" "deno.jsonc"))))
+                     project-root projectile--deno-config-names)))
     (projectile--json-tasks file 'tasks "deno" "deno task %s")))
 
 (defun projectile-tasks-from-composer (project-root)
@@ -11001,57 +11044,65 @@ duplicates dropped."
 (defun projectile-tasks-from-just (project-root)
   "Return the recipes of the justfile in PROJECT-ROOT as tasks."
   (when-let* ((file (projectile--first-task-file
-                     project-root '("justfile" ".justfile" "Justfile"))))
-    (mapcar (lambda (name) (cons (format "just:%s" name) (format "just %s" name)))
-            ;; A recipe starts in column zero, may be marked quiet with
-            ;; `@' and may take parameters.  The lookahead keeps `:=',
-            ;; which is an assignment, from reading as a recipe.
-            (projectile--matches-in-file
-             file "^@?\\([a-zA-Z_][a-zA-Z0-9_-]*\\)[^:\n]*:\\(?:[^=\n]\\|$\\)"))))
+                     project-root projectile--justfile-names)))
+    ;; A recipe starts in column zero, may be marked quiet with `@' and
+    ;; may take parameters.  The lookahead keeps `:=', which is an
+    ;; assignment, from reading as a recipe.
+    (projectile--tasks-named
+     (projectile--matches-in-file
+      file "^@?\\([a-zA-Z_][a-zA-Z0-9_-]*\\)[^:\n]*:\\(?:[^=\n]\\|$\\)")
+     "just" "just %s")))
+
+(defun projectile--taskfile-task-names (file)
+  "Return the keys of the top-level `tasks:' mapping in the Taskfile FILE.
+Those are the lines indented exactly one level under it; anything deeper
+belongs to a task rather than naming one."
+  (with-temp-buffer
+    (insert-file-contents file)
+    (goto-char (point-min))
+    (let ((case-fold-search nil)
+          names)
+      (when (re-search-forward "^tasks:[ \t]*$" nil t)
+        (forward-line 1)
+        (let ((indent (current-indentation)))
+          (while (and (not (eobp))
+                      (or (looking-at-p "^[ \t]*$")
+                          (< 0 (current-indentation))))
+            (when (and (= (current-indentation) indent)
+                       (looking-at "[ \t]+\\([a-zA-Z0-9_.:-]+\\):"))
+              (let ((name (match-string 1)))
+                (unless (member name names)
+                  (push name names))))
+            (forward-line 1))))
+      (nreverse names))))
 
 (defun projectile-tasks-from-taskfile (project-root)
   "Return the tasks of the go-task Taskfile in PROJECT-ROOT."
   (when-let* ((file (projectile--first-task-file
-                     project-root '("Taskfile.yml" "Taskfile.yaml"
-                                    "Taskfile.dist.yml" "Taskfile.dist.yaml"))))
-    (mapcar (lambda (name) (cons (format "task:%s" name) (format "task %s" name)))
-            ;; The keys of the top-level `tasks:' mapping, i.e. the lines
-            ;; indented exactly one level under it.
-            (with-temp-buffer
-              (insert-file-contents file)
-              (goto-char (point-min))
-              (let ((case-fold-search nil)
-                    names)
-                (when (re-search-forward "^tasks:[ \t]*$" nil t)
-                  (forward-line 1)
-                  (let ((indent (current-indentation)))
-                    (while (and (not (eobp))
-                                (or (looking-at-p "^[ \t]*$")
-                                    (< 0 (current-indentation))))
-                      (when (and (= (current-indentation) indent)
-                                 (looking-at "[ \t]+\\([a-zA-Z0-9_.:-]+\\):"))
-                        (let ((name (match-string 1)))
-                          (unless (member name names)
-                            (push name names))))
-                      (forward-line 1))))
-                (nreverse names))))))
+                     project-root projectile--taskfile-names)))
+    (projectile--tasks-named (projectile--taskfile-task-names file)
+                             "task" "task %s")))
 
 (defun projectile-tasks-from-make (project-root)
   "Return the targets of the Makefile in PROJECT-ROOT as tasks.
 Only plain named targets are offered - pattern rules, file targets and
 the special dot-targets aren't things you'd run by hand."
   (when-let* ((file (projectile--first-task-file
-                     project-root '("Makefile" "makefile" "GNUmakefile"))))
-    (mapcar (lambda (name) (cons (format "make:%s" name) (format "make %s" name)))
-            (projectile--matches-in-file
-             file "^\\([a-zA-Z0-9][a-zA-Z0-9_-]*\\)[ \t]*:\\(?:[^=\n]\\|$\\)"))))
+                     project-root projectile--makefile-names)))
+    (projectile--tasks-named
+     (projectile--matches-in-file
+      file "^\\([a-zA-Z0-9][a-zA-Z0-9_-]*\\)[ \t]*:\\(?:[^=\n]\\|$\\)")
+     "make" "make %s")))
 
 (defun projectile-discovered-tasks (&optional project-root)
   "Return the tasks discovered in the project at PROJECT-ROOT.
 PROJECT-ROOT defaults to the current project's root.  The tasks come
 from `projectile-task-providers'; a provider that signals is skipped."
   (when projectile-discover-tasks
-    (when-let* ((root (or project-root (projectile-project-root))))
+    (when-let* ((root (or project-root (projectile-project-root)))
+                ;; One listing of the root answers every provider's
+                ;; "does this manifest exist?" question.
+                (projectile--task-entry-set (projectile--directory-entry-set root)))
       (seq-mapcat (lambda (provider)
                     (condition-case err
                         (funcall provider root)
@@ -11257,7 +11308,7 @@ See `projectile-subproject-markers'."
                        ;; A wildcard would have to be expanded per
                        ;; directory, and a name with a directory component
                        ;; (`debian/control') isn't a plain marker.
-                       (not (string-match-p "[*?]" file))
+                       (not (projectile--wildcard-p file))
                        (not (string-search "/" file))
                        (not (member file markers)))
               (push file markers))))
@@ -11280,10 +11331,13 @@ into a subproject."
     (dolist (marker markers)
       (puthash marker t marker-set))
     (dolist (file (projectile-project-files root))
-      ;; A manifest sitting in the root itself has no directory part -
-      ;; that's the project, not a subproject.
-      (when-let* ((dir (file-name-directory file)))
-        (when (gethash (file-name-nondirectory file) marker-set)
+      ;; The marker test first: it's a hash lookup against a name we
+      ;; already have, while `file-name-directory' allocates - and this
+      ;; runs over every file in the project.  A manifest sitting in the
+      ;; root itself has no directory part, which is the project rather
+      ;; than a subproject.
+      (when (gethash (file-name-nondirectory file) marker-set)
+        (when-let* ((dir (file-name-directory file)))
           (puthash dir t dirs))))
     (sort (hash-table-keys dirs) #'string<)))
 
@@ -11298,12 +11352,12 @@ if no subproject is found between DIR and the project root."
          (dir (or dir (file-name-directory (or (buffer-file-name) default-directory))))
          (result nil))
     ;; Walk up from current directory, stop at (but include) project root.
+    ;; Each level costs one directory listing rather than one stat per
+    ;; marker, which matters here - the derived marker set is long.
     (while (and (not result)
                 dir
                 (string-prefix-p project-root dir))
-      (when (seq-some (lambda (m)
-                        (file-exists-p (expand-file-name m dir)))
-                      markers)
+      (when (projectile--directory-marker dir markers 'files-only)
         (setq result dir))
       (let ((parent (file-name-directory (directory-file-name dir))))
         (setq dir (unless (string= parent dir) parent))))
@@ -11320,9 +11374,17 @@ that part of the repository."
          (subprojects (projectile-project-subprojects project-root)))
     (unless subprojects
       (user-error "No subprojects found in %s" project-root))
-    (let ((subproject (projectile-completing-read "Subproject: " subprojects)))
-      (projectile-find-file-in-directory
-       (expand-file-name subproject project-root)))))
+    (let* ((subproject (projectile-completing-read "Subproject: " subprojects))
+           ;; Narrow the project's own listing rather than indexing the
+           ;; subdirectory afresh: it's already there, and indexing the
+           ;; subdirectory as if it were a project of its own would drop
+           ;; the project's ignore rules.
+           (files (projectile--restrict-to-subdirs
+                   (projectile-project-files project-root) (list subproject)))
+           (file (projectile-completing-read "Find file: " files
+                                             :caller 'projectile-read-file)))
+      (find-file (expand-file-name file project-root))
+      (run-hooks 'projectile-find-file-hook))))
 
 (defun projectile-compilation-dir ()
   "Retrieve the compilation directory for this project."
@@ -11562,8 +11624,8 @@ with a prefix ARG."
 SHOW-PROMPT and PROMPT-PREFIX are as in `projectile--run-lifecycle-phase',
 which does the actual work - the subproject only changes the directory
 the command runs in."
-  (let* ((subproject-root (projectile-subproject-root))
-         (project-root (projectile-acquire-root))
+  (let* ((project-root (projectile-acquire-root))
+         (subproject-root (projectile-subproject-root))
          (projectile-project-compilation-dir
           (file-relative-name subproject-root project-root)))
     (projectile--run-lifecycle-phase phase show-prompt prompt-prefix)))

--- a/projectile.el
+++ b/projectile.el
@@ -11222,20 +11222,81 @@ COMMAND-TYPE, when non-nil, selects the per-type command history
                             '(compile-history . 1)
                           'compile-history))))
 
-(defun projectile-subproject-root ()
-  "Find the root of the nearest subproject containing the current file.
-Walk up from `default-directory' looking for the project type's
-`:project-file' marker, stopping at the project root.  Returns the
-directory containing the nearest marker, or signals an error if no
-subproject is found between the current directory and the project root."
+;;; Subprojects
+;;
+;; A monorepo is one project as far as version control (and therefore
+;; Projectile) is concerned, but its parts each have a manifest of their
+;; own - a crate, a package, a module.  Those are subprojects: Projectile
+;; keeps treating the repository as the project, and these commands let
+;; you work on the part you're in.
+
+(defcustom projectile-subproject-markers nil
+  "File names that mark a subproject inside a project.
+
+When nil (the default) the markers are derived from the registered
+project types - every type's `:project-file' - so registering a project
+type also teaches Projectile to recognize its manifest inside a
+monorepo.  Set this to an explicit list to narrow things down, e.g. to
+the manifests of the languages you actually work in.
+
+Derived markers never include the wildcard patterns some types use
+\(`?*.csproj' and friends), nor names with a directory component."
+  :group 'projectile
+  :type '(choice (const :tag "Derive from the registered project types" nil)
+                 (repeat string))
+  :package-version '(projectile . "3.3.0"))
+
+(defun projectile--subproject-markers ()
+  "Return the file names that mark a subproject.
+See `projectile-subproject-markers'."
+  (or projectile-subproject-markers
+      (let (markers)
+        (dolist (record projectile-project-types)
+          (dolist (file (ensure-list (plist-get (cdr record) 'project-file)))
+            (when (and (stringp file)
+                       ;; A wildcard would have to be expanded per
+                       ;; directory, and a name with a directory component
+                       ;; (`debian/control') isn't a plain marker.
+                       (not (string-match-p "[*?]" file))
+                       (not (string-search "/" file))
+                       (not (member file markers)))
+              (push file markers))))
+        markers)))
+
+(defun projectile-project-subprojects (&optional project-root)
+  "Return the subprojects of the project at PROJECT-ROOT.
+
+A subproject is a directory below the root that holds a project manifest
+of its own (see `projectile-subproject-markers').  The result is a sorted
+list of directory names relative to the root, each ending in a slash.
+
+The project's own file listing is what gets scanned, so the ignore rules
+apply as usual - the manifest of a vendored dependency doesn't turn it
+into a subproject."
+  (let* ((root (or project-root (projectile-acquire-root)))
+         (markers (projectile--subproject-markers))
+         (marker-set (make-hash-table :test 'equal))
+         (dirs (make-hash-table :test 'equal)))
+    (dolist (marker markers)
+      (puthash marker t marker-set))
+    (dolist (file (projectile-project-files root))
+      ;; A manifest sitting in the root itself has no directory part -
+      ;; that's the project, not a subproject.
+      (when-let* ((dir (file-name-directory file)))
+        (when (gethash (file-name-nondirectory file) marker-set)
+          (puthash dir t dirs))))
+    (sort (hash-table-keys dirs) #'string<)))
+
+(defun projectile-subproject-root (&optional dir)
+  "Find the root of the nearest subproject containing DIR.
+Walk up from DIR (the current file's directory by default) looking for
+one of `projectile-subproject-markers', stopping at the project root.
+Returns the directory containing the nearest marker, or signals an error
+if no subproject is found between DIR and the project root."
   (let* ((project-root (projectile-acquire-root))
-         (type (projectile-project-type project-root))
-         (project-file (projectile-project-type-attribute type 'project-file))
-         (markers (if (listp project-file) project-file (list project-file)))
-         (dir (file-name-directory (or (buffer-file-name) default-directory)))
+         (markers (projectile--subproject-markers))
+         (dir (or dir (file-name-directory (or (buffer-file-name) default-directory))))
          (result nil))
-    (unless markers
-      (user-error "Project type `%s' has no project-file defined" type))
     ;; Walk up from current directory, stop at (but include) project root.
     (while (and (not result)
                 dir
@@ -11248,6 +11309,20 @@ subproject is found between the current directory and the project root."
         (setq dir (unless (string= parent dir) parent))))
     (or result
         (user-error "No subproject found between current directory and project root"))))
+
+;;;###autoload
+(defun projectile-find-file-in-subproject ()
+  "Jump to a file in one of the current project's subprojects.
+Prompts for the subproject first, so the file completion only covers
+that part of the repository."
+  (interactive)
+  (let* ((project-root (projectile-acquire-root))
+         (subprojects (projectile-project-subprojects project-root)))
+    (unless subprojects
+      (user-error "No subprojects found in %s" project-root))
+    (let ((subproject (projectile-completing-read "Subproject: " subprojects)))
+      (projectile-find-file-in-directory
+       (expand-file-name subproject project-root)))))
 
 (defun projectile-compilation-dir ()
   "Retrieve the compilation directory for this project."
@@ -11431,11 +11506,12 @@ never treated as dynamic."
           (plist-get (alist-get (projectile-project-type) projectile-project-types)
                      (intern (format "%s-command" phase)))))))
 
-(defun projectile--run-lifecycle-phase (phase show-prompt)
+(defun projectile--run-lifecycle-phase (phase show-prompt &optional prompt-prefix)
   "Run the current project's command for lifecycle PHASE.
 PHASE is a symbol naming an entry of `projectile--lifecycle-phases'.
 With SHOW-PROMPT non-nil force prompting for the command, as in
-`projectile--run-project-cmd'."
+`projectile--run-project-cmd'.  PROMPT-PREFIX overrides the phase's own
+prompt."
   (let* ((descriptor (projectile--phase-descriptor phase))
          (command (funcall (plist-get descriptor :command-fn)
                            (projectile-compilation-dir)))
@@ -11444,7 +11520,8 @@ With SHOW-PROMPT non-nil force prompting for the command, as in
     (projectile--run-project-cmd command command-map
                                  :command-type phase
                                  :show-prompt show-prompt
-                                 :prompt-prefix (plist-get descriptor :prompt)
+                                 :prompt-prefix (or prompt-prefix
+                                                    (plist-get descriptor :prompt))
                                  :save-buffers (plist-get descriptor :save-buffers)
                                  :no-cache (projectile--phase-command-dynamic-p phase)
                                  :use-comint-mode (symbol-value (plist-get descriptor :use-comint-var)))))
@@ -11480,10 +11557,21 @@ with a prefix ARG."
   (interactive "P")
   (projectile--run-lifecycle-phase 'test arg))
 
+(defun projectile--run-subproject-phase (phase show-prompt prompt-prefix)
+  "Run lifecycle PHASE in the nearest subproject of the current file.
+SHOW-PROMPT and PROMPT-PREFIX are as in `projectile--run-lifecycle-phase',
+which does the actual work - the subproject only changes the directory
+the command runs in."
+  (let* ((subproject-root (projectile-subproject-root))
+         (project-root (projectile-acquire-root))
+         (projectile-project-compilation-dir
+          (file-relative-name subproject-root project-root)))
+    (projectile--run-lifecycle-phase phase show-prompt prompt-prefix)))
+
 ;;;###autoload
 (defun projectile-compile-subproject (arg)
   "Run compilation in the nearest subproject.
-Find the closest build file (e.g. pom.xml, build.gradle) between the
+Find the closest project manifest (e.g. pom.xml, Cargo.toml) between the
 current directory and the project root, then run the project's compile
 command there.  This is useful for multi-module projects where building
 a single module is faster than building the entire project.
@@ -11492,22 +11580,12 @@ Normally you'll be prompted for a compilation command, unless
 variable `compilation-read-command'.  You can force the prompt
 with a prefix ARG."
   (interactive "P")
-  (let* ((subproject-root (projectile-subproject-root))
-         (project-root (projectile-acquire-root))
-         (projectile-project-compilation-dir
-          (file-relative-name subproject-root project-root))
-         (command (projectile-compilation-command (projectile-compilation-dir)))
-         (command-map (if (projectile--cache-project-commands-p) projectile-compilation-cmd-map)))
-    (projectile--run-project-cmd command command-map
-                                 :show-prompt arg
-                                 :prompt-prefix "Compile subproject command: "
-                                 :save-buffers t
-                                 :use-comint-mode projectile-compile-use-comint-mode)))
+  (projectile--run-subproject-phase 'compile arg "Compile subproject command: "))
 
 ;;;###autoload
 (defun projectile-test-subproject (arg)
   "Run tests in the nearest subproject.
-Find the closest build file (e.g. pom.xml, build.gradle) between the
+Find the closest project manifest (e.g. pom.xml, Cargo.toml) between the
 current directory and the project root, then run the project's test
 command there.  This is useful for multi-module projects where testing
 a single module is faster than testing the entire project.
@@ -11516,17 +11594,18 @@ Normally you'll be prompted for a compilation command, unless
 variable `compilation-read-command'.  You can force the prompt
 with a prefix ARG."
   (interactive "P")
-  (let* ((subproject-root (projectile-subproject-root))
-         (project-root (projectile-acquire-root))
-         (projectile-project-compilation-dir
-          (file-relative-name subproject-root project-root))
-         (command (projectile-test-command (projectile-compilation-dir)))
-         (command-map (if (projectile--cache-project-commands-p) projectile-test-cmd-map)))
-    (projectile--run-project-cmd command command-map
-                                 :show-prompt arg
-                                 :prompt-prefix "Test subproject command: "
-                                 :save-buffers t
-                                 :use-comint-mode projectile-test-use-comint-mode)))
+  (projectile--run-subproject-phase 'test arg "Test subproject command: "))
+
+;;;###autoload
+(defun projectile-run-subproject (arg)
+  "Run the nearest subproject.
+Like `projectile-compile-subproject', but for the project's run command -
+handy in a monorepo where each service is started from its own directory.
+
+Normally you'll be prompted for a command, unless variable
+`compilation-read-command'.  You can force the prompt with a prefix ARG."
+  (interactive "P")
+  (projectile--run-subproject-phase 'run arg "Run subproject command: "))
 
 (defun projectile-test-at-point-python-name (node)
   "Return the test name for the Python `function_definition' NODE.
@@ -13848,8 +13927,11 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "c t") #'projectile-test-project)
     (define-key map (kbd "c .") #'projectile-run-test-at-point)
     (define-key map (kbd "c r") #'projectile-run-project)
+    ;; subprojects (see `projectile-project-subprojects')
     (define-key map (kbd "c m c") #'projectile-compile-subproject)
     (define-key map (kbd "c m t") #'projectile-test-subproject)
+    (define-key map (kbd "c m r") #'projectile-run-subproject)
+    (define-key map (kbd "c m f") #'projectile-find-file-in-subproject)
     (define-key map (kbd "c x") #'projectile-run-task)
     (define-key map (kbd "c X") #'projectile-repeat-last-task)
     ;; integration with utilities
@@ -14172,6 +14254,11 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("cp" "package" projectile-package-project)
       ("cx" "run task" projectile-run-task)
       ("cX" "repeat last task" projectile-repeat-last-task)]
+     ["Subproject"
+      ("cmf" "find file" projectile-find-file-in-subproject)
+      ("cmc" "compile" projectile-compile-subproject)
+      ("cmt" "test" projectile-test-subproject)
+      ("cmr" "run" projectile-run-subproject)]
      ["Shells / Run"
       ("xr" "run" projectile-dispatch-run)
       ("xe" "eshell" projectile-dispatch-run-eshell)
@@ -14232,6 +14319,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
          ["Find test file" projectile-find-test-file]
          ["Find directory" projectile-find-dir]
          ["Find file in directory" projectile-find-file-in-directory]
+         ["Find file in subproject" projectile-find-file-in-subproject]
          ["Find other file" projectile-find-other-file]
          ["Find file of kind" projectile-find-file-of-kind]
          ["Jump between implementation file and test file" projectile-toggle-between-implementation-and-test]
@@ -14308,6 +14396,10 @@ search/replace case-sensitive, `--word' makes it match whole words,
          "--"
          ["Run task" projectile-run-task]
          ["Repeat last task" projectile-repeat-last-task]
+         "--"
+         ["Compile subproject" projectile-compile-subproject]
+         ["Test subproject" projectile-test-subproject]
+         ["Run subproject" projectile-run-subproject]
          "--"
          ["Repeat last build command" projectile-repeat-last-command])
         ("Session"

--- a/projectile.el
+++ b/projectile.el
@@ -6378,6 +6378,11 @@ a manual COMMAND-TYPE command is created with
                                   :install "task install")
 ;; Go should take higher precedence than Make because Go projects often have a Makefile.
 (projectile-register-project-type 'go projectile-go-project-test-function
+                                  ;; The type is detected by predicate (a
+                                  ;; project can be Go without a go.mod), but
+                                  ;; the module file is still what marks a Go
+                                  ;; project's root - and its subprojects.
+                                  :project-file "go.mod"
                                   :compile "go build"
                                   :test "go test ./..."
                                   :test-suffix "_test")

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -576,13 +576,23 @@
       (expect (projectile-project-subprojects "/proj/") :to-equal '("crates/parser/")))))
 
 (describe "projectile-find-file-in-subproject"
-  (it "finds the file in the chosen subproject's directory"
+  (it "completes over just the chosen subproject's files, from the project's listing"
     (spy-on 'projectile-acquire-root :and-return-value "/proj/")
     (spy-on 'projectile-project-subprojects :and-return-value '("app/" "lib/"))
-    (spy-on 'projectile-completing-read :and-return-value "lib/")
-    (spy-on 'projectile-find-file-in-directory)
-    (projectile-find-file-in-subproject)
-    (expect 'projectile-find-file-in-directory :to-have-been-called-with "/proj/lib/"))
+    (spy-on 'projectile-project-files :and-return-value
+            '("app/main.js" "lib/util.js" "lib/util.test.js" "README.md"))
+    (spy-on 'find-file)
+    (let (offered)
+      (spy-on 'projectile-completing-read :and-call-fake
+              (lambda (prompt choices &rest _)
+                (if (string-prefix-p "Subproject" prompt)
+                    "lib/"
+                  (setq offered choices)
+                  "lib/util.js")))
+      (projectile-find-file-in-subproject)
+      ;; only the subproject's files, and the project is indexed once
+      (expect offered :to-equal '("lib/util.js" "lib/util.test.js"))
+      (expect 'find-file :to-have-been-called-with "/proj/lib/util.js")))
 
   (it "errors when the project has no subprojects"
     (spy-on 'projectile-acquire-root :and-return-value "/proj/")

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -474,8 +474,26 @@
     (expect 'projectile-run-compilation
             :to-have-been-called-with "make build" nil)))
 
+(describe "projectile--subproject-markers"
+  (it "derives the markers from the registered project types"
+    (let ((projectile-subproject-markers nil))
+      (expect (member "Cargo.toml" (projectile--subproject-markers)) :to-be-truthy)
+      (expect (member "package.json" (projectile--subproject-markers)) :to-be-truthy)
+      (expect (member "go.mod" (projectile--subproject-markers)) :to-be-truthy)))
+
+  (it "leaves out wildcard patterns and names with a directory component"
+    (let ((projectile-subproject-markers nil))
+      (expect (seq-find (lambda (m) (string-match-p "[*?]" m))
+                        (projectile--subproject-markers))
+              :to-be nil)
+      (expect (member "debian/control" (projectile--subproject-markers)) :to-be nil)))
+
+  (it "honors an explicit list"
+    (let ((projectile-subproject-markers '("only.this")))
+      (expect (projectile--subproject-markers) :to-equal '("only.this")))))
+
 (describe "projectile-subproject-root"
-  (it "returns the nearest ancestor directory that holds a project-file marker"
+  (it "returns the nearest ancestor directory that holds a project marker"
     (let* ((root (file-name-as-directory (make-temp-file "projectile-sub" t)))
            (sub (file-name-as-directory (expand-file-name "mod" root)))
            (deep (file-name-as-directory (expand-file-name "src" sub))))
@@ -485,8 +503,22 @@
             (write-region "" nil (expand-file-name "pom.xml" root))
             (write-region "" nil (expand-file-name "pom.xml" sub))
             (spy-on 'projectile-acquire-root :and-return-value root)
-            (spy-on 'projectile-project-type :and-return-value 'maven)
-            (spy-on 'projectile-project-type-attribute :and-return-value "pom.xml")
+            (let ((default-directory deep))
+              (expect (projectile-subproject-root) :to-equal sub)))
+        (delete-directory root t))))
+
+  (it "recognizes a subproject of a different kind than the project itself"
+    ;; A polyglot monorepo: the manifest of the part you're in counts,
+    ;; whatever the type of the repository as a whole is.
+    (let* ((root (file-name-as-directory (make-temp-file "projectile-sub" t)))
+           (sub (file-name-as-directory (expand-file-name "crates/parser" root)))
+           (deep (file-name-as-directory (expand-file-name "src" sub))))
+      (unwind-protect
+          (progn
+            (make-directory deep t)
+            (write-region "" nil (expand-file-name "package.json" root))
+            (write-region "" nil (expand-file-name "Cargo.toml" sub))
+            (spy-on 'projectile-acquire-root :and-return-value root)
             (let ((default-directory deep))
               (expect (projectile-subproject-root) :to-equal sub)))
         (delete-directory root t))))
@@ -500,8 +532,6 @@
             (make-directory deep t)
             (write-region "" nil (expand-file-name "pom.xml" root))
             (spy-on 'projectile-acquire-root :and-return-value root)
-            (spy-on 'projectile-project-type :and-return-value 'maven)
-            (spy-on 'projectile-project-type-attribute :and-return-value "pom.xml")
             (let ((default-directory deep))
               (expect (projectile-subproject-root) :to-equal root)))
         (delete-directory root t))))
@@ -513,11 +543,51 @@
           (progn
             (make-directory deep t)
             (spy-on 'projectile-acquire-root :and-return-value root)
-            (spy-on 'projectile-project-type :and-return-value 'maven)
-            (spy-on 'projectile-project-type-attribute :and-return-value "pom.xml")
             (let ((default-directory deep))
               (expect (projectile-subproject-root) :to-throw 'user-error)))
         (delete-directory root t)))))
+
+(describe "projectile-project-subprojects"
+  (it "lists the directories below the root that hold a manifest"
+    (spy-on 'projectile-project-files :and-return-value
+            '("README.md"
+              "package.json"
+              "crates/parser/Cargo.toml"
+              "crates/parser/src/lib.rs"
+              "services/api/go.mod"
+              "services/api/main.go"
+              "docs/index.md"))
+    (expect (projectile-project-subprojects "/proj/")
+            :to-equal '("crates/parser/" "services/api/")))
+
+  (it "does not count the project's own manifest as a subproject"
+    (spy-on 'projectile-project-files :and-return-value '("Cargo.toml" "src/main.rs"))
+    (expect (projectile-project-subprojects "/proj/") :to-be nil))
+
+  (it "reports a directory once, however many manifests it holds"
+    (spy-on 'projectile-project-files :and-return-value
+            '("app/package.json" "app/Cargo.toml" "app/Makefile"))
+    (expect (projectile-project-subprojects "/proj/") :to-equal '("app/")))
+
+  (it "honors an explicit marker list"
+    (spy-on 'projectile-project-files :and-return-value
+            '("crates/parser/Cargo.toml" "web/package.json"))
+    (let ((projectile-subproject-markers '("Cargo.toml")))
+      (expect (projectile-project-subprojects "/proj/") :to-equal '("crates/parser/")))))
+
+(describe "projectile-find-file-in-subproject"
+  (it "finds the file in the chosen subproject's directory"
+    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    (spy-on 'projectile-project-subprojects :and-return-value '("app/" "lib/"))
+    (spy-on 'projectile-completing-read :and-return-value "lib/")
+    (spy-on 'projectile-find-file-in-directory)
+    (projectile-find-file-in-subproject)
+    (expect 'projectile-find-file-in-directory :to-have-been-called-with "/proj/lib/"))
+
+  (it "errors when the project has no subprojects"
+    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    (spy-on 'projectile-project-subprojects :and-return-value nil)
+    (expect (projectile-find-file-in-subproject) :to-throw 'user-error)))
 
 (describe "projectile-compile-subproject"
   (it "compiles with the subproject as the relative compilation dir"
@@ -533,5 +603,21 @@
       (expect 'projectile--run-project-cmd :to-have-been-called)
       ;; the subproject dir is passed relative to the project root
       (expect seen-dir :to-equal "mod/"))))
+
+(describe "projectile-run-subproject"
+  (it "runs the project's run command in the subproject"
+    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    (spy-on 'projectile-subproject-root :and-return-value "/proj/services/api/")
+    (spy-on 'projectile-compilation-dir :and-return-value "/proj/services/api/")
+    (spy-on 'projectile-run-command :and-return-value "go run .")
+    (spy-on 'projectile--cache-project-commands-p :and-return-value nil)
+    (let (seen-dir seen-command)
+      (spy-on 'projectile--run-project-cmd :and-call-fake
+              (lambda (command &rest _)
+                (setq seen-dir projectile-project-compilation-dir
+                      seen-command command)))
+      (projectile-run-subproject nil)
+      (expect seen-command :to-equal "go run .")
+      (expect seen-dir :to-equal "services/api/"))))
 
 ;;; projectile-commands-test.el ends here

--- a/test/projectile-project-type-test.el
+++ b/test/projectile-project-type-test.el
@@ -641,6 +641,11 @@
     (projectile-test-with-stub-root "proj" ("README")
       (expect (projectile-cabal-project-p) :to-be nil))))
 
+(describe "go project type"
+  (it "registers go.mod as a project file, so it can anchor a root"
+    (expect (projectile-project-type-attribute 'go 'project-file) :to-equal "go.mod")
+    (expect (member "go.mod" projectile-project-root-files) :to-be-truthy)))
+
 (describe "projectile-flutter-project-p"
   (it "is true for a pubspec.yaml that depends on the Flutter SDK"
     (projectile-test-with-stub-root "proj" ("pubspec.yaml")


### PR DESCRIPTION
`projectile-subproject-root` only looked for the marker of the project's *own*
type, so a Cargo crate sitting under a `package.json` project was invisible to
it, and a type whose marker is a predicate rather than a file (Go, until this
PR) errored outright with "has no project-file defined". The markers now come
from every registered project type, which is what makes the existing
`projectile-compile-subproject` and `projectile-test-subproject` useful in a
polyglot repository.

On top of that: `projectile-project-subprojects` lists a monorepo's parts (out
of the project's own file listing, so the ignore rules apply),
`projectile-find-file-in-subproject` scopes file completion to one of them, and
`projectile-run-subproject` joins compile and test - all three of which now go
through the lifecycle phase table instead of reimplementing it.

The last commit is a performance pass over everything in this stack. The
subproject walk was probing every derived marker with its own stat at every
directory level, and the top-down root search still probed one name at a time,
which got worse as #2119 nearly doubled `projectile-project-root-files`. They
share one directory-listing probe now: three directories deep in a Cargo
project the subproject walk goes from 177 filesystem calls to 3, task discovery
from 20 to 8, and the root search needs 260 where master needed 700 with half
as many markers.

Last of three stacked PRs, on top of #2119 and #2120.