### PR TITLE
Remember a lifecycle command edited at the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 
 ### Bugs fixed
 
+- [#2097](https://github.com/bbatsov/projectile/issues/2097): Fix `projectile-compile-project` and `projectile-test-project` forgetting a command you edited at the prompt in a CMake project. Since 3.2.0 a command a project type registers as a function is resolved on every run (so a preset picker can prompt again), but that also threw away your edit - it's now remembered, and `projectile-discard-command-cache` hands the project back to the picker. Only CMake ships function-valued commands out of the box, which is why `projectile-run-project` looked unaffected: CMake registers no run command.
 - [#2118](https://github.com/bbatsov/projectile/issues/2118): Fix `projectile-find-file` showing "Projectile is indexing" forever with `projectile-async-indexing` enabled. The indexing command's result is handed over by its process sentinel, and Emacs doesn't guarantee it runs that while a command sits waiting on the process - the wait then never ended, and only `C-g` (which returns to the command loop, where the sentinel does run) got out of it.
   - Projectile now waits for the process rather than for the sentinel, and collects the finished command's output itself if the sentinel hasn't run within `projectile-async-index-sentinel-timeout` (1 second). The parsing is shared, so the result is the same either way.
   - Should even that fail, it indexes synchronously rather than reporting an empty project.

--- a/doc/modules/ROOT/pages/tasks.adoc
+++ b/doc/modules/ROOT/pages/tasks.adoc
@@ -39,6 +39,13 @@ to drop the cached commands for the current project so they're re-read on the
 next run. You can also wire it into an `after-save-hook` for `.dir-locals.el`
 buffers if you edit them often.
 
+A project type can also register a command as a *function* rather than a
+string - CMake's preset pickers do this. Such a command is resolved afresh on
+every run, so the picker gets to prompt each time instead of being frozen after
+the first run. Editing what it offers you at the prompt overrides it: the
+edited command is remembered like any other, and `projectile-discard-command-cache`
+hands the project back to the function.
+
 By default, Projectile will not add consecutive duplicate commands to its
 command history.  To alter this behaviour you can use `projectile-cmd-hist-ignoredups`.
   The default value of `t` means consecutive duplicates are ignored, a value

--- a/projectile.el
+++ b/projectile.el
@@ -11553,8 +11553,11 @@ Duplicates are handled according to `projectile-cmd-hist-ignoredups'."
 
 Cache the COMMAND for later use inside the hash-table COMMAND-MAP.
 With NO-CACHE non-nil the command is not stored in COMMAND-MAP (though
-its result still enters the command history); this is for
-function-derived commands that must be re-resolved on every run.
+its result still enters the command history) unless the user edited it
+at the prompt.  This is for function-derived commands, which must be
+re-resolved on every run so they can prompt again - but an edit is the
+user overriding that function, and overriding it once shouldn't have to
+be repeated on every run (issue #2097).
 
 COMMAND-TYPE, when non-nil, is the lifecycle command type symbol
 \(e.g. `compile' or `test') and is used to keep a per-type command
@@ -11582,6 +11585,9 @@ The placeholder `%p' in COMMAND is replaced with the project name.
 The command actually run is returned."
   (let* ((project-root (projectile-acquire-root))
          (default-directory (or directory (projectile-compilation-dir)))
+         ;; What the caller resolved, before the user got a say - the two
+         ;; differing is how we know the command was edited at the prompt.
+         (derived-command command)
          (command (projectile-maybe-read-command show-prompt
                                                  command
                                                  prompt-prefix
@@ -11591,8 +11597,12 @@ The command actually run is returned."
     (when command-map
       ;; A function-derived command (NO-CACHE) is re-resolved on every run so
       ;; it can prompt again (e.g. a CMake preset picker); don't freeze its
-      ;; result in the cache, only feed it to the history below.
-      (unless no-cache
+      ;; result in the cache, only feed it to the history below.  An edit at
+      ;; the prompt is a different matter: the user has overridden the
+      ;; function, so remember that instead of offering the function's
+      ;; answer again next time (issue #2097).  `projectile-discard-command-cache'
+      ;; hands the project back to the function.
+      (unless (and no-cache (equal command derived-command))
         (puthash default-directory command command-map))
       ;; Record into the combined per-project history (read by
       ;; `projectile-repeat-last-command') and, when known, into the

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -325,7 +325,44 @@
       (projectile-configure-project nil)
       ;; the preset picker runs on each configure, not just the first
       (expect 'projectile--cmake-select-command :to-have-been-called-times 2)
-      (expect (hash-table-count projectile-configure-cmd-map) :to-equal 0))))
+      (expect (hash-table-count projectile-configure-cmd-map) :to-equal 0)))
+
+  ;; #2097: not caching a function-derived command also threw away a command
+  ;; the user had edited at the prompt, so every run offered the function's
+  ;; answer again and the edit had to be redone each time.
+  (it "remembers a command edited at the prompt (#2097)"
+    (let ((projectile-project-types projectile-project-types)
+          (projectile-compilation-cmd-map (make-hash-table :test 'equal))
+          (projectile-project-compilation-cmd nil)
+          (projectile-per-project-compilation-buffer nil))
+      (defun projectile-test--dyn-compile () "cmake --build build")
+      (projectile-register-project-type 'dyn-compile-project '("dyn.marker")
+                                        :compile 'projectile-test--dyn-compile)
+      (spy-on 'projectile-project-type :and-return-value 'dyn-compile-project)
+      ;; the user edits the offered command
+      (spy-on 'projectile-maybe-read-command
+              :and-return-value "cmake --build build -j8")
+      (projectile-compile-project nil)
+      (expect (gethash "/proj/" projectile-compilation-cmd-map)
+              :to-equal "cmake --build build -j8")
+      ;; ...so it's what the next invocation offers, function or no function
+      (expect (projectile-compilation-command "/proj/")
+              :to-equal "cmake --build build -j8")))
+
+  (it "still doesn't cache a function's own answer when it's accepted as-is (#1676)"
+    (let ((projectile-project-types projectile-project-types)
+          (projectile-compilation-cmd-map (make-hash-table :test 'equal))
+          (projectile-project-compilation-cmd nil)
+          (projectile-per-project-compilation-buffer nil))
+      (defun projectile-test--dyn-compile2 () "cmake --build build")
+      (projectile-register-project-type 'dyn-compile-project-2 '("dyn.marker")
+                                        :compile 'projectile-test--dyn-compile2)
+      (spy-on 'projectile-project-type :and-return-value 'dyn-compile-project-2)
+      ;; the user accepts what the function produced
+      (spy-on 'projectile-maybe-read-command
+              :and-call-fake (lambda (_arg default &rest _) default))
+      (projectile-compile-project nil)
+      (expect (hash-table-count projectile-compilation-cmd-map) :to-equal 0))))
 
 (describe "display-variant commands"
   ;; The other-window/-frame variants share a helper and differ only in the


### PR DESCRIPTION
Reproduced: in a CMake project, editing the command at the `projectile-compile-project`
prompt has no effect on the next run, which offers `cmake --build build` again.

3.2.0 made a lifecycle command that a project type registers as a *function*
resolve on every run, so a preset picker can prompt each time rather than being
frozen once its first result lands in the cache (#1549, #1676). It did that by
skipping the command cache entirely for such commands - which also throws away
a command the user typed at the prompt.

An edit is the user overriding the function, so it gets cached like any other
command now; only the function's own answer, accepted unchanged, stays uncached.
`projectile-discard-command-cache` hands the project back to the picker.

That also explains the reporter's puzzle about `projectile-run-project` seeming
fine: CMake is the only bundled type with function-valued commands, and it
registers no run command at all.

Both halves have specs - the edit is remembered, and an unchanged answer still
isn't cached so the picker keeps prompting.

Fixes #2097