### PR TITLE
Discover rake tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
      so the line-length and duplicate-heading rules don't fit this file. -->
 <!-- markdownlint-disable MD013 MD024 -->
 
+## master (unreleased)
+
+### New features
+
+- [#2130](https://github.com/bbatsov/projectile/pull/2130): `projectile-run-task` now also discovers rake tasks, read out of the project's `Rakefile` and its `.rake` files (in `rakelib`, `tasks` and `lib/tasks`) rather than by running `rake -T`, which would load the whole application. Tasks are qualified with their `namespace` (`rake:db:migrate`) and run through `bundle exec` when the project has a `Gemfile`.
+
 ## 3.3.0 (2026-07-27)
 
 ### New features

--- a/doc/modules/ROOT/pages/tasks.adoc
+++ b/doc/modules/ROOT/pages/tasks.adoc
@@ -167,6 +167,10 @@ image::projectile-discovered-tasks.png[projectile-run-task offering npm scripts 
 | `Taskfile.yml` and friends
 | `task:build`
 
+| rake tasks
+| `Rakefile`, plus the `.rake` files in `rakelib`, `tasks` and `lib/tasks`
+| `rake:db:migrate`
+
 | Make targets
 | `Makefile`, `makefile`, `GNUmakefile`
 | `make:test`
@@ -176,6 +180,13 @@ Discovered tasks carry the name of the tool that defines them, so they never
 collide with the tasks you configure yourself, and you can tell at the prompt
 where a task came from. Only plain named Make targets are offered - pattern
 rules, file targets and the dot-targets aren't things you'd run by hand.
+
+Rake tasks are read out of the project's task files rather than by running
+`rake -T`, which would mean loading the whole application just to fill a
+completion prompt. Tasks are qualified with the `namespace` blocks they sit in
+(`rake:db:migrate`), and run through `bundle exec` when the project has a
+`Gemfile`. A task whose name is computed at runtime (`task type, [:id]`) can't
+be known without running rake, so it isn't listed.
 
 Set `projectile-discover-tasks` to nil to turn this off, or customize
 `projectile-task-providers` to add your own. A provider is a function taking

--- a/projectile.el
+++ b/projectile.el
@@ -6411,6 +6411,15 @@ a manual COMMAND-TYPE command is created with
 (defconst projectile--makefile-names '("Makefile" "makefile" "GNUmakefile")
   "The file names GNU make reads its targets from.")
 
+(defconst projectile--rakefile-names
+  '("Rakefile" "rakefile" "Rakefile.rb" "rakefile.rb")
+  "The file names rake accepts as a project's main task file.")
+
+(defconst projectile--rake-task-directories '("rakelib" "tasks" "lib/tasks")
+  "Directories a project keeps its extra `.rake' files in.
+`rakelib' is rake's own convention, `lib/tasks' is Rails\\='s, and
+`tasks' is what a lot of gems use.")
+
 (defconst projectile--deno-config-names '("deno.json" "deno.jsonc")
   "The file names Deno reads its configuration from.")
 
@@ -11081,6 +11090,7 @@ them (e.g. `npm:build'), so they never collide with configured ones."
     projectile-tasks-from-composer
     projectile-tasks-from-just
     projectile-tasks-from-taskfile
+    projectile-tasks-from-rake
     projectile-tasks-from-make)
   "Functions that discover the tasks a project's tooling defines.
 
@@ -11233,6 +11243,77 @@ the special dot-targets aren't things you'd run by hand."
      (projectile--matches-in-file
       file "^\\([a-zA-Z0-9][a-zA-Z0-9_-]*\\)[ \t]*:\\(?:[^=\n]\\|$\\)")
      "make" "make %s")))
+
+(defun projectile--rake-task-files (project-root)
+  "Return the files rake tasks may be defined in under PROJECT-ROOT.
+That's the project's Rakefile plus the `.rake' files in the usual task
+directories (see `projectile--rake-task-directories').  Returns nil when
+the project has no Rakefile, since without one there's nothing for rake
+to run - which also keeps this provider free for non-Ruby projects."
+  (when-let* ((rakefile (projectile--first-task-file
+                         project-root projectile--rakefile-names)))
+    (cons rakefile
+          (mapcan (lambda (dir)
+                    (let ((dir (expand-file-name dir project-root)))
+                      (when (file-directory-p dir)
+                        (ignore-errors
+                          (directory-files dir t "\\.rake\\'" 'nosort)))))
+                  projectile--rake-task-directories))))
+
+(defun projectile--rake-task-names (file)
+  "Return the names of the rake tasks defined in FILE.
+
+Only tasks whose name is written out literally are returned: a name
+built from a variable (`task type, [:id]') can't be known without
+running rake, which this deliberately doesn't do.  Names are qualified
+with the `namespace' blocks they sit in, so a task is returned under the
+name you'd actually invoke it by."
+  (let ((names nil)
+        ;; Stack of (INDENT . NAME) for the `namespace' blocks we're in.
+        (namespaces nil))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (goto-char (point-min))
+      (let ((case-fold-search nil))
+        (while (not (eobp))
+          (let ((indent (current-indentation)))
+            (cond
+             ;; Leaving a block: drop the namespace it opened, if any.
+             ((looking-at "[ \t]*end\\_>")
+              (when (and namespaces (<= indent (caar namespaces)))
+                (pop namespaces)))
+             ((looking-at "[ \t]*namespace[ \t]+[:'\"]?\\([a-zA-Z0-9_][a-zA-Z0-9_-]*\\)")
+              (push (cons indent (match-string 1)) namespaces))
+             ;; `task' followed by whitespace - not `task.files = ...',
+             ;; which is a method call on a block argument.
+             ((looking-at
+               (concat "[ \t]*\\(?:multi\\)?task[ \t]+"
+                       ;; :symbol | 'string' | "string" | bare-word:
+                       "\\(?::\\([a-zA-Z0-9_][a-zA-Z0-9_:-]*\\)"
+                       "\\|[\"']\\([^\"'\n]+\\)[\"']"
+                       "\\|\\([a-zA-Z0-9_][a-zA-Z0-9_-]*\\):\\)"))
+              (let* ((name (or (match-string 1) (match-string 2) (match-string 3)))
+                     (qualified (string-join
+                                 (append (reverse (mapcar #'cdr namespaces))
+                                         (list name))
+                                 ":")))
+                (unless (member qualified names)
+                  (push qualified names))))))
+          (forward-line 1))))
+    (nreverse names)))
+
+(defun projectile-tasks-from-rake (project-root)
+  "Return the rake tasks of the project in PROJECT-ROOT.
+The tasks are read out of the project's Rakefile and `.rake' files
+rather than by running `rake -T', which would load the whole
+application."
+  (when-let* ((files (projectile--rake-task-files project-root)))
+    (let ((runner (if (projectile--task-file project-root "Gemfile")
+                      "bundle exec rake"
+                    "rake")))
+      (projectile--tasks-named
+       (delete-dups (mapcan #'projectile--rake-task-names files))
+       "rake" (concat runner " %s")))))
 
 (defun projectile-discovered-tasks (&optional project-root)
   "Return the tasks discovered in the project at PROJECT-ROOT.

--- a/test/projectile-tasks-test.el
+++ b/test/projectile-tasks-test.el
@@ -195,6 +195,109 @@ tasks:
         (expect (projectile-tasks-from-taskfile (projectile-project-root))
                 :to-equal '(("task:build" . "task build"))))))
 
+  (describe "projectile-tasks-from-rake"
+    (it "reads the tasks of a Rakefile, in all the forms rake accepts"
+      (projectile-test-with-project
+          (("Rakefile" . "require 'rake/testtask'
+
+desc 'Build the gem'
+task build: :generate
+
+task :coverage do
+  puts 'coverage'
+end
+
+task 'legacy:import' do
+end
+
+multitask :parallel do
+end
+"))
+        (expect (projectile-tasks-from-rake (projectile-project-root))
+                :to-equal '(("rake:build" . "rake build")
+                            ("rake:coverage" . "rake coverage")
+                            ("rake:legacy:import" . "rake legacy:import")
+                            ("rake:parallel" . "rake parallel")))))
+
+    (it "qualifies a task with the namespaces it sits in"
+      (projectile-test-with-project
+          (("Rakefile" . "namespace :db do
+  task :migrate do
+  end
+
+  namespace :schema do
+    task :load do
+    end
+  end
+end
+
+task :console do
+end
+"))
+        (expect (projectile-tasks-from-rake (projectile-project-root))
+                :to-equal '(("rake:db:migrate" . "rake db:migrate")
+                            ("rake:db:schema:load" . "rake db:schema:load")
+                            ("rake:console" . "rake console")))))
+
+    (it "skips a task whose name is built at runtime"
+      ;; `task type, [:id]' names the task after a variable - there's no way
+      ;; to know what it is without running rake.
+      (projectile-test-with-project
+          (("Rakefile" . "namespace :changelog do
+  %w[new fix change].each do |type|
+    task type, [:id] do |_task, args|
+    end
+  end
+
+  task :merge do
+  end
+end
+"))
+        (expect (projectile-tasks-from-rake (projectile-project-root))
+                :to-equal '(("rake:changelog:merge" . "rake changelog:merge")))))
+
+    (it "does not mistake a method call on a block argument for a task"
+      ;; `task.files = ...' inside a RakeTask block is not a definition.
+      (projectile-test-with-project
+          (("Rakefile" . "RuboCop::RakeTask.new(:internal_investigation) do |task|
+  task.files = ['lib/rubocop/cop/*/*.rb']
+  task.options = ['--no-output']
+end
+
+task :real do
+end
+"))
+        (expect (projectile-tasks-from-rake (projectile-project-root))
+                :to-equal '(("rake:real" . "rake real")))))
+
+    (it "picks up the .rake files of the usual task directories"
+      (projectile-test-with-project
+          (("Rakefile" . "task :root_task do\nend\n")
+           ("lib/tasks/db.rake" . "namespace :db do\n  task :seed do\n  end\nend\n")
+           ("tasks/release.rake" . "task :cut_release do\nend\n")
+           ("rakelib/extra.rake" . "task :extra do\nend\n")
+           ("lib/tasks/notes.txt" . "task :not_a_rake_file do\nend\n"))
+        (let ((names (mapcar #'car (projectile-tasks-from-rake (projectile-project-root)))))
+          (expect names :to-contain "rake:root_task")
+          (expect names :to-contain "rake:db:seed")
+          (expect names :to-contain "rake:cut_release")
+          (expect names :to-contain "rake:extra")
+          (expect names :not :to-contain "rake:not_a_rake_file"))))
+
+    (it "runs through bundler when the project has a Gemfile"
+      (projectile-test-with-project
+          (("Rakefile" . "task :spec do\nend\n")
+           ("Gemfile" . "source 'https://rubygems.org'\n"))
+        (expect (projectile-tasks-from-rake (projectile-project-root))
+                :to-equal '(("rake:spec" . "bundle exec rake spec")))))
+
+    (it "returns nothing without a Rakefile, even when .rake files exist"
+      ;; Without a Rakefile there's nothing for rake to run, and skipping
+      ;; the directory scan keeps this free for non-Ruby projects.
+      (projectile-test-with-project
+          (("lib/tasks/db.rake" . "task :seed do\nend\n"))
+        (expect (projectile-tasks-from-rake (projectile-project-root)) :to-be nil))))
+
   (describe "projectile-tasks-from-make"
     (it "reads the named targets of a Makefile"
       (projectile-test-with-project


### PR DESCRIPTION
Rake was the obvious gap in the task providers - most Ruby projects keep their
tasks there, and Rails apps spread them across `lib/tasks/*.rake` too.

The tasks are read out of the Rakefile and the `.rake` files rather than by
running `rake -T`, which would load the whole application just to fill a
completion prompt. The tradeoff is that only literally-named tasks can be
offered: `task type, [:id]` inside an `each` loop isn't knowable without
running rake. In exchange the provider stays as cheap as the others, and it
costs nothing at all in a project with no Rakefile.

Names are qualified with the `namespace` blocks they sit in, so you get
`rake:db:migrate` rather than `rake:migrate`, and the command runs through
`bundle exec` when there's a `Gemfile`.

Checked against real projects rather than just the fixtures - rubocop (17
tasks), rubocop-ast (14) and metaredux (2) all come out right, including
`prof:run`, `changelog:merge` and `references:verify`. Two things that had to
be handled to get there: `task.files = [...]` inside a `RakeTask.new` block is
a method call on the block argument and not a definition, and rubocop's
`%w[new fix change].each { |type| task type, [:id] }` is the dynamic case
above. Both have specs.