### PR TITLE
Give each lifecycle command its own compilation buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New features
 
+- [#1867](https://github.com/bbatsov/projectile/issues/1867): Add `projectile-per-command-compilation-buffer`, which gives each lifecycle command its own compilation buffer (`*compilation*<test>`) instead of having compile, test and run share one and overwrite each other's output. It composes with `projectile-per-project-compilation-buffer` (`*compilation*<my-project:test>`), and running the test at point shares the test buffer.
 - [#2121](https://github.com/bbatsov/projectile/pull/2121): Projectile now recognizes the subprojects of a monorepo - any directory below the root holding a manifest of its own.
   - `projectile-find-file-in-subproject` (`s-p c m f`) prompts for a subproject and completes over just its files; `projectile-project-subprojects` lists them, scanning the project's file listing so the ignore rules apply.
   - `projectile-run-subproject` (`s-p c m r`) joins the existing `projectile-compile-subproject` and `projectile-test-subproject`, which now share the lifecycle machinery rather than reimplementing it.

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -339,6 +339,20 @@ project-specific. This requires that the user set:
 
 Both of these degrade properly when not inside a project.
 
+Within one project those commands still share a buffer, since they all use
+`compilation-mode` - so running the tests discards the build output. To keep
+them apart, name the buffer after the command as well:
+
+[source,elisp]
+----
+(setq projectile-per-command-compilation-buffer t)
+----
+
+That gives you `+*compilation*<test>+` and `+*compilation*<compile>+`, or
+`+*compilation*<my-project:test>+` with both options enabled. Running the test
+at point shares the test buffer. Named tasks already get a buffer each, named
+after the task.
+
 == Limit the number of project file buffers
 
 Projectile can be configured to keep a maximum number of file buffers of a project

--- a/doc/modules/ROOT/pages/configuration_index.adoc
+++ b/doc/modules/ROOT/pages/configuration_index.adoc
@@ -14,6 +14,12 @@ and the other reference pages.
 | `projectile-after-switch-project-hook`
 | Hooks run right after project is switched.
 
+| `projectile-alien-honors-ignores`
+| Whether ‘alien’ indexing applies Projectile’s own ignore rules.
+
+| `projectile-async-index-sentinel-timeout`
+| Seconds to wait for a finished index’s result before collecting it.
+
 | `projectile-async-indexing`
 | Whether to index projects without freezing Emacs.
 
@@ -83,6 +89,9 @@ and the other reference pages.
 | `projectile-dirconfig-file`
 | The file which serves both as a project marker and configuration file.
 
+| `projectile-discover-tasks`
+| Whether to offer the tasks a project’s own tooling defines.
+
 | `projectile-dynamic-mode-line`
 | If true, update the mode-line dynamically.
 
@@ -124,6 +133,9 @@ and the other reference pages.
 
 | `projectile-frecency-max-files`
 | Maximum number of files tracked per project.
+
+| `projectile-frecency-max-projects`
+| Maximum number of projects whose frecency history is kept.
 
 | `projectile-generic-command`
 | Command used by projectile to get the files in a generic project.
@@ -224,6 +236,9 @@ and the other reference pages.
 | `projectile-package-use-comint-mode`
 | Make the output buffer of ‘projectile-package-project’ interactive.
 
+| `projectile-per-command-compilation-buffer`
+| When non-nil, each lifecycle command gets its own compilation buffer.
+
 | `projectile-per-project-compilation-buffer`
 | When non-nil, the compilation command makes the per-project compilation buffer.
 
@@ -263,6 +278,9 @@ and the other reference pages.
 | `projectile-replace-max-matches`
 | Upper bound on how many matches ‘projectile-replace-review’ collects.
 
+| `projectile-replace-scan-chunk-size`
+| Number of candidate files scanned per async chunk before yielding.
+
 | `projectile-require-project-root`
 | Require the presence of a project root to operate when true.
 
@@ -277,6 +295,9 @@ and the other reference pages.
 
 | `projectile-search-use-ripgrep`
 | Whether ‘projectile-search-review’ accelerates literal search with ripgrep.
+
+| `projectile-search-whole-word`
+| Whether the reviewable search/replace start in whole-word mode.
 
 | `projectile-session-autosave`
 | Whether ‘projectile-session-mode’ saves sessions automatically.
@@ -314,6 +335,9 @@ and the other reference pages.
 | `projectile-sort-order`
 | The sort order used for a project’s files.
 
+| `projectile-subproject-markers`
+| File names that mark a subproject inside a project.
+
 | `projectile-svn-command`
 | Command used by projectile to get the files in a svn project.
 
@@ -331,6 +355,9 @@ and the other reference pages.
 
 | `projectile-tags-file-name`
 | The name of the tags file Projectile excludes from indexing.
+
+| `projectile-task-providers`
+| Functions that discover the tasks a project’s tooling defines.
 
 | `projectile-tasks`
 | An alist of named tasks that can be run with ‘projectile-run-task’.

--- a/projectile.el
+++ b/projectile.el
@@ -1440,6 +1440,21 @@ It assumes the test/ folder is at the same level as src/."
   :type 'boolean
   :package-version '(projectile . "2.6.0"))
 
+(defcustom projectile-per-command-compilation-buffer nil
+  "When non-nil, each lifecycle command gets its own compilation buffer.
+
+Compiling, testing and running a project all use `compilation-mode' and
+therefore share one buffer, so running the tests discards the build
+output and vice versa.  With this enabled the command type is part of the
+buffer name (`*compilation*<test>'), which keeps them apart.
+
+Composes with `projectile-per-project-compilation-buffer': with both
+enabled the buffer is named after the project and the command
+\(`*compilation*<my-project:test>')."
+  :group 'projectile
+  :type 'boolean
+  :package-version '(projectile . "3.3.0"))
+
 (defcustom projectile-after-switch-project-hook nil
   "Hooks run right after project is switched."
   :group 'projectile
@@ -11329,12 +11344,32 @@ supplied via .dir-locals.el and finally the default configure command
 for a project of that type."
   (projectile--phase-command 'configure compile-dir))
 
+(defvar projectile--compilation-command-type nil
+  "Lifecycle command type of the compilation being started, or nil.
+Bound by `projectile--run-project-cmd' for the duration of the call, so
+`projectile-compilation-buffer-name' - which `compile' calls with nothing
+but the mode name - can tell a test run from a build.")
+
 (defun projectile-compilation-buffer-name (compilation-mode)
   "Meant to be used for `compilation-buffer-name-function`.
 Argument COMPILATION-MODE is the name of the major mode used for the
-compilation buffer."
-  (concat "*" (downcase compilation-mode) "*"
-          (if (projectile-project-p) (concat "<" (projectile-project-name) ">") "")))
+compilation buffer.
+
+The name is qualified by the project and/or the lifecycle command type,
+according to `projectile-per-project-compilation-buffer' and
+`projectile-per-command-compilation-buffer'."
+  (let ((qualifiers
+         (delq nil
+               (list (and projectile-per-project-compilation-buffer
+                          (projectile-project-p)
+                          (projectile-project-name))
+                     (and projectile-per-command-compilation-buffer
+                          projectile--compilation-command-type
+                          (symbol-name projectile--compilation-command-type))))))
+    (concat "*" (downcase compilation-mode) "*"
+            (if qualifiers
+                (concat "<" (string-join qualifiers ":") ">")
+              ""))))
 
 (defun projectile-current-project-buffer-p ()
   "Meant to be used for `compilation-save-buffers-predicate`.
@@ -11623,7 +11658,10 @@ The command actually run is returned."
                                                  prompt-prefix
                                                  command-type))
          (compilation-buffer-name-function compilation-buffer-name-function)
-         (compilation-save-buffers-predicate compilation-save-buffers-predicate))
+         (compilation-save-buffers-predicate compilation-save-buffers-predicate)
+         ;; `compile' calls the buffer-name function with just the mode
+         ;; name, so the command type has to reach it this way.
+         (projectile--compilation-command-type command-type))
     (when command-map
       ;; A function-derived command (NO-CACHE) is re-resolved on every run so
       ;; it can prompt again (e.g. a CMake preset picker); don't freeze its
@@ -11648,8 +11686,10 @@ The command actually run is returned."
                            (projectile-project-buffer-p (current-buffer)
                                                         project-root))))
     (when projectile-per-project-compilation-buffer
-      (setq compilation-buffer-name-function #'projectile-compilation-buffer-name)
       (setq compilation-save-buffers-predicate #'projectile-current-project-buffer-p))
+    (when (or projectile-per-project-compilation-buffer
+              projectile-per-command-compilation-buffer)
+      (setq compilation-buffer-name-function #'projectile-compilation-buffer-name))
     (when buffer-name-function
       (setq compilation-buffer-name-function buffer-name-function))
     (unless command
@@ -11992,8 +12032,11 @@ a prefix ARG you can edit the command before it's run."
             ;; prompt only when explicitly asked to with a prefix arg.
             (compilation-read-command nil))
         ;; A nil command-map keeps the project's cached test command and
-        ;; command history untouched.
+        ;; command history untouched - the command type is still declared,
+        ;; so this shares the test compilation buffer and the test history
+        ;; at the prompt.
         (projectile--run-project-cmd command nil
+                                     :command-type 'test
                                      :show-prompt arg
                                      :prompt-prefix "Test at point command: "
                                      :save-buffers t

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -364,6 +364,84 @@
       (projectile-compile-project nil)
       (expect (hash-table-count projectile-compilation-cmd-map) :to-equal 0))))
 
+(describe "projectile-compilation-buffer-name"
+  ;; #1867: compile, test and run all use compilation-mode, so within a
+  ;; project they shared one buffer and each run discarded the last one's
+  ;; output.
+  (before-each
+    (spy-on 'projectile-project-p :and-return-value t)
+    (spy-on 'projectile-project-name :and-return-value "my-project"))
+
+  (it "is the plain compilation buffer when neither option is on"
+    (let ((projectile-per-project-compilation-buffer nil)
+          (projectile-per-command-compilation-buffer nil)
+          (projectile--compilation-command-type 'test))
+      (expect (projectile-compilation-buffer-name "compilation")
+              :to-equal "*compilation*")))
+
+  (it "qualifies by project"
+    (let ((projectile-per-project-compilation-buffer t)
+          (projectile-per-command-compilation-buffer nil)
+          (projectile--compilation-command-type 'test))
+      (expect (projectile-compilation-buffer-name "compilation")
+              :to-equal "*compilation*<my-project>")))
+
+  (it "qualifies by command type"
+    (let ((projectile-per-project-compilation-buffer nil)
+          (projectile-per-command-compilation-buffer t)
+          (projectile--compilation-command-type 'test))
+      (expect (projectile-compilation-buffer-name "compilation")
+              :to-equal "*compilation*<test>")))
+
+  (it "qualifies by both, project first"
+    (let ((projectile-per-project-compilation-buffer t)
+          (projectile-per-command-compilation-buffer t)
+          (projectile--compilation-command-type 'compile))
+      (expect (projectile-compilation-buffer-name "compilation")
+              :to-equal "*compilation*<my-project:compile>")))
+
+  (it "omits the command type when there isn't one"
+    (let ((projectile-per-project-compilation-buffer nil)
+          (projectile-per-command-compilation-buffer t)
+          (projectile--compilation-command-type nil))
+      (expect (projectile-compilation-buffer-name "compilation")
+              :to-equal "*compilation*"))))
+
+(describe "per-command compilation buffers (#1867)"
+  (before-each
+    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    (spy-on 'projectile-project-root :and-return-value "/proj/")
+    (spy-on 'projectile-project-p :and-return-value t)
+    (spy-on 'projectile-project-name :and-return-value "my-project")
+    (spy-on 'projectile-compilation-dir :and-return-value "/proj/")
+    (spy-on 'file-directory-p :and-return-value t)
+    (spy-on 'projectile-maybe-read-command :and-call-fake
+            (lambda (_arg default &rest _) default)))
+
+  (it "sends compile and test output to different buffers"
+    (let ((projectile-per-command-compilation-buffer t)
+          (projectile-per-project-compilation-buffer nil)
+          names)
+      (spy-on 'projectile-run-compilation :and-call-fake
+              (lambda (&rest _)
+                (push (funcall compilation-buffer-name-function "compilation") names)))
+      (projectile--run-project-cmd "make" nil :command-type 'compile)
+      (projectile--run-project-cmd "make test" nil :command-type 'test)
+      (expect (nreverse names)
+              :to-equal '("*compilation*<compile>" "*compilation*<test>"))))
+
+  (it "leaves them sharing a buffer when the option is off"
+    (let ((projectile-per-command-compilation-buffer nil)
+          (projectile-per-project-compilation-buffer t)
+          names)
+      (spy-on 'projectile-run-compilation :and-call-fake
+              (lambda (&rest _)
+                (push (funcall compilation-buffer-name-function "compilation") names)))
+      (projectile--run-project-cmd "make" nil :command-type 'compile)
+      (projectile--run-project-cmd "make test" nil :command-type 'test)
+      (expect (nreverse names)
+              :to-equal '("*compilation*<my-project>" "*compilation*<my-project>")))))
+
 (describe "display-variant commands"
   ;; The other-window/-frame variants share a helper and differ only in the
   ;; display function they hand off to.


### PR DESCRIPTION
Compile, test and run all use `compilation-mode`, so inside one project they
share a buffer and running the tests throws away the build output. The issue
notes the blocker: which role a given `projectile--run-project-cmd` call is
playing wasn't available where the buffer gets named. It is now - the command
type has been threaded through for other reasons - so it only had to be carried
into the naming function.

`projectile-per-command-compilation-buffer` (off by default) gives you
`*compilation*<test>` and `*compilation*<compile>`, and composes with the
per-project option for `*compilation*<my-project:test>`.

`projectile-run-test-at-point` now declares itself a test run, so it shares the
test buffer instead of an unqualified one, and gets the test command history at
its prompt. It still doesn't touch the cached test command.

Also regenerates the configuration variable index, which had gone stale by nine
variables - four of them mine from this cycle.

Fixes #1867