### PR TITLE
Don't wait forever for an index that already finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@
 
 ### Bugs fixed
 
+- [#2118](https://github.com/bbatsov/projectile/issues/2118): Fix `projectile-find-file` showing "Projectile is indexing" forever with `projectile-async-indexing` enabled. The indexing command's result is handed over by its process sentinel, and Emacs doesn't guarantee it runs that while a command sits waiting on the process - the wait then never ended, and only `C-g` (which returns to the command loop, where the sentinel does run) got out of it.
+  - Projectile now waits for the process rather than for the sentinel, and collects the finished command's output itself if the sentinel hasn't run within `projectile-async-index-sentinel-timeout` (1 second). The parsing is shared, so the result is the same either way.
+  - Should even that fail, it indexes synchronously rather than reporting an empty project.
 - [#2119](https://github.com/bbatsov/projectile/pull/2119): Fix the `angular` project type never matching anything: its two markers were ANDed, but a project has either `angular.json` (Angular 6+) or `.angular-cli.json`, never both.
 - [#2119](https://github.com/bbatsov/projectile/pull/2119): Fix the Python project types shadowing each other - `pyproject.toml` was checked before `django`, `python-poetry`, `python-pipenv` and `python-tox`, and since nearly every Python project has one, those four types never matched (a Django project also lost its file kinds along the way).
 - [#2119](https://github.com/bbatsov/projectile/pull/2119): Fix `php-symfony` not matching a modern Symfony project: it required an `app` directory, gone since Symfony 3, and a `vendor` directory, which only exists after someone has run composer.

--- a/doc/modules/ROOT/pages/indexing.adoc
+++ b/doc/modules/ROOT/pages/indexing.adoc
@@ -542,6 +542,13 @@ NOTE: It has no effect under `native` indexing (the Emacs Lisp directory walk
 can't run off the main thread), in batch mode, or while a keyboard macro is
 executing - those index synchronously.
 
+The result of the indexing command reaches Projectile from the process's
+sentinel, and Emacs doesn't guarantee it runs that promptly while a command is
+waiting on the process. If it hasn't run `projectile-async-index-sentinel-timeout`
+seconds after the command finished, Projectile parses the output itself instead
+of waiting any longer. You shouldn't ever need to touch that option; it exists
+because waiting forever was once possible.
+
 You can also warm the cache ahead of time, without blocking, using kbd:[M-x]
 `projectile-index-project-async`:
 

--- a/projectile.el
+++ b/projectile.el
@@ -206,6 +206,21 @@ using the native indexing method."
           (const :tag "Persistent" persistent))
   :package-version '(projectile . "2.9.0"))
 
+(defcustom projectile-async-index-sentinel-timeout 1.0
+  "Seconds to wait for a finished index's result before collecting it.
+
+The asynchronous indexer hands its result over from the indexing
+process's sentinel.  Once that process has exited, Emacs is expected to
+run the sentinel promptly - but it isn't guaranteed to while a command is
+waiting for it, and Projectile then used to wait forever (issue #2118).
+
+After this many seconds Projectile parses the finished command's output
+itself instead.  There's no correctness difference; the timeout only
+decides how long to let Emacs do it first."
+  :group 'projectile
+  :type 'number
+  :package-version '(projectile . "3.3.0"))
+
 (defcustom projectile-async-indexing t
   "Whether to index projects without freezing Emacs.
 
@@ -3677,6 +3692,50 @@ Remote ROOTs are handled via TRAMP (`make-process' is given a non-nil
            ;; nil on Windows without `sh', in which case we decline below and
            ;; the caller falls back to the synchronous runner (see #2116).
            (shell (projectile--posix-shell))
+           ;; The result is delivered by this function rather than
+           ;; straight from the sentinel, so a caller waiting on the
+           ;; process can also deliver it (see
+           ;; `projectile--dir-files-alien-await' and issue #2118).  It
+           ;; runs at most once, whoever gets there first.
+           (finished nil)
+           (finish
+            (lambda (proc)
+              (unless finished
+                (setq finished t)
+                (unwind-protect
+                    ;; A consumer that gives up on the wait (e.g. a C-g during
+                    ;; `projectile--dir-files-alien-await') marks the process
+                    ;; aborted and kills it.  Killing fires the sentinel with a
+                    ;; `signal' status, but we must not then report a bogus
+                    ;; failure or clobber the errors buffer - just clean up.
+                    (unless (process-get proc 'projectile-aborted)
+                      (let ((exit-code (process-exit-status proc))
+                            (files (projectile--restrict-to-subdirs
+                                    (with-current-buffer stdout-buffer
+                                      (projectile--ext-command-output-files))
+                                    restrict)))
+                        (cond
+                         ;; Clean exit: pass the listing through.
+                         ((and (numberp exit-code) (zerop exit-code))
+                          (funcall callback files nil))
+                         ;; Non-zero exit but we still got a listing: trust it,
+                         ;; mirroring the synchronous runner.  Surface stderr
+                         ;; and mention it quietly when there's anything to see.
+                         (files
+                          (when (projectile--surface-ext-command-errors errors-file)
+                            (message "Projectile: `%s' exited with code %s but produced output; using it (see *projectile-files-errors*)"
+                                     command exit-code))
+                          (funcall callback files nil))
+                         ;; Non-zero exit and nothing on stdout: a real failure.
+                         (t
+                          (projectile--surface-ext-command-errors errors-file)
+                          (funcall callback
+                                   nil
+                                   (format "exit code %s: %s"
+                                           exit-code command))))))
+                  (when (buffer-live-p stdout-buffer) (kill-buffer stdout-buffer))
+                  (when (file-exists-p errors-file)
+                    (ignore-errors (delete-file errors-file)))))))
            (proc
             (when shell
               (condition-case nil
@@ -3690,45 +3749,16 @@ Remote ROOTs are handled via TRAMP (`make-process' is given a non-nil
                    :sentinel
                    (lambda (proc _event)
                      (when (memq (process-status proc) '(exit signal))
-                       (unwind-protect
-                           ;; A consumer that gives up on the wait (e.g. a C-g during
-                           ;; `projectile--dir-files-alien-await') marks the process
-                           ;; aborted and kills it.  Killing fires this sentinel with a
-                           ;; `signal' status, but we must not then report a bogus
-                           ;; failure or clobber the errors buffer - just clean up.
-                           (unless (process-get proc 'projectile-aborted)
-                             (let ((exit-code (process-exit-status proc))
-                                   (files (projectile--restrict-to-subdirs
-                                           (with-current-buffer stdout-buffer
-                                             (projectile--ext-command-output-files))
-                                           restrict)))
-                               (cond
-                                ;; Clean exit: pass the listing through.
-                                ((and (numberp exit-code) (zerop exit-code))
-                                 (funcall callback files nil))
-                                ;; Non-zero exit but we still got a listing: trust it,
-                                ;; mirroring the synchronous runner.  Surface stderr
-                                ;; and mention it quietly when there's anything to see.
-                                (files
-                                 (when (projectile--surface-ext-command-errors errors-file)
-                                   (message "Projectile: `%s' exited with code %s but produced output; using it (see *projectile-files-errors*)"
-                                            command exit-code))
-                                 (funcall callback files nil))
-                                ;; Non-zero exit and nothing on stdout: a real failure.
-                                (t
-                                 (projectile--surface-ext-command-errors errors-file)
-                                 (funcall callback
-                                          nil
-                                          (format "exit code %s: %s"
-                                                  exit-code command))))))
-                         (when (buffer-live-p stdout-buffer) (kill-buffer stdout-buffer))
-                         (when (file-exists-p errors-file)
-                           (ignore-errors (delete-file errors-file)))))))
+                       (funcall finish proc))))
                 ;; A failed spawn (e.g. Windows can't exec the shell, #2116)
                 ;; signals `file-error'; trap it and decline so the caller
                 ;; falls back to the synchronous runner, rather than letting
                 ;; it escape from indexing.
                 (file-error nil)))))
+      ;; Hand the delivery function to whoever waits on the process, so a
+      ;; sentinel that doesn't get run can't strand them (see #2118).
+      (when (processp proc)
+        (process-put proc 'projectile-finish finish))
       ;; No process: either no POSIX shell was found (Windows without `sh',
       ;; see #2116), a spawn error was trapped above, or a file-name handler
       ;; declined (e.g. a remote host that doesn't support `make-process').
@@ -3876,9 +3906,29 @@ and timers (but not interactive commands) may run while we wait."
                                (propertize (abbreviate-file-name directory)
                                            'face 'font-lock-keyword-face)))))
         (unwind-protect
-            (while (not done)
-              (accept-process-output proc 0.1)
-              (progress-reporter-update reporter))
+            (progn
+              (while (and (not done) (process-live-p proc))
+                (accept-process-output proc 0.1)
+                (progress-reporter-update reporter))
+              ;; The command is done, but the result reaches us from the
+              ;; process sentinel, and that isn't guaranteed to have run:
+              ;; `accept-process-output' on a process that has already
+              ;; exited returns without running it, and the status change
+              ;; may not be noticed until Emacs is back in its command
+              ;; loop.  That used to leave this loop spinning forever with
+              ;; the progress reporter turning (issue #2118).  Pump the
+              ;; event loop briefly - `sit-for', unlike
+              ;; `accept-process-output', does run pending sentinels - and
+              ;; if the result still hasn't arrived, deliver it here.
+              (unless done
+                (let ((deadline (+ (projectile-time-seconds)
+                                   projectile-async-index-sentinel-timeout)))
+                  (while (and (not done) (< (projectile-time-seconds) deadline))
+                    (sit-for 0.02)
+                    (progress-reporter-update reporter)))
+                (unless done
+                  (when-let* ((finish (process-get proc 'projectile-finish)))
+                    (funcall finish proc)))))
           ;; Runs on normal completion and on `keyboard-quit': make sure we
           ;; never leave the indexing process running behind us.  Mark it
           ;; aborted first so its sentinel skips the failure path (killing
@@ -3888,10 +3938,14 @@ and timers (but not interactive commands) may run while we wait."
             (process-put proc 'projectile-aborted t)
             (delete-process proc)))
         (progress-reporter-done reporter))
-      (if err
-          (user-error "Projectile indexing failed: %s.  \
-See the *projectile-files-errors* buffer for details" err)
-        files)))))
+      (cond
+       (err
+        (user-error "Projectile indexing failed: %s.  \
+See the *projectile-files-errors* buffer for details" err))
+       (done files)
+       ;; Neither the sentinel nor we could deliver a result - rather than
+       ;; report an empty project, index the old (blocking) way.
+       (t (projectile-dir-files-alien directory vcs subdirs)))))))
 
 (defun projectile--dir-files-alien-maybe-async (directory &optional vcs subdirs)
   "Return alien-indexed files for DIRECTORY, without freezing when possible.

--- a/test/projectile-async-test.el
+++ b/test/projectile-async-test.el
@@ -376,6 +376,57 @@ that stores into it as the async callback."
     (expect (projectile--dir-files-alien-await "/proj/") :to-equal '("fallback.el"))
     (expect 'projectile-dir-files-alien :to-have-been-called))
 
+  (it "lets a queued sentinel deliver the result before stepping in (#2118)"
+    (let (finish-calls)
+      (spy-on 'projectile-dir-files-alien-async :and-call-fake
+              (lambda (_dir callback &rest _)
+                (let ((proc (make-process :name "projectile-test-index"
+                                          :command '("sh" "-c" "exit 0")
+                                          :noquery t
+                                          :sentinel
+                                          (lambda (p _e)
+                                            (when (memq (process-status p) '(exit signal))
+                                              (funcall callback '("from-sentinel.el") nil))))))
+                  (process-put proc 'projectile-finish
+                               (lambda (_p) (push 'finish finish-calls)))
+                  proc)))
+      (expect (projectile--dir-files-alien-await "/proj/")
+              :to-equal '("from-sentinel.el"))
+      ;; the sentinel got there first, so we never took over
+      (expect finish-calls :to-be nil)))
+
+  (it "delivers the result itself when the sentinel never runs (#2118)"
+    ;; The reported hang: the indexing command finishes and is reaped, but
+    ;; its sentinel isn't run while we wait, so the callback never fires
+    ;; and the progress reporter spins forever.  Simulated here by a
+    ;; process whose sentinel does nothing at all.
+    (let (proc)
+      (spy-on 'projectile-dir-files-alien-async :and-call-fake
+              (lambda (_dir callback &rest _)
+                (setq proc (make-process :name "projectile-test-index"
+                                         :command '("sh" "-c" "exit 0")
+                                         :noquery t
+                                         :sentinel #'ignore))
+                (process-put proc 'projectile-finish
+                             (lambda (_p) (funcall callback '("a.el" "src/b.el") nil)))
+                proc))
+      (let ((projectile-async-index-sentinel-timeout 0.05))
+        (expect (projectile--dir-files-alien-await "/proj/")
+                :to-equal '("a.el" "src/b.el")))))
+
+  (it "indexes synchronously when no result can be had at all (#2118)"
+    ;; Same as above, but nothing knows how to deliver the result either -
+    ;; report the project's files the slow way rather than claim it's empty.
+    (spy-on 'projectile-dir-files-alien-async :and-call-fake
+            (lambda (_dir _callback &rest _)
+              (make-process :name "projectile-test-index"
+                            :command '("sh" "-c" "exit 0")
+                            :noquery t
+                            :sentinel #'ignore)))
+    (spy-on 'projectile-dir-files-alien :and-return-value '("fallback.el"))
+    (let ((projectile-async-index-sentinel-timeout 0.05))
+      (expect (projectile--dir-files-alien-await "/proj/") :to-equal '("fallback.el"))))
+
   (it "signals a user-error, and kills the process, when indexing fails"
     (let ((proc (start-process "projectile-test-sleep" nil "sleep" "30")))
       ;; Hand back a live process (so the await path, not the can't-start


### PR DESCRIPTION
The asynchronous indexer hands its result over from the indexing process's
sentinel, and `projectile--dir-files-alien-await` looped until that happened.
But Emacs doesn't guarantee it runs a sentinel while a command is sitting in
`accept-process-output`: the process exits and is reaped, the status change
goes unnoticed, and the wait never ends. That matches the report exactly -
the spinner turning with no process running, `C-g` being the only way out
(it returns to the command loop, where sentinels do run), and the problem
disappearing with `projectile-async-indexing` set to nil.

So the loop now waits for the *process* rather than for the sentinel. Once the
process is gone it pumps the event loop briefly - `sit-for`, unlike
`accept-process-output`, runs pending sentinels - and if the result still
hasn't arrived it parses the finished command's output itself, through the same
code the sentinel would have run (now a run-once function shared by both, so
whoever gets there first wins). If even that comes up empty, it indexes
synchronously rather than reporting an empty project.

I could not reproduce the stuck sentinel here, so the regression specs
simulate it with a process whose sentinel does nothing. Both of them hang the
old code and pass on this branch.

A side benefit: when Projectile collects the result itself, the git
post-processing steps (submodule listing, deleted files) no longer run as
synchronous subprocesses nested inside a sentinel, which is its own hazard.

Fixes #2118