### PR TITLE
Put the fix next to the doctor's diagnosis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New features
 
+- [#2133](https://github.com/bbatsov/projectile/pull/2133): `projectile-doctor` findings you can act on now carry a button that does it - `[enable]` for a disabled `projectile-mode`, `[enable caching]` on a large uncached project, `[open dirconfig]` for a `.projectile` with prefix-less lines, `[edit .dir-locals.el]` for an undetected project type. Pressing one regenerates the report, so the finding answers for itself; findings Projectile can't act on stay plain advice.
 - [#2132](https://github.com/bbatsov/projectile/pull/2132): The dashboard gained a "Notable files" section linking the project's README, changelog, license, its type's own manifest and its `.projectile` (see `projectile-dashboard-link-files`), plus a count of its open buffers and a summary of the ignore rules in effect.
   - A project with nothing cached now offers an `[index now]` button instead of only reporting that it isn't indexed.
   - Both report buffers set up `outline-minor-mode` over their sections, so a long report folds with the usual outline keys, and their footers derive the keys they advertise with `substitute-command-keys` rather than hardcoding them.

--- a/doc/modules/ROOT/pages/troubleshooting.adoc
+++ b/doc/modules/ROOT/pages/troubleshooting.adoc
@@ -26,7 +26,15 @@ image::projectile-doctor.png[The Projectile doctor report: project root, type, i
 
 The report is meant to be pasted into a bug report, so kbd:[w]
 (`projectile-report-copy`) copies it as plain text with the faces and buttons
-stripped. kbd:[g] regenerates it and kbd:[q] buries the buffer.
+stripped. kbd:[g] regenerates it, kbd:[f] folds a section and kbd:[q] buries
+the buffer.
+
+A finding that Projectile can do something about carries a button on the line
+under it - `[enable]` for a disabled `projectile-mode`, `[enable caching]` on a
+big uncached project, `[open dirconfig]` for a `.projectile` that needs editing.
+Pressing it does the thing and regenerates the report, so the finding answers
+for itself. kbd:[TAB] (or kbd:[n]) moves between them. Findings Projectile
+can't act on - a missing `fd`, say - stay plain advice.
 
 * *Project* - the project root and, crucially, *which* entry of
 `projectile-project-root-functions` found it and off which marker file, the

--- a/projectile.el
+++ b/projectile.el
@@ -45,6 +45,7 @@
 (require 'grep)
 (require 'fileloop)
 (require 'filenotify)
+(require 'outline)
 (eval-when-compile
   ;; `transient' is bundled with Emacs 28.1+ (Projectile's minimum), but
   ;; it's only needed once `projectile-dispatch' is invoked, so it's
@@ -13417,10 +13418,38 @@ a nil `:root' and the rendering degrades to saying so."
 
 ;;;; Doctor findings
 
+(defun projectile-doctor--finding (severity message &optional action-label action)
+  "Return a finding of SEVERITY described by MESSAGE.
+SEVERITY is one of `ok\\=', `warn\\=' or `info\\='.
+
+ACTION, when given, is a function of no arguments that does something
+about the finding, and ACTION-LABEL is what to call it in the report.
+The report renders such a finding with a button, so the fix sits next to
+the diagnosis rather than in a sentence telling you what to go and type."
+  (list :severity severity :message message
+        :action-label action-label :action action))
+
+(defun projectile-doctor--enable-mode ()
+  "Turn `projectile-mode\\=' on."
+  (projectile-mode 1)
+  (message "Projectile: `projectile-mode' enabled"))
+
+(defun projectile-doctor--set-option (option value)
+  "Set OPTION to VALUE for this session, the way Customize would.
+Says so, since the change doesn\\='t outlive Emacs unless it\\='s saved."
+  (customize-set-variable option value)
+  (message "Projectile: `%s' set to %s for this session - use %s to keep it"
+           option value
+           (substitute-command-keys "\\[customize-save-variable]")))
+
+(defun projectile-doctor--visit-dirconfig ()
+  "Visit the current project\\='s dirconfig file, creating it if need be."
+  (find-file (expand-file-name projectile-dirconfig-file
+                               (projectile-acquire-root))))
+
 (defun projectile-doctor--findings (data)
   "Return the list of findings for the report DATA.
-Each finding is a cons of a status symbol (`ok', `warn' or `info') and
-a one-line description."
+Each finding is a plist built by `projectile-doctor--finding\\='."
   (let* ((remote (plist-get data :remote))
          (method (plist-get data :indexing-method))
          (external (memq method '(alien hybrid)))
@@ -13428,78 +13457,104 @@ a one-line description."
          (cfg (plist-get data :dirconfig))
          (findings nil))
     (push (if (eq (plist-get data :type) 'generic)
-              (cons 'warn (concat "Project type not detected (generic).  "
-                                  "Register a type with "
-                                  "`projectile-register-project-type', or set "
-                                  "`projectile-project-type' in .dir-locals.el."))
-            (cons 'ok (format "Project type detected: %s."
-                              (plist-get data :type))))
+              (projectile-doctor--finding
+               'warn (concat "Project type not detected (generic).  "
+                             "Register a type with "
+                             "`projectile-register-project-type', or set "
+                             "`projectile-project-type' in .dir-locals.el.")
+               "edit .dir-locals.el" #'projectile-edit-dir-locals)
+            (projectile-doctor--finding
+             'ok (format "Project type detected: %s." (plist-get data :type))))
           findings)
     (when (and external (eq (plist-get data :vcs) 'git))
       (push (pcase (plist-get data :git)
-              ('present (cons 'ok "git is installed and lists the project files."))
-              ('skipped (cons 'info "git availability not checked (remote project)."))
-              (_ (cons 'warn (concat "git is not installed, but this is a git "
-                                     "project - indexing falls back to `find'."))))
+              ('present (projectile-doctor--finding
+                         'ok "git is installed and lists the project files."))
+              ('skipped (projectile-doctor--finding
+                         'info "git availability not checked (remote project)."))
+              (_ (projectile-doctor--finding
+                  'warn (concat "git is not installed, but this is a git "
+                                "project - indexing falls back to `find'."))))
             findings))
     (when external
       (push (pcase (plist-get data :fd)
-              ('present (cons 'ok "fd is installed and used for fast indexing."))
-              ('skipped (cons 'info "fd availability not checked (remote project)."))
-              (_ (cons 'warn (concat "fd is not installed.  Installing it speeds "
-                                     "up indexing noticeably on large projects "
-                                     "(see `projectile-git-use-fd')."))))
+              ('present (projectile-doctor--finding
+                         'ok "fd is installed and used for fast indexing."))
+              ('skipped (projectile-doctor--finding
+                         'info "fd availability not checked (remote project)."))
+              (_ (projectile-doctor--finding
+                  'warn (concat "fd is not installed.  Installing it speeds "
+                                "up indexing noticeably on large projects "
+                                "(see `projectile-git-use-fd')."))))
             findings))
     (when (and (eq (plist-get data :rg) 'missing) (not remote))
-      (push (cons 'info (concat "ripgrep (rg) is not installed; "
-                                "`projectile-ripgrep' and the fast path of the "
-                                "search reviewer need it."))
+      (push (projectile-doctor--finding
+             'info (concat "ripgrep (rg) is not installed; "
+                           "`projectile-ripgrep' and the fast path of the "
+                           "search reviewer need it."))
             findings))
     (when (integerp count)
       (cond
        ((>= count projectile-doctor--huge-project)
-        (push (cons 'warn (format (concat "%d files indexed.  That's a lot - "
-                                          "check the ignore rules above, a "
-                                          "build or vendor directory may be "
-                                          "sneaking in.")
-                                  count))
+        (push (projectile-doctor--finding
+               'warn (format (concat "%d files indexed.  That's a lot - "
+                                     "check the ignore rules above, a "
+                                     "build or vendor directory may be "
+                                     "sneaking in.")
+                             count)
+               "edit ignores" #'projectile-doctor--visit-dirconfig)
               findings))
        ((and (>= count projectile-doctor--large-project)
              (not (plist-get data :caching)))
-        (push (cons 'warn (format (concat "%d files indexed with caching "
-                                          "disabled.  Set "
-                                          "`projectile-enable-caching' to t "
-                                          "(or `persistent').")
-                                  count))
+        (push (projectile-doctor--finding
+               'warn (format (concat "%d files indexed with caching "
+                                     "disabled.  Set "
+                                     "`projectile-enable-caching' to t "
+                                     "(or `persistent').")
+                             count)
+               "enable caching"
+               (lambda () (projectile-doctor--set-option
+                           'projectile-enable-caching t)))
               findings))
-       (t (push (cons 'ok (format "%d files indexed." count)) findings))))
+       (t (push (projectile-doctor--finding
+                 'ok (format "%d files indexed." count))
+                findings))))
     (when (and remote (not (plist-get data :async-indexing)))
-      (push (cons 'warn (concat "Remote project with `projectile-async-indexing' "
-                                "off - indexing will block Emacs for as long as "
-                                "the remote takes."))
+      (push (projectile-doctor--finding
+             'warn (concat "Remote project with `projectile-async-indexing' "
+                           "off - indexing will block Emacs for as long as "
+                           "the remote takes.")
+             "enable async indexing"
+             (lambda () (projectile-doctor--set-option
+                         'projectile-async-indexing t)))
             findings))
     (when cfg
       (when (projectile-dirconfig-keep cfg)
-        (push (cons 'info (format (concat "The dirconfig has %d `+' keep "
-                                          "entries, so the project is "
-                                          "restricted to those subdirectories "
-                                          "- everything else is invisible to "
-                                          "Projectile.")
-                                  (length (projectile-dirconfig-keep cfg))))
+        (push (projectile-doctor--finding
+               'info (format (concat "The dirconfig has %d `+' keep "
+                                     "entries, so the project is "
+                                     "restricted to those subdirectories "
+                                     "- everything else is invisible to "
+                                     "Projectile.")
+                             (length (projectile-dirconfig-keep cfg)))
+               "open dirconfig" #'projectile-doctor--visit-dirconfig)
               findings))
       (when (projectile-dirconfig-prefixless-ignore cfg)
-        (push (cons 'warn (concat "The dirconfig has lines without a "
-                                  "`+'/`-'/`!' prefix.  They are treated as "
-                                  "ignore rules for now, but the implicit form "
-                                  "is being phased out - prefix them with `-'."))
+        (push (projectile-doctor--finding
+               'warn (concat "The dirconfig has lines without a "
+                             "`+'/`-'/`!' prefix.  They are treated as "
+                             "ignore rules for now, but the implicit form "
+                             "is being phased out - prefix them with `-'.")
+               "open dirconfig" #'projectile-doctor--visit-dirconfig)
               findings)))
     (unless (plist-get data :projectile-mode)
-      (push (cons 'warn (concat "`projectile-mode' is not enabled; "
-                                "Projectile's keymap and mode line are "
-                                "inactive."))
+      (push (projectile-doctor--finding
+             'warn (concat "`projectile-mode' is not enabled; "
+                           "Projectile's keymap and mode line are "
+                           "inactive.")
+             "enable" #'projectile-doctor--enable-mode)
             findings))
     (nreverse findings)))
-
 
 ;;;; Doctor report rendering
 
@@ -13685,15 +13740,25 @@ in .dir-locals.el to pin a type, or register one with
     ;; lone warning shouldn't be buried among a dozen `ok' lines.
     (dolist (finding (projectile-doctor--sort-findings
                       (projectile-doctor--findings data)))
-      (pcase-let* ((`(,severity . ,message) finding)
-                   (`(,label . ,face)
-                    (pcase severity
+      (pcase-let* ((`(,label . ,face)
+                    (pcase (plist-get finding :severity)
                       ('ok '("ok" . projectile-report-ok))
                       ('warn '("warn" . projectile-report-warning))
                       (_ '("info" . projectile-report-info)))))
         (insert (projectile--report-face (format "%-6s" label) face)
-                message "\n")))
-    (projectile--report-hints '((revert-buffer . "refresh")
+                (plist-get finding :message)
+                "\n")
+        ;; Put the fix under the diagnosis rather than describing it.  Its
+        ;; own line, because findings are long and a button at the end of
+        ;; one sits past the window edge where nobody will find it.
+        (when-let* ((action (plist-get finding :action)))
+          (insert (make-string 6 ?\s))
+          (insert-text-button (format "[%s]" (plist-get finding :action-label))
+                              'type 'projectile-doctor-action
+                              'projectile-action action)
+          (insert "\n"))))
+    (projectile--report-hints '((forward-button . "next action")
+                                (revert-buffer . "refresh")
                                 (projectile-report-copy . "copy")
                                 (outline-toggle-children . "fold")
                                 (quit-window . "quit")))))
@@ -13703,14 +13768,35 @@ in .dir-locals.el to pin a type, or register one with
 The order within each severity is preserved, so the report still reads
 in the order the checks are written."
   (let ((rank (lambda (finding)
-                (pcase (car finding) ('warn 0) ('ok 2) (_ 1)))))
+                (pcase (plist-get finding :severity) ('warn 0) ('ok 2) (_ 1)))))
     (sort (copy-sequence findings)
           (lambda (a b) (< (funcall rank a) (funcall rank b))))))
+
+(defun projectile-doctor--run-action (button)
+  "Run the action BUTTON stands for, then regenerate the report.
+Regenerating is the point: the finding that prompted the action should
+answer for itself once it has been dealt with."
+  (let ((action (button-get button 'projectile-action)))
+    (funcall action)
+    (when (derived-mode-p 'projectile-doctor-mode)
+      (revert-buffer))))
+
+(define-button-type 'projectile-doctor-action
+  'action #'projectile-doctor--run-action
+  'follow-link t
+  'help-echo "mouse-1, RET: do something about this finding")
 
 (defvar projectile-doctor-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "q") #'quit-window)
     (define-key map (kbd "w") #'projectile-report-copy)
+    ;; The findings carry action buttons, so moving between them is worth
+    ;; a key - as is folding a report that runs past a screenful.
+    (define-key map (kbd "TAB") #'forward-button)
+    (define-key map (kbd "<backtab>") #'backward-button)
+    (define-key map (kbd "n") #'forward-button)
+    (define-key map (kbd "p") #'backward-button)
+    (define-key map (kbd "f") #'outline-toggle-children)
     map)
   "Keymap for `projectile-doctor-mode'.")
 

--- a/test/projectile-doctor-test.el
+++ b/test/projectile-doctor-test.el
@@ -93,26 +93,31 @@
 
 (defun projectile-doctor-test--finding (data pattern)
   "Return DATA's finding whose text matches PATTERN, if any."
-  (seq-find (lambda (finding) (string-match-p pattern (cdr finding)))
+  (seq-find (lambda (finding)
+              (string-match-p pattern (plist-get finding :message)))
             (projectile-doctor--findings data)))
+
+(defun projectile-doctor-test--severity (finding)
+  "Return FINDING's severity."
+  (plist-get finding :severity))
 
 (describe "projectile-doctor findings"
   (it "suggests installing fd when it's missing under alien indexing"
     (let ((finding (projectile-doctor-test--finding
                     '(:indexing-method alien :fd missing :projectile-mode t)
                     "fd is not installed")))
-      (expect (car finding) :to-be 'warn))
+      (expect (projectile-doctor-test--severity finding) :to-be 'warn))
     (let ((finding (projectile-doctor-test--finding
                     '(:indexing-method alien :fd present :projectile-mode t)
                     "fd is installed")))
-      (expect (car finding) :to-be 'ok)))
+      (expect (projectile-doctor-test--severity finding) :to-be 'ok)))
 
   (it "flags a large project with caching disabled"
     (let ((finding (projectile-doctor-test--finding
                     '(:indexing-method native :file-count 20000
                       :caching nil :projectile-mode t)
                     "caching")))
-      (expect (car finding) :to-be 'warn))
+      (expect (projectile-doctor-test--severity finding) :to-be 'warn))
     (expect (projectile-doctor-test--finding
              '(:indexing-method native :file-count 20000
                :caching t :projectile-mode t)
@@ -124,14 +129,14 @@
                     '(:indexing-method alien :file-count 100000
                       :caching t :projectile-mode t)
                     "That's a lot")))
-      (expect (car finding) :to-be 'warn)))
+      (expect (projectile-doctor-test--severity finding) :to-be 'warn)))
 
   (it "flags a remote project indexed synchronously"
     (let ((finding (projectile-doctor-test--finding
                     '(:indexing-method alien :remote "/ssh:host:"
                       :async-indexing nil :projectile-mode t)
                     "Remote project")))
-      (expect (car finding) :to-be 'warn))
+      (expect (projectile-doctor-test--severity finding) :to-be 'warn))
     (expect (projectile-doctor-test--finding
              '(:indexing-method alien :remote "/ssh:host:"
                :async-indexing t :projectile-mode t)
@@ -144,20 +149,87 @@
                                            :prefixless-ignore '("tmp")))
            (data (list :indexing-method 'native :projectile-mode t
                        :dirconfig cfg)))
-      (expect (car (projectile-doctor-test--finding data "without a"))
+      (expect (projectile-doctor-test--severity (projectile-doctor-test--finding data "without a"))
               :to-be 'warn)
-      (expect (car (projectile-doctor-test--finding data "keep"))
+      (expect (projectile-doctor-test--severity (projectile-doctor-test--finding data "keep"))
               :to-be 'info)))
 
   (it "warns when the project type wasn't detected"
-    (expect (car (projectile-doctor-test--finding
+    (expect (projectile-doctor-test--severity (projectile-doctor-test--finding
                   '(:type generic :indexing-method native :projectile-mode t)
                   "type not detected"))
             :to-be 'warn)
-    (expect (car (projectile-doctor-test--finding
+    (expect (projectile-doctor-test--severity (projectile-doctor-test--finding
                   '(:type emacs-eldev :indexing-method native :projectile-mode t)
                   "type detected"))
             :to-be 'ok)))
+
+(describe "actionable findings"
+  (it "offers to enable projectile-mode when it is off"
+    (let ((finding (projectile-doctor-test--finding
+                    '(:indexing-method native :projectile-mode nil)
+                    "projectile-mode. is not enabled")))
+      (expect (plist-get finding :action-label) :to-equal "enable")
+      (spy-on 'projectile-mode)
+      (funcall (plist-get finding :action))
+      (expect 'projectile-mode :to-have-been-called-with 1)))
+
+  (it "offers to enable caching on a large uncached project"
+    (let ((finding (projectile-doctor-test--finding
+                    '(:indexing-method native :file-count 20000
+                      :caching nil :projectile-mode t)
+                    "caching")))
+      (expect (plist-get finding :action-label) :to-equal "enable caching")
+      (spy-on 'customize-set-variable)
+      (funcall (plist-get finding :action))
+      (expect 'customize-set-variable
+              :to-have-been-called-with 'projectile-enable-caching t)))
+
+  (it "offers to open the dirconfig behind a prefix-less-lines warning"
+    (projectile-test-with-stub-root "proj" (".projectile")
+      (let* ((cfg (make-projectile-dirconfig :prefixless-ignore t))
+             (finding (projectile-doctor-test--finding
+                       (list :indexing-method 'native :projectile-mode t
+                             :dirconfig cfg)
+                       "without a")))
+        (expect (plist-get finding :action-label) :to-equal "open dirconfig")
+        (spy-on 'find-file)
+        (funcall (plist-get finding :action))
+        (expect 'find-file :to-have-been-called-with
+                (expand-file-name ".projectile" (projectile-project-root))))))
+
+  (it "leaves a finding you cannot act on without a button"
+    ;; Projectile can't install fd for you, so that one stays advice.
+    (let ((finding (projectile-doctor-test--finding
+                    '(:indexing-method alien :fd missing :projectile-mode t)
+                    "fd is not installed")))
+      (expect (plist-get finding :action) :to-be nil))
+    (let ((finding (projectile-doctor-test--finding
+                    '(:indexing-method native :file-count 5 :projectile-mode t)
+                    "5 files indexed")))
+      (expect (plist-get finding :action) :to-be nil)))
+
+  (it "renders an action as a button and runs it on RET"
+    (let ((ran nil))
+      (spy-on 'projectile-doctor--findings :and-return-value
+              (list (projectile-doctor--finding
+                     'warn "something is off" "fix it"
+                     (lambda () (setq ran t)))))
+      (with-temp-buffer
+        (projectile-doctor-mode)
+        (let ((inhibit-read-only t))
+          (projectile-doctor--render '(:root "/proj/")))
+        (goto-char (point-min))
+        (expect (re-search-forward "\\[fix it\\]" nil t) :to-be-truthy)
+        ;; the label is part of the report text, so a pasted report still
+        ;; says what could be done about the finding
+        (goto-char (point-min))
+        (search-forward "fix it")
+        (spy-on 'revert-buffer)
+        (push-button (1- (point)))
+        (expect ran :to-be t)
+        ;; and the report regenerates, so the finding answers for itself
+        (expect 'revert-buffer :to-have-been-called)))))
 
 (describe "report rendering"
   (defun projectile-report-test--faces-at (regexp)
@@ -191,10 +263,14 @@
 
   (describe "projectile-doctor--sort-findings"
     (it "puts what wants action first, keeping each severity's own order"
-      (expect (projectile-doctor--sort-findings
-               '((ok . "a") (info . "b") (warn . "c") (ok . "d") (warn . "e")))
-              :to-equal '((warn . "c") (warn . "e") (info . "b")
-                          (ok . "a") (ok . "d")))))
+      (expect (mapcar (lambda (f) (plist-get f :message))
+                      (projectile-doctor--sort-findings
+                       (list (projectile-doctor--finding 'ok "a")
+                             (projectile-doctor--finding 'info "b")
+                             (projectile-doctor--finding 'warn "c")
+                             (projectile-doctor--finding 'ok "d")
+                             (projectile-doctor--finding 'warn "e"))))
+              :to-equal '("c" "e" "b" "a" "d"))))
 
   (describe "projectile-report-copy"
     (it "copies the report without its text properties"
@@ -220,7 +296,8 @@
   (describe "the doctor buffer"
     (it "renders its findings colored by severity"
       (spy-on 'projectile-doctor--findings :and-return-value
-              '((warn . "fd is not installed") (ok . "all good")))
+              (list (projectile-doctor--finding 'warn "fd is not installed")
+                    (projectile-doctor--finding 'ok "all good")))
       (with-temp-buffer
         (projectile-doctor--render '(:root "/proj/" :type 'npm))
         (expect (projectile-report-test--faces-at "^warn")


### PR DESCRIPTION
The last idea from the prior-art dig in #2132. Flycheck's `verify-setup` renders
a disabled checker as `(manually disabled) [enable]` - the fix sits next to the
diagnosis instead of being described in a sentence. The doctor was doing the
sentence version.

Findings become plists rather than `(SEVERITY . MESSAGE)` conses, so one can
carry an action and a label. Four of them can be acted on:

- `projectile-mode` is off -> `[enable]`
- large project with caching disabled -> `[enable caching]`
- dirconfig with prefix-less lines, or `+` keep entries -> `[open dirconfig]`
- project type not detected -> `[edit .dir-locals.el]`

Pressing one runs it and regenerates the report, so the finding that prompted
the action visibly answers for itself. Findings Projectile can't do anything
about - a missing `fd`, a missing `rg` - deliberately stay plain advice rather
than growing a button that would only explain.

Two things came out of looking at it rendered rather than just tested:

- The button started out at the end of the finding's line, which is where it's
  invisible - findings are long and that's well past the window edge. It's on
  its own indented line now.
- The footer hint for folding rendered as `M-x outline-toggle-children` because
  nothing was bound to it. The doctor now binds `f` for that, and `TAB`/`n` for
  moving between the action buttons it has acquired.

Setting an option goes through `customize-set-variable` and says it's for this
session unless saved, rather than quietly setting a variable the user would then
find mysteriously changed.