### PR TITLE
Give the dashboard more to say, and let both reports fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### New features
 
+- [#2132](https://github.com/bbatsov/projectile/pull/2132): The dashboard gained a "Notable files" section linking the project's README, changelog, license, its type's own manifest and its `.projectile` (see `projectile-dashboard-link-files`), plus a count of its open buffers and a summary of the ignore rules in effect.
+  - A project with nothing cached now offers an `[index now]` button instead of only reporting that it isn't indexed.
+  - Both report buffers set up `outline-minor-mode` over their sections, so a long report folds with the usual outline keys, and their footers derive the keys they advertise with `substitute-command-keys` rather than hardcoding them.
 - [#2131](https://github.com/bbatsov/projectile/pull/2131): The `projectile-doctor` and `projectile-dashboard` buffers are no longer plain text: section headers, field labels, the project's identity and the doctor's findings are faced by meaning, with the findings colored by severity and sorted so anything wanting action comes first.
   - All the new faces only inherit from standard ones, so themes style them without knowing about Projectile and a terminal without colors degrades to what you got before.
   - `projectile-report-copy` (`w` in either buffer) copies the buffer as plain text, without the faces and buttons - a doctor report usually ends up in an issue.

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -611,7 +611,11 @@ you're in:
 
 image::projectile-dashboard.png[The Projectile dashboard: project info, version control status, recent files and tasks]
 
-* the project's name, root, type and file count
+* the project's name, root, type, file count, how many of its buffers are
+open, and a summary of the ignore rules in effect
+* the files worth having a link to - README, changelog, license, the project
+type's own manifest and its `.projectile`, when it has them (see
+`projectile-dashboard-link-files`)
 * the version control system, the current branch and how many files are
 modified or untracked
 * the project files you visit most, ranked by frecency - the same ranking
@@ -627,7 +631,12 @@ kbd:[w] copies and kbd:[q] buries the buffer.
 
 kbd:[w] (`projectile-report-copy`) puts the dashboard on the kill ring as plain
 text, with the faces and buttons stripped, which is what you want when pasting
-it into an issue or a chat window.
+it into an issue or a chat window. The sections are `outline-minor-mode`
+headings, so they fold with the usual outline keys when the dashboard grows
+longer than you want to scroll.
+
+A project with nothing cached yet says so rather than indexing itself, but it
+offers an `[index now]` button that warms the cache in the background.
 
 `projectile-dashboard-sections` picks which sections show up and in what order,
 and `projectile-dashboard-recent-files` how many recent files are listed:

--- a/projectile.el
+++ b/projectile.el
@@ -13199,14 +13199,28 @@ Only the words whose polarity is unambiguous are colored."
 
 (defun projectile--report-hints (bindings)
   "Insert a dimmed footer line describing BINDINGS.
-BINDINGS is an alist of (KEY . DESCRIPTION)."
+BINDINGS is an alist of (COMMAND . DESCRIPTION).  The key is looked up
+with `substitute-command-keys', so the hint tells the truth even when the
+buffer\\='s map has been rebound - the trick Flycheck\\='s verify buffer uses."
   (insert "\n"
           (projectile--report-face
            (mapconcat (lambda (binding)
-                        (format "%s %s" (car binding) (cdr binding)))
+                        (format "%s %s"
+                                (substitute-command-keys
+                                 (format "\\[%s]" (car binding)))
+                                (cdr binding)))
                       bindings "   ")
            'projectile-report-hint)
           "\n"))
+
+(defun projectile--report-setup-outline ()
+  "Make the report\\='s sections collapsible with `outline-minor-mode'.
+Section titles are capitalized and start in column zero, while every
+field label is lowercase, so that one distinction is the whole heading
+regexp - no dependency on `magit-section' needed to fold a long report."
+  (setq-local outline-regexp "[A-Z]")
+  (setq-local outline-level (lambda () 1))
+  (outline-minor-mode 1))
 
 ;;;###autoload
 (defun projectile-report-copy ()
@@ -13679,7 +13693,10 @@ in .dir-locals.el to pin a type, or register one with
                       (_ '("info" . projectile-report-info)))))
         (insert (projectile--report-face (format "%-6s" label) face)
                 message "\n")))
-    (projectile--report-hints '(("g" . "refresh") ("w" . "copy") ("q" . "quit")))))
+    (projectile--report-hints '((revert-buffer . "refresh")
+                                (projectile-report-copy . "copy")
+                                (outline-toggle-children . "fold")
+                                (quit-window . "quit")))))
 
 (defun projectile-doctor--sort-findings (findings)
   "Return FINDINGS ordered warnings first, then info, then `ok'.
@@ -13707,7 +13724,8 @@ and \\[quit-window] buries it.
 \\{projectile-doctor-mode-map}"
   (setq-local revert-buffer-function
               (lambda (&rest _)
-                (projectile-doctor--report projectile-doctor--directory))))
+                (projectile-doctor--report projectile-doctor--directory)))
+  (projectile--report-setup-outline))
 
 (defun projectile-doctor--report (dir)
   "Render a doctor report for DIR into the report buffer and return it."
@@ -13776,17 +13794,20 @@ risking a hang, and the report says so."
 ;; switch would be intolerable.
 
 (defcustom projectile-dashboard-sections
-  '(project vcs recent tasks commands)
+  '(project links vcs recent tasks commands)
   "The sections `projectile-dashboard' renders, in order.
 
-Each element is one of the symbols `project' (name, root, type and file
-count), `vcs' (version-control system, branch and working tree status),
-`recent' (the project files you visit most, ranked by frecency), `tasks'
-\(the project's named tasks) and `commands' (the configured lifecycle
-commands).  Dropping a section skips both its rendering and the work
-needed to fill it in."
+Each element is one of the symbols `project' (name, root, type, file and
+buffer counts, ignore rules), `links' (the project's README, changelog,
+license, manifest and Projectile configuration, when it has them), `vcs'
+\(version-control system, branch and working tree status), `recent' (the
+project files you visit most, ranked by frecency), `tasks' (the project's
+named tasks) and `commands' (the configured lifecycle commands).
+Dropping a section skips both its rendering and the work needed to fill
+it in."
   :group 'projectile
   :type '(repeat (choice (const :tag "Project summary" project)
+                         (const :tag "Notable files" links)
                          (const :tag "Version control" vcs)
                          (const :tag "Recently visited files" recent)
                          (const :tag "Tasks" tasks)
@@ -13929,6 +13950,64 @@ the last thing to do in somebody's project-switch action."
                    (cons phase command)))))
            projectile--lifecycle-phases))))
 
+(defcustom projectile-dashboard-link-files
+  '("README" "CHANGELOG" "CONTRIBUTING" "LICENSE" "COPYING")
+  "Base names the dashboard offers as links when the project has them.
+
+Matched case-insensitively and ignoring any extension, so \"README\"
+finds `README.md\\=' as well as `README.rst\\='.  The project\\='s own marker
+file (`package.json\\=', `Cargo.toml\\=', ...) and its `.projectile\\=' are
+always offered when present, without being listed here."
+  :group 'projectile
+  :type '(repeat string)
+  :package-version '(projectile . "3.4.0"))
+
+(defun projectile-dashboard--links (root type)
+  "Return the notable files of the project at ROOT of TYPE, as relative names.
+Answered from a single listing of the project root, so this costs one
+`directory-files\\=' however many names are looked for."
+  (when-let* ((entries (projectile--directory-entry-set root)))
+    (let ((found nil))
+      ;; The docs a human looks for, matched without their extension.
+      (dolist (base projectile-dashboard-link-files)
+        (when-let* ((hit (seq-find
+                          (lambda (entry)
+                            (string-equal (downcase base)
+                                          (downcase (file-name-base entry))))
+                          (sort (hash-table-keys entries) #'string<))))
+          (push hit found)))
+      ;; The project\\='s own manifest, and its Projectile configuration.
+      (dolist (name (append (ensure-list
+                             (projectile-project-type-attribute type 'project-file))
+                            (list projectile-dirconfig-file ".dir-locals.el")))
+        (when (and (stringp name)
+                   (not (projectile--wildcard-p name))
+                   (gethash name entries)
+                   (not (member name found)))
+          (push name found)))
+      (nreverse found))))
+
+(defun projectile-dashboard--ignore-summary (root)
+  "Return a one-line summary of the ignore rules in effect at ROOT.
+Counting compiled patterns is free - they are derived from the
+configuration and the project\\='s dirconfig, both of which are cached."
+  (ignore-errors
+    (let* ((default-directory root)
+           ;; Reads the project's dirconfig; the parser caches it, so this
+           ;; costs nothing the rest of Projectile isn't paying anyway.
+           (cfg (projectile-parse-dirconfig-file))
+           (local (if cfg
+                      (+ (length (projectile-dirconfig-ignore cfg))
+                         (length (projectile-dirconfig-ensure cfg)))
+                    0))
+           (global (+ (length projectile-globally-ignored-directories)
+                      (length projectile-globally-ignored-files)
+                      (length projectile-globally-ignored-file-suffixes))))
+      (if (zerop local)
+          (format "%d global patterns" global)
+        (format "%d global patterns, %d from %s"
+                global local projectile-dirconfig-file)))))
+
 (defun projectile-dashboard--collect-in-project (dir root)
   "Collect the dashboard data for the project at ROOT, reached from DIR.
 Must run in a buffer that has ROOT's directory-local variables applied -
@@ -13946,6 +14025,12 @@ see `projectile-dashboard--collect', which arranges that."
            :name (when project (ignore-errors (projectile-project-name root)))
            :type (when project (ignore-errors (projectile-project-type)))
            :file-count (unless (eq cached 'uncached) (length cached))
+           :buffer-count (length (ignore-errors (projectile-project-buffers root)))
+           :links (when project
+                    (ignore-errors
+                      (projectile-dashboard--links
+                       root (ignore-errors (projectile-project-type)))))
+           :ignores (when project (projectile-dashboard--ignore-summary root))
            :recent-files (when (projectile-dashboard--section-p 'recent)
                            (projectile-dashboard--recent-files root))
            :tasks (when (projectile-dashboard--section-p 'tasks)
@@ -14008,6 +14093,13 @@ that the dashboard stays cheap enough to be a
   "Open the root of the project BUTTON stands for in Dired."
   (dired (button-get button 'projectile-root)))
 
+(defun projectile-dashboard--index (button)
+  "Index the project BUTTON stands for, then refresh the dashboard."
+  (let ((root (button-get button 'projectile-root)))
+    (projectile-index-project-async root)
+    (message "Projectile: indexing %s - press %s to refresh when it finishes"
+             root (substitute-command-keys "\\[revert-buffer]"))))
+
 (define-button-type 'projectile-dashboard-file
   'action #'projectile-dashboard--visit-file
   'follow-link t
@@ -14032,6 +14124,11 @@ that the dashboard stays cheap enough to be a
   'action #'projectile-dashboard--open-dired
   'follow-link t
   'help-echo "mouse-1, RET: open the project root in Dired")
+
+(define-button-type 'projectile-dashboard-index
+  'action #'projectile-dashboard--index
+  'follow-link t
+  'help-echo "mouse-1, RET: index this project in the background")
 
 
 ;;;; Dashboard rendering
@@ -14083,11 +14180,18 @@ The lifecycle commands are named after their phase by construction (see
     (insert "\n")
     (projectile-dashboard--field "type" (plist-get data :type)
                                  'projectile-report-value)
-    (projectile-dashboard--field
-     "files"
-     (if-let* ((count (plist-get data :file-count)))
-         (format "%d (cached)" count)
-       "not indexed yet"))
+    (projectile-dashboard--label "files")
+    (if-let* ((count (plist-get data :file-count)))
+        (insert (format "%d (cached)\n" count))
+      ;; The dashboard never indexes on its own - but it can offer to.
+      (insert "not indexed yet  ")
+      (projectile-dashboard--button "[index now]" 'projectile-dashboard-index root)
+      (insert "\n"))
+    (when-let* ((buffers (plist-get data :buffer-count)))
+      (unless (zerop buffers)
+        (projectile-dashboard--field "buffers" (format "%d open" buffers))))
+    (when-let* ((ignores (plist-get data :ignores)))
+      (projectile-dashboard--field "ignores" ignores))
     (when (plist-get data :remote)
       (projectile-dashboard--field "remote" (plist-get data :remote)))))
 
@@ -14124,6 +14228,18 @@ The lifecycle commands are named after their phase by construction (see
          (projectile-dashboard--button "open the VC interface"
                                        'projectile-dashboard-vc root)
          (insert "\n"))))))
+
+(defun projectile-dashboard--render-links (data)
+  "Render DATA's notable project files."
+  (let ((root (plist-get data :root))
+        (links (plist-get data :links)))
+    (projectile-dashboard--section "Notable files")
+    (if (null links)
+        (insert "  none found\n")
+      (dolist (file links)
+        (projectile-dashboard--entry file 'projectile-dashboard-file root
+                                     'projectile-file file)
+        (insert "\n")))))
 
 (defun projectile-dashboard--render-recent (data)
   "Render DATA's recently visited files."
@@ -14192,12 +14308,16 @@ explains why none of them claimed the directory.
     (dolist (section projectile-dashboard-sections)
       (pcase section
         ('project (projectile-dashboard--render-project data))
+        ('links (projectile-dashboard--render-links data))
         ('vcs (projectile-dashboard--render-vcs data))
         ('recent (projectile-dashboard--render-recent data))
         ('tasks (projectile-dashboard--render-tasks data))
         ('commands (projectile-dashboard--render-commands data))))
-    (projectile--report-hints '(("RET" . "act on entry") ("TAB" . "next entry")
-                                ("g" . "refresh") ("w" . "copy") ("q" . "bury")))))
+    (projectile--report-hints '((push-button . "act on entry")
+                                (forward-button . "next entry")
+                                (revert-buffer . "refresh")
+                                (projectile-report-copy . "copy")
+                                (quit-window . "bury")))))
 
 
 ;;;; The dashboard buffer
@@ -14225,7 +14345,8 @@ move between them.  \\[revert-buffer] refreshes the dashboard and \\[quit-window
   (setq-local revert-buffer-function
               (lambda (&rest _)
                 (projectile-dashboard--refresh
-                 projectile-dashboard--directory))))
+                 projectile-dashboard--directory)))
+  (projectile--report-setup-outline))
 
 (defun projectile-dashboard--refresh (dir)
   "Render the dashboard for DIR into the dashboard buffer and return it."

--- a/test/projectile-dashboard-test.el
+++ b/test/projectile-dashboard-test.el
@@ -383,6 +383,64 @@
     (expect (lookup-key projectile-command-map (kbd "P"))
             :to-be 'projectile-dashboard)))
 
+(describe "projectile-dashboard notable files"
+  (it "links the docs, the type's manifest and the Projectile config"
+    (projectile-test-with-project
+        (("README.md" . "# demo")
+         ("CHANGELOG.md" . "# changes")
+         ("LICENSE" . "MIT")
+         ("package.json" . "{}")
+         (".projectile" . "")
+         ("src/main.js" . ""))
+      (let ((links (projectile-dashboard--links (projectile-project-root) 'npm)))
+        (expect links :to-contain "README.md")
+        (expect links :to-contain "CHANGELOG.md")
+        (expect links :to-contain "LICENSE")
+        ;; the project type's own manifest
+        (expect links :to-contain "package.json")
+        (expect links :to-contain ".projectile")
+        ;; ordinary sources are not "notable"
+        (expect links :not :to-contain "src/main.js"))))
+
+  (it "matches a doc regardless of its extension"
+    (projectile-test-with-project (("README.rst" . "demo"))
+      (expect (projectile-dashboard--links (projectile-project-root) 'generic)
+              :to-contain "README.rst"))
+    (projectile-test-with-project (("README" . "demo"))
+      (expect (projectile-dashboard--links (projectile-project-root) 'generic)
+              :to-contain "README")))
+
+  (it "offers nothing when the project has none of them"
+    (projectile-test-with-project (("src/main.js" . ""))
+      ;; `.projectile' is created by the test macro, so that one is expected
+      (expect (seq-remove (lambda (f) (equal f ".projectile"))
+                          (projectile-dashboard--links (projectile-project-root) 'generic))
+              :to-be nil)))
+
+  (it "does not offer a wildcard manifest it cannot resolve"
+    ;; the dotnet types use `?*.csproj' as their project file
+    (projectile-test-with-project (("Demo.csproj" . ""))
+      (expect (projectile-dashboard--links (projectile-project-root) 'dotnet)
+              :not :to-contain "?*.csproj"))))
+
+(describe "projectile-dashboard indexing prompt"
+  (it "offers to index a project that has nothing cached"
+    (spy-on 'projectile-project-buffers :and-return-value nil)
+    (with-temp-buffer
+      (projectile-dashboard--render-project
+       '(:root "/proj/" :name "proj" :type npm :file-count nil))
+      (expect (buffer-string) :to-match "not indexed yet")
+      (goto-char (point-min))
+      (expect (re-search-forward "index now" nil t) :to-be-truthy)))
+
+  (it "reports the count instead once the project is cached"
+    (spy-on 'projectile-project-buffers :and-return-value nil)
+    (with-temp-buffer
+      (projectile-dashboard--render-project
+       '(:root "/proj/" :name "proj" :type npm :file-count 42))
+      (expect (buffer-string) :to-match "42 (cached)")
+      (expect (buffer-string) :not :to-match "index now"))))
+
 (provide 'projectile-dashboard-test)
 
 ;;; projectile-dashboard-test.el ends here

--- a/test/projectile-doctor-test.el
+++ b/test/projectile-doctor-test.el
@@ -228,12 +228,25 @@
         (expect (projectile-report-test--faces-at "^ok")
                 :to-be 'projectile-report-ok)))
 
-    (it "ends with a hint line naming the copy key"
+    (it "describes its keys by looking them up, not by hardcoding them"
+      ;; `substitute-command-keys' means the footer keeps telling the truth
+      ;; after a rebind, rather than advertising a key that no longer works.
       (spy-on 'projectile-doctor--findings :and-return-value nil)
       (with-temp-buffer
-        (projectile-doctor--render '(:root "/proj/"))
-        (goto-char (point-max))
-        (expect (buffer-string) :to-match "w copy")))))
+        (projectile-doctor-mode)
+        (let ((inhibit-read-only t))
+          (projectile-doctor--render '(:root "/proj/")))
+        (expect (buffer-string) :to-match "w copy"))
+      (with-temp-buffer
+        (projectile-doctor-mode)
+        (use-local-map (let ((map (make-sparse-keymap)))
+                         (set-keymap-parent map projectile-doctor-mode-map)
+                         (define-key map (kbd "C-c C-w") #'projectile-report-copy)
+                         (define-key map (kbd "w") nil)
+                         map))
+        (let ((inhibit-read-only t))
+          (projectile-doctor--render '(:root "/proj/")))
+        (expect (buffer-string) :to-match "C-c C-w copy")))))
 
 (provide 'projectile-doctor-test)
 


### PR DESCRIPTION
Follow-up to #2131, with a few ideas borrowed from packages that solve the same
problem.

The dashboard reported plenty about how Projectile sees a project and almost
nothing about the project itself. It now has a "Notable files" section linking
the things you actually open first - README, changelog, license, the project
type's own manifest, the `.projectile` - all resolved from the single directory
listing it was already doing, so the section is free. Alongside them: how many
of the project's buffers are open, and how many ignore patterns are in effect.

`not indexed yet` used to be a dead end. It now comes with an `[index now]`
button that warms the cache in the background - Flycheck's `verify-setup` trick
of putting the fix next to the diagnosis, which is worth stealing wholesale.

Both buffers now set up `outline-minor-mode` over their sections. The heading
regexp is just `[A-Z]`: section titles are capitalized and every field label is
lowercase, so that distinction was already there for free. That gets folding
without depending on `magit-section`, which would drag in compat 31, cond-let
and llama for a package whose only dependency today is compat.

Their footers also derive the keys they advertise with `substitute-command-keys`
(another Flycheck habit) rather than hardcoding `w`, so a rebind can't make the
hint lie. There's a spec that rebinds the copy key and checks the footer follows.