### PR TITLE
Give the doctor and dashboard a visual language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### New features
 
+- [#2131](https://github.com/bbatsov/projectile/pull/2131): The `projectile-doctor` and `projectile-dashboard` buffers are no longer plain text: section headers, field labels, the project's identity and the doctor's findings are faced by meaning, with the findings colored by severity and sorted so anything wanting action comes first.
+  - All the new faces only inherit from standard ones, so themes style them without knowing about Projectile and a terminal without colors degrades to what you got before.
+  - `projectile-report-copy` (`w` in either buffer) copies the buffer as plain text, without the faces and buttons - a doctor report usually ends up in an issue.
 - [#2130](https://github.com/bbatsov/projectile/pull/2130): `projectile-run-task` now also discovers rake tasks, read out of the project's `Rakefile` and its `.rake` files (in `rakelib`, `tasks` and `lib/tasks`) rather than by running `rake -T`, which would load the whole application. Tasks are qualified with their `namespace` (`rake:db:migrate`) and run through `bundle exec` when the project has a `Gemfile`.
 
 ## 3.3.0 (2026-07-27)

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -24,6 +24,10 @@ the project around `default-directory`:
 
 image::projectile-doctor.png[The Projectile doctor report: project root, type, indexing method and available tools]
 
+The report is meant to be pasted into a bug report, so kbd:[w]
+(`projectile-report-copy`) copies it as plain text with the faces and buttons
+stripped. kbd:[g] regenerates it and kbd:[q] buries the buffer.
+
 * *Project* - the project root and, crucially, *which* entry of
 `projectile-project-root-functions` found it and off which marker file, the
 project name and where it came from, and whether the root is remote (TRAMP).

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -622,8 +622,12 @@ modified or untracked
 Everything worth acting on is a button, so the dashboard doubles as a launcher.
 kbd:[RET] on a file visits it, on a task or a lifecycle command runs it, on the
 branch opens the project's VC interface (Magit, if you have it), and on the
-root opens it in Dired. kbd:[TAB] moves to the next button, kbd:[g] refreshes
-and kbd:[q] buries the buffer.
+root opens it in Dired. kbd:[TAB] moves to the next button, kbd:[g] refreshes,
+kbd:[w] copies and kbd:[q] buries the buffer.
+
+kbd:[w] (`projectile-report-copy`) puts the dashboard on the kill ring as plain
+text, with the faces and buttons stripped, which is what you want when pasting
+it into an issue or a chat window.
 
 `projectile-dashboard-sections` picks which sections show up and in what order,
 and `projectile-dashboard-recent-files` how many recent files are listed:

--- a/projectile.el
+++ b/projectile.el
@@ -13110,6 +13110,120 @@ entered, keeping the entries made so far."
 ;; the project root - is skipped for remote (TRAMP) projects and marked
 ;; as skipped in the report, so the doctor can't hang on a slow host.
 
+;;;; Shared rendering for the report buffers
+;;
+;; The doctor and the dashboard are both label/value reports, and they
+;; share their look.  Two rules keep them honest:
+;;
+;; - Every face here only inherits, so themes style them without knowing
+;;   Projectile exists, and a terminal without colors degrades to plain
+;;   text rather than to something unreadable.
+;; - The buffer text stays plain ASCII.  Faces are a display layer on top
+;;   of it, so what you see and what you yank are the same characters -
+;;   which matters because a doctor report's destination is usually a bug
+;;   report (see `projectile-report-copy').
+
+(defface projectile-report-section
+  '((t :inherit font-lock-function-name-face :weight bold))
+  "Face for the section headers of the doctor and dashboard buffers."
+  :group 'projectile
+  :package-version '(projectile . "3.4.0"))
+
+(defface projectile-report-label
+  '((t :inherit shadow))
+  "Face for the field labels of the doctor and dashboard buffers.
+Labels are dimmed so the values they introduce carry the eye."
+  :group 'projectile
+  :package-version '(projectile . "3.4.0"))
+
+(defface projectile-report-value
+  '((t :inherit font-lock-string-face))
+  "Face for the values that identify a project - its root, type and name."
+  :group 'projectile
+  :package-version '(projectile . "3.4.0"))
+
+(defface projectile-report-ok
+  '((t :inherit success))
+  "Face for a finding that reports something is fine, and for `on'/`present'."
+  :group 'projectile
+  :package-version '(projectile . "3.4.0"))
+
+(defface projectile-report-warning
+  '((t :inherit warning))
+  "Face for a finding that suggests a change, and for `missing'."
+  :group 'projectile
+  :package-version '(projectile . "3.4.0"))
+
+(defface projectile-report-info
+  '((t :inherit shadow))
+  "Face for a purely informational finding."
+  :group 'projectile
+  :package-version '(projectile . "3.4.0"))
+
+(defface projectile-report-hint
+  '((t :inherit shadow :slant italic))
+  "Face for the key hints at the foot of a report buffer."
+  :group 'projectile
+  :package-version '(projectile . "3.4.0"))
+
+(defun projectile--report-face (string face)
+  "Return STRING propertized with FACE."
+  (propertize string 'face face))
+
+(defun projectile--report-title (title &optional char)
+  "Insert TITLE underlined with CHAR (`=' by default).
+The rule is kept as text rather than expressed with a face, so a yanked
+report reads the same as the rendered one - but it is dimmed, so the
+title carries the emphasis rather than competing with its own underline."
+  (insert (projectile--report-face title 'projectile-report-section) "\n"
+          (projectile--report-face (make-string (length title) (or char ?=))
+                                   'projectile-report-label)
+          "\n"))
+
+(defun projectile--report-section (title)
+  "Insert the header of a report section titled TITLE."
+  (insert "\n")
+  (projectile--report-title title ?-))
+
+(defun projectile--report-label (label width)
+  "Insert LABEL, dimmed and padded out to WIDTH."
+  (insert (projectile--report-face label 'projectile-report-label)
+          (make-string (max 1 (- width (length label))) ?\s)))
+
+(defun projectile--report-status-face (value)
+  "Return the face for the status word VALUE, or nil when it isn't one.
+Only the words whose polarity is unambiguous are colored."
+  (cond ((member value '("on" "present" "yes")) 'projectile-report-ok)
+        ((member value '("missing")) 'projectile-report-warning)
+        ((member value '("off" "skipped" "none")) 'projectile-report-info)))
+
+(defun projectile--report-hints (bindings)
+  "Insert a dimmed footer line describing BINDINGS.
+BINDINGS is an alist of (KEY . DESCRIPTION)."
+  (insert "\n"
+          (projectile--report-face
+           (mapconcat (lambda (binding)
+                        (format "%s %s" (car binding) (cdr binding)))
+                      bindings "   ")
+           'projectile-report-hint)
+          "\n"))
+
+;;;###autoload
+(defun projectile-report-copy ()
+  "Copy the current report buffer to the kill ring as plain text.
+
+Strips the faces and buttons, so what lands in the clipboard is exactly
+the text of the report - ready to paste into an issue, an email or a
+chat window without dragging Emacs\\='s text properties along."
+  (interactive)
+  (unless (derived-mode-p 'projectile-doctor-mode 'projectile-dashboard-mode)
+    (user-error "Not in a Projectile report buffer"))
+  (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+    (kill-new text)
+    (message "Copied %d lines of %s to the kill ring"
+             (count-lines (point-min) (point-max))
+             (if (derived-mode-p 'projectile-doctor-mode) "the report" "the dashboard"))))
+
 (defconst projectile-doctor-buffer-name "*projectile-doctor*"
   "The name of the buffer `projectile-doctor' renders its report in.")
 
@@ -13375,18 +13489,19 @@ a one-line description."
 
 ;;;; Doctor report rendering
 
-(defun projectile-doctor--field (label value)
+(defun projectile-doctor--field (label value &optional face)
   "Insert a LABEL/VALUE line into the report.
-VALUE is rendered with `%s'; a nil or empty one reads as \"n/a\"."
-  (insert label
-          (make-string (max 1 (- projectile-doctor--label-width (length label)))
-                       ?\s)
-          (if (or (null value) (equal value "")) "n/a" (format "%s" value))
-          "\n"))
+VALUE is rendered with `%s'; a nil or empty one reads as \"n/a\".  FACE,
+when given, is applied to the value; otherwise a value that is an
+unambiguous status word is colored by its polarity."
+  (projectile--report-label label projectile-doctor--label-width)
+  (let* ((value (if (or (null value) (equal value "")) "n/a" (format "%s" value)))
+         (face (or face (projectile--report-status-face value))))
+    (insert (if face (projectile--report-face value face) value) "\n")))
 
 (defun projectile-doctor--section (title)
   "Insert the header of a report section titled TITLE."
-  (insert "\n" title "\n" (make-string (length title) ?-) "\n"))
+  (projectile--report-section title))
 
 (defun projectile-doctor--list-field (label items)
   "Insert LABEL followed by ITEMS, one per line."
@@ -13443,14 +13558,16 @@ cached too.
 
 (defun projectile-doctor--render (data)
   "Render the report described by DATA into the current buffer."
-  (insert "Projectile doctor report\n"
-          "========================\n"
-          (format "projectile %s, Emacs %s, %s\n"
-                  projectile-version emacs-version system-type))
+  (projectile--report-title "Projectile doctor report")
+  (insert (projectile--report-face
+           (format "projectile %s, Emacs %s, %s\n"
+                   projectile-version emacs-version system-type)
+           'projectile-report-label))
   (if (null (plist-get data :root))
       (projectile-doctor--render-no-project data)
     (projectile-doctor--section "Project")
-    (projectile-doctor--field "root" (plist-get data :root))
+    (projectile-doctor--field "root" (plist-get data :root)
+                              'projectile-report-value)
     (projectile-doctor--field
      "detected by"
      (when-let* ((func (plist-get data :root-function)))
@@ -13550,17 +13667,33 @@ in .dir-locals.el to pin a type, or register one with
                                      (plist-get data :excluded-entries)))
 
     (projectile-doctor--section "Findings")
-    (dolist (finding (projectile-doctor--findings data))
-      (insert (format "%-6s%s\n"
-                      (pcase (car finding)
-                        ('ok "ok")
-                        ('warn "warn")
-                        (_ "info"))
-                      (cdr finding))))))
+    ;; Anything that wants action first - a report is read top-down and a
+    ;; lone warning shouldn't be buried among a dozen `ok' lines.
+    (dolist (finding (projectile-doctor--sort-findings
+                      (projectile-doctor--findings data)))
+      (pcase-let* ((`(,severity . ,message) finding)
+                   (`(,label . ,face)
+                    (pcase severity
+                      ('ok '("ok" . projectile-report-ok))
+                      ('warn '("warn" . projectile-report-warning))
+                      (_ '("info" . projectile-report-info)))))
+        (insert (projectile--report-face (format "%-6s" label) face)
+                message "\n")))
+    (projectile--report-hints '(("g" . "refresh") ("w" . "copy") ("q" . "quit")))))
+
+(defun projectile-doctor--sort-findings (findings)
+  "Return FINDINGS ordered warnings first, then info, then `ok'.
+The order within each severity is preserved, so the report still reads
+in the order the checks are written."
+  (let ((rank (lambda (finding)
+                (pcase (car finding) ('warn 0) ('ok 2) (_ 1)))))
+    (sort (copy-sequence findings)
+          (lambda (a b) (< (funcall rank a) (funcall rank b))))))
 
 (defvar projectile-doctor-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "q") #'quit-window)
+    (define-key map (kbd "w") #'projectile-report-copy)
     map)
   "Keymap for `projectile-doctor-mode'.")
 
@@ -13905,21 +14038,19 @@ that the dashboard stays cheap enough to be a
 
 (defun projectile-dashboard--label (label)
   "Insert LABEL padded out to the dashboard's label column."
-  (insert label
-          (make-string (max 1 (- projectile-dashboard--label-width
-                                 (length label)))
-                       ?\s)))
+  (projectile--report-label label projectile-dashboard--label-width))
 
-(defun projectile-dashboard--field (label value)
+(defun projectile-dashboard--field (label value &optional face)
   "Insert a LABEL/VALUE line into the dashboard.
-VALUE is rendered with `%s'; a nil or empty one reads as \"n/a\"."
+VALUE is rendered with `%s'; a nil or empty one reads as \"n/a\".  FACE,
+when given, is applied to the value."
   (projectile-dashboard--label label)
-  (insert (if (or (null value) (equal value "")) "n/a" (format "%s" value))
-          "\n"))
+  (let ((value (if (or (null value) (equal value "")) "n/a" (format "%s" value))))
+    (insert (if face (projectile--report-face value face) value) "\n")))
 
 (defun projectile-dashboard--section (title)
   "Insert the header of a dashboard section titled TITLE."
-  (insert "\n" title "\n" (make-string (length title) ?-) "\n"))
+  (projectile--report-section title))
 
 (defun projectile-dashboard--button (label type root &rest properties)
   "Insert a button labelled LABEL of button TYPE for the project at ROOT.
@@ -13950,7 +14081,8 @@ The lifecycle commands are named after their phase by construction (see
     (projectile-dashboard--label "root")
     (projectile-dashboard--button root 'projectile-dashboard-dired root)
     (insert "\n")
-    (projectile-dashboard--field "type" (plist-get data :type))
+    (projectile-dashboard--field "type" (plist-get data :type)
+                                 'projectile-report-value)
     (projectile-dashboard--field
      "files"
      (if-let* ((count (plist-get data :file-count)))
@@ -13971,13 +14103,17 @@ The lifecycle commands are named after their phase by construction (see
        (projectile-dashboard--button (plist-get data :branch)
                                      'projectile-dashboard-vc root)
        (insert "\n")
-       (projectile-dashboard--field
-        "status"
-        (if (eq state 'partial)
-            "unavailable"
-          (format "%d modified, %d untracked"
-                  (plist-get data :modified)
-                  (plist-get data :untracked)))))
+       (let ((modified (plist-get data :modified))
+             (untracked (plist-get data :untracked)))
+         (projectile-dashboard--field
+          "status"
+          (if (eq state 'partial)
+              "unavailable"
+            (format "%d modified, %d untracked" modified untracked))
+          (unless (eq state 'partial)
+            (if (and (zerop modified) (zerop untracked))
+                'projectile-report-ok
+              'projectile-report-warning)))))
       ('skipped
        (projectile-dashboard--field "status" "not checked (remote project)"))
       ('unavailable
@@ -14047,8 +14183,10 @@ explains why none of them claimed the directory.
 
 (defun projectile-dashboard--render (data)
   "Render the dashboard described by DATA into the current buffer."
-  (insert "Projectile project dashboard\n"
-          "============================\n")
+  (projectile--report-title
+   (if-let* ((name (plist-get data :name)))
+       (format "Projectile dashboard: %s" name)
+     "Projectile dashboard"))
   (if (null (plist-get data :root))
       (projectile-dashboard--render-no-project data)
     (dolist (section projectile-dashboard-sections)
@@ -14058,8 +14196,8 @@ explains why none of them claimed the directory.
         ('recent (projectile-dashboard--render-recent data))
         ('tasks (projectile-dashboard--render-tasks data))
         ('commands (projectile-dashboard--render-commands data))))
-    (insert "\nRET acts on the entry at point, TAB moves to the next one, "
-            "g refreshes, q buries.\n")))
+    (projectile--report-hints '(("RET" . "act on entry") ("TAB" . "next entry")
+                                ("g" . "refresh") ("w" . "copy") ("q" . "bury")))))
 
 
 ;;;; The dashboard buffer
@@ -14072,6 +14210,7 @@ explains why none of them claimed the directory.
     ;; here than the `next-line'/`previous-line' these shadow.
     (define-key map (kbd "n") #'forward-button)
     (define-key map (kbd "p") #'backward-button)
+    (define-key map (kbd "w") #'projectile-report-copy)
     map)
   "Keymap for `projectile-dashboard-mode'.")
 

--- a/test/projectile-doctor-test.el
+++ b/test/projectile-doctor-test.el
@@ -159,6 +159,82 @@
                   "type detected"))
             :to-be 'ok)))
 
+(describe "report rendering"
+  (defun projectile-report-test--faces-at (regexp)
+    "Return the face of the text matched by REGEXP in the current buffer."
+    (goto-char (point-min))
+    (when (re-search-forward regexp nil t)
+      (get-text-property (match-beginning 0) 'face)))
+
+  (describe "projectile--report-title"
+    (it "faces the title and dims its underline"
+      (with-temp-buffer
+        (projectile--report-title "Hello")
+        (expect (projectile-report-test--faces-at "Hello")
+                :to-be 'projectile-report-section)
+        ;; the rule is text, so a yanked report still reads the same...
+        (expect (buffer-string) :to-equal "Hello\n=====\n")
+        ;; ...but it recedes rather than competing with the title
+        (expect (projectile-report-test--faces-at "=====")
+                :to-be 'projectile-report-label))))
+
+  (describe "projectile--report-status-face"
+    (it "colors the status words whose polarity is unambiguous"
+      (expect (projectile--report-status-face "on") :to-be 'projectile-report-ok)
+      (expect (projectile--report-status-face "present") :to-be 'projectile-report-ok)
+      (expect (projectile--report-status-face "missing") :to-be 'projectile-report-warning)
+      (expect (projectile--report-status-face "off") :to-be 'projectile-report-info))
+
+    (it "leaves anything else alone"
+      (expect (projectile--report-status-face "alien") :to-be nil)
+      (expect (projectile--report-status-face "git") :to-be nil)))
+
+  (describe "projectile-doctor--sort-findings"
+    (it "puts what wants action first, keeping each severity's own order"
+      (expect (projectile-doctor--sort-findings
+               '((ok . "a") (info . "b") (warn . "c") (ok . "d") (warn . "e")))
+              :to-equal '((warn . "c") (warn . "e") (info . "b")
+                          (ok . "a") (ok . "d")))))
+
+  (describe "projectile-report-copy"
+    (it "copies the report without its text properties"
+      (with-temp-buffer
+        (projectile-doctor-mode)
+        (let ((inhibit-read-only t))
+          (projectile--report-title "Projectile doctor report")
+          (insert (propertize "root" 'face 'projectile-report-label))
+          (insert-text-button "a button" 'action #'ignore))
+        (let ((kill-ring nil))
+          (projectile-report-copy)
+          (let ((copied (current-kill 0)))
+            (expect copied :to-equal "Projectile doctor report\n========================\nroota button")
+            ;; nothing carries a face or a button into the clipboard
+            (expect (text-properties-at 0 copied) :to-be nil)
+            (expect (next-property-change 0 copied) :to-be nil)))))
+
+    (it "refuses outside a report buffer"
+      (with-temp-buffer
+        (fundamental-mode)
+        (expect (projectile-report-copy) :to-throw 'user-error))))
+
+  (describe "the doctor buffer"
+    (it "renders its findings colored by severity"
+      (spy-on 'projectile-doctor--findings :and-return-value
+              '((warn . "fd is not installed") (ok . "all good")))
+      (with-temp-buffer
+        (projectile-doctor--render '(:root "/proj/" :type 'npm))
+        (expect (projectile-report-test--faces-at "^warn")
+                :to-be 'projectile-report-warning)
+        (expect (projectile-report-test--faces-at "^ok")
+                :to-be 'projectile-report-ok)))
+
+    (it "ends with a hint line naming the copy key"
+      (spy-on 'projectile-doctor--findings :and-return-value nil)
+      (with-temp-buffer
+        (projectile-doctor--render '(:root "/proj/"))
+        (goto-char (point-max))
+        (expect (buffer-string) :to-match "w copy")))))
+
 (provide 'projectile-doctor-test)
 
 ;;; projectile-doctor-test.el ends here


### PR DESCRIPTION
Both buffers were plain text, with all the structure carried by ASCII rules and
column padding. The doctor's findings were the worst of it - severity is exactly
what color is for, and `ok`, `warn` and `info` all rendered identically grey.

Section headers, field labels, the project's identity (root, type) and the
findings are now faced by meaning. Findings are also sorted warn-first, since a
report is read top-down and a lone warning shouldn't sit buried among a dozen
`ok` lines.

Three constraints shaped it:

- Every face only `:inherit`s from a standard one (`success`, `warning`,
  `shadow`, `font-lock-*`), so themes style them without knowing Projectile
  exists, and a terminal without colors degrades to exactly what you saw before.
- The buffer text stays plain ASCII. The `----` rules are still text rather than
  an underline face, so a yanked report reads like the rendered one.
- The rules are *dimmed* rather than faced like their titles - the first pass had
  them in the section face and the bright underlines competed with the headers.

And since a doctor report's usual destination is an issue, `projectile-report-copy`
(`w` in either buffer) makes that explicit: the buffer goes onto the kill ring
with faces and buttons stripped, so nothing drags Emacs text properties along.

Both buffers grew a dimmed footer listing their keys, which is also how `w`
becomes discoverable.