### PR TITLE
Add projectile-find-changed-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New features
 
+- [#2134](https://github.com/bbatsov/projectile/pull/2134): Add `projectile-find-changed-file` (`s-p C`), which completes over the files git reports as staged, unstaged or untracked - or, with a prefix argument, over everything that differs from a revision you pick.
 - [#2133](https://github.com/bbatsov/projectile/pull/2133): `projectile-doctor` findings you can act on now carry a button that does it - `[enable]` for a disabled `projectile-mode`, `[enable caching]` on a large uncached project, `[open dirconfig]` for a `.projectile` with prefix-less lines, `[edit .dir-locals.el]` for an undetected project type. Pressing one regenerates the report, so the finding answers for itself; findings Projectile can't act on stay plain advice.
 - [#2132](https://github.com/bbatsov/projectile/pull/2132): The dashboard gained a "Notable files" section linking the project's README, changelog, license, its type's own manifest and its `.projectile` (see `projectile-dashboard-link-files`), plus a count of its open buffers and a summary of the ignore rules in effect.
   - A project with nothing cached now offers an `[index now]` button instead of only reporting that it isn't indexed.

--- a/doc/modules/ROOT/pages/cheatsheet.adoc
+++ b/doc/modules/ROOT/pages/cheatsheet.adoc
@@ -52,6 +52,9 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p l]
 | Display a list of all files in a directory (that's not necessarily a project)
 
+| kbd:[s-p C]
+| Jump to a file changed in the project - staged, unstaged or untracked. With a prefix argument, everything that differs from a revision you pick. Git only.
+
 | kbd:[s-p s s]
 | Search the project with the configured backend (`projectile-search`, see below). With a prefix argument it performs a regexp search.
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -603,6 +603,21 @@ NOTE: `projectile-dispatch` is powered by `transient`, which is bundled with
 Emacs 28.1+ (Projectile's minimum), so the menu is always available. It's bound
 to kbd:[s-p m], and kbd:[C-u s-p p] opens it when switching projects.
 
+== Finding changed files
+
+`projectile-find-changed-file` (kbd:[s-p C]) completes over the files you have
+actually touched rather than the whole project: everything git reports as
+staged, unstaged or untracked.
+
+With a prefix argument it asks for a revision to compare against - completing
+over the project's branches - and the candidates become everything that differs
+from it, plus anything not yet tracked. That is the "what did this branch
+change" list, which is usually what you want when picking a review back up.
+
+The command is git-only and says so on any other version control system. Paths
+are reported relative to the project even when it sits below the repository
+root, and files outside it are left out.
+
 [[dashboard]]
 == Project dashboard
 

--- a/projectile.el
+++ b/projectile.el
@@ -13926,7 +13926,7 @@ Used by the buffer's `revert-buffer' to regenerate it.")
 
 ;;;; Dashboard data collection
 
-(defun projectile-dashboard--git (root &rest args)
+(defun projectile--git (root &rest args)
   "Run git with ARGS in ROOT and return its output, or nil when it fails.
 No shell is involved, and the call would go through TRAMP for a remote
 ROOT - which is why the callers make sure never to reach here with one.
@@ -13939,6 +13939,106 @@ taking the index lock and rewriting the index behind the user's back."
                      (apply #'process-file "git" nil '(t nil) nil
                             "--no-optional-locks" args)))
         (buffer-string)))))
+
+(defun projectile--git-toplevel (root)
+  "Return the toplevel of the git repository containing ROOT, or nil."
+  (when-let* ((top (projectile--git root "rev-parse" "--show-toplevel")))
+    (file-name-as-directory (file-truename (string-trim top)))))
+
+(defun projectile--git-relativize (paths root toplevel)
+  "Return PATHS, given relative to TOPLEVEL, relative to ROOT instead.
+Git reports porcelain and diff paths relative to the repository root
+regardless of where it was run, so a project sitting below that root
+needs them translated - and anything outside the project dropped."
+  (if (equal (file-truename root) toplevel)
+      paths
+    (delq nil
+          (mapcar (lambda (path)
+                    (let ((absolute (expand-file-name path toplevel))
+                          (root (file-truename root)))
+                      (when (string-prefix-p root absolute)
+                        (file-relative-name absolute root))))
+                  paths))))
+
+(defun projectile--git-status-changed-files (root)
+  "Return the paths git reports as changed in ROOT\\='s working tree.
+Covers staged, unstaged and untracked files, as repository-relative
+paths.  A rename occupies two NUL-separated fields - the new name and
+then the old one - so those are consumed in step rather than the old
+name being mistaken for another changed file."
+  (when-let* ((output (projectile--git root "status" "--porcelain" "-z"
+                                       "--untracked-files=all")))
+    (let ((records (split-string output "\0" t))
+          files)
+      (while records
+        (let ((record (pop records)))
+          ;; "XY PATH", with X and Y the index and worktree status codes.
+          (when (> (length record) 3)
+            (let ((status (substring record 0 2))
+                  (path (substring record 3)))
+              (push path files)
+              ;; A rename or copy carries the source path in the next field.
+              (when (string-match-p "[RC]" status)
+                (pop records))))))
+      (nreverse files))))
+
+(defun projectile-git-changed-files (root &optional base)
+  "Return the files changed in the project at ROOT, relative to it.
+
+Without BASE that is the working tree: everything staged, unstaged or
+untracked.  With BASE - a branch, tag or any other revision - it is
+everything that differs from it, plus the files not yet tracked at all,
+which is what \"show me what this branch changed\" usually means.
+
+Only git is supported; any other version control system returns nil."
+  (when (eq (projectile-project-vcs root) 'git)
+    (when-let* ((toplevel (projectile--git-toplevel root)))
+      (let ((paths
+             (if base
+                 (append
+                  (when-let* ((diff (projectile--git root "diff" "--name-only"
+                                                     "-z" base)))
+                    (split-string diff "\0" t))
+                  (when-let* ((new (projectile--git root "ls-files" "-z"
+                                                    "--others" "--exclude-standard")))
+                    (split-string new "\0" t)))
+               (projectile--git-status-changed-files root))))
+        (seq-uniq (projectile--git-relativize paths root toplevel))))))
+
+(defun projectile--read-git-ref (root)
+  "Read a git revision to compare against, completing over ROOT\\='s branches."
+  (let ((branches (when-let* ((output (projectile--git
+                                       root "for-each-ref" "--format=%(refname:short)"
+                                       "refs/heads" "refs/remotes")))
+                    (split-string output "\n" t))))
+    (completing-read "Compare against: " branches nil nil nil nil
+                     (car (member "main" branches)))))
+
+;;;###autoload
+(defun projectile-find-changed-file (&optional arg)
+  "Jump to a file changed in the current project.
+
+That is everything git reports as staged, unstaged or untracked.  With a
+prefix ARG you are asked for a revision to compare against instead - a
+branch, say - and the candidates become everything that differs from it,
+which is the \"what did this branch touch\" list.
+
+Only git projects are supported."
+  (interactive "P")
+  (let* ((root (projectile-acquire-root))
+         (base (when arg (projectile--read-git-ref root))))
+    (unless (eq (projectile-project-vcs root) 'git)
+      (user-error "`projectile-find-changed-file' needs a git project"))
+    (let ((files (projectile-git-changed-files root base)))
+      (unless files
+        (user-error "No changed files in %s%s" root
+                    (if base (format " compared to %s" base) "")))
+      (find-file (expand-file-name
+                  (projectile-completing-read
+                   (if base (format "Changed vs %s: " base) "Changed file: ")
+                   files :caller 'projectile-find-changed-file)
+                  root))
+      (run-hooks 'projectile-find-file-hook))))
 
 (defun projectile-dashboard--git-status (root)
   "Return the git branch and working tree counts for ROOT as a plist.
@@ -13954,9 +14054,9 @@ be meaningless for it.
 The plist's `:vcs-state' is `ok' when both answered, `partial' when only
 the branch could be determined and `unavailable' when git couldn't
 answer at all (not installed, no commits yet, a broken repository)."
-  (if-let* ((branch (projectile-dashboard--git
+  (if-let* ((branch (projectile--git
                      root "rev-parse" "--abbrev-ref" "HEAD")))
-      (let ((status (projectile-dashboard--git
+      (let ((status (projectile--git
                      root "status" "--porcelain" "--untracked-files=normal"
                      "--" "."))
             (modified 0)
@@ -14557,6 +14657,7 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "B s") #'projectile-bookmark-set)
     (define-key map (kbd "B j") #'projectile-bookmark-jump)
     (define-key map (kbd "B d") #'projectile-bookmark-delete)
+    (define-key map (kbd "C") #'projectile-find-changed-file)
     (define-key map (kbd "d") #'projectile-find-dir)
     (define-key map (kbd "D") #'projectile-dired)
     (define-key map (kbd "e") #'projectile-recentf)
@@ -14890,6 +14991,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("g" "file dwim" projectile-dispatch-find-file-dwim)
       ("a" "other file" projectile-dispatch-find-other-file)
       ("l" "file in dir" projectile-find-file-in-directory)
+      ("C" "changed file" projectile-find-changed-file)
       ("F" "file in known projects" projectile-find-file-in-known-projects)
       ("d" "dir" projectile-dispatch-find-dir)
       ("D" "dired" projectile-dispatch-dired)
@@ -15007,6 +15109,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
          ["Find directory" projectile-find-dir]
          ["Find file in directory" projectile-find-file-in-directory]
          ["Find file in subproject" projectile-find-file-in-subproject]
+         ["Find changed file" projectile-find-changed-file]
          ["Find other file" projectile-find-other-file]
          ["Find file of kind" projectile-find-file-of-kind]
          ["Jump between implementation file and test file" projectile-toggle-between-implementation-and-test]

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -773,4 +773,140 @@
       (expect (commandp (intern (format "projectile-%s-subproject" phase)))
               :to-be-truthy))))
 
+(describe "projectile-git-changed-files"
+  (defun projectile-changed-test--git (&rest args)
+    (apply #'call-process "git" nil nil nil args))
+
+  (defun projectile-changed-test--init ()
+    (projectile-changed-test--git "init" "-q")
+    (projectile-changed-test--git "config" "user.email" "t@t.dev")
+    (projectile-changed-test--git "config" "user.name" "T"))
+
+  (it "reports staged, unstaged and untracked files"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/" "project/committed.el" "project/edited.el" "project/staged.el")
+      (let* ((root (projectile-test-project-root))
+             (default-directory root))
+        (projectile-changed-test--init)
+        (projectile-changed-test--git "add" "-A")
+        (projectile-changed-test--git "commit" "-qm" "init")
+        (write-region ";; edited\n" nil "edited.el")
+        (write-region ";; staged\n" nil "staged.el")
+        (projectile-changed-test--git "add" "staged.el")
+        (write-region "" nil "untracked.el")
+        (spy-on 'projectile-project-vcs :and-return-value 'git)
+        (let ((files (projectile-git-changed-files root)))
+          (expect files :to-contain "edited.el")
+          (expect files :to-contain "staged.el")
+          (expect files :to-contain "untracked.el")
+          (expect files :not :to-contain "committed.el"))))))
+
+  (it "reports a rename once, by its new name"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/" "project/old-name.el")
+      (let* ((root (projectile-test-project-root))
+             (default-directory root))
+        (projectile-changed-test--init)
+        (projectile-changed-test--git "add" "-A")
+        (projectile-changed-test--git "commit" "-qm" "init")
+        (projectile-changed-test--git "mv" "old-name.el" "new-name.el")
+        (spy-on 'projectile-project-vcs :and-return-value 'git)
+        (let ((files (projectile-git-changed-files root)))
+          ;; the source path of a rename must not read as another changed file
+          (expect files :to-equal '("new-name.el")))))))
+
+  (it "lists every file under a new directory, not just the directory"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/" "project/committed.el")
+      (let* ((root (projectile-test-project-root))
+             (default-directory root))
+        (projectile-changed-test--init)
+        (projectile-changed-test--git "add" "-A")
+        (projectile-changed-test--git "commit" "-qm" "init")
+        (make-directory "fresh" t)
+        (write-region "" nil "fresh/a.el")
+        (write-region "" nil "fresh/b.el")
+        (spy-on 'projectile-project-vcs :and-return-value 'git)
+        (let ((files (projectile-git-changed-files root)))
+          (expect files :to-contain "fresh/a.el")
+          (expect files :to-contain "fresh/b.el"))))))
+
+  (it "compares against a base revision when given one"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("project/" "project/base.el")
+      (let* ((root (projectile-test-project-root))
+             (default-directory root))
+        (projectile-changed-test--init)
+        (projectile-changed-test--git "add" "-A")
+        (projectile-changed-test--git "commit" "-qm" "init")
+        (projectile-changed-test--git "branch" "-M" "main")
+        (projectile-changed-test--git "checkout" "-q" "-b" "feature")
+        (write-region ";; changed on the branch\n" nil "base.el")
+        (write-region "" nil "added.el")
+        (projectile-changed-test--git "add" "-A")
+        (projectile-changed-test--git "commit" "-qm" "work")
+        (spy-on 'projectile-project-vcs :and-return-value 'git)
+        (let ((files (projectile-git-changed-files root "main")))
+          (expect files :to-contain "base.el")
+          (expect files :to-contain "added.el"))
+        ;; and with no base, a clean tree has nothing to show
+        (expect (projectile-git-changed-files root) :to-be nil)))))
+
+  (it "translates paths when the project sits below the repository root"
+    (projectile-test-with-sandbox
+     (projectile-test-with-files
+      ("repo/" "repo/outside.el" "repo/sub/" "repo/sub/.projectile" "repo/sub/inside.el")
+      (let* ((repo (file-truename (expand-file-name "repo/")))
+             (default-directory repo))
+        (projectile-changed-test--init)
+        (projectile-changed-test--git "add" "-A")
+        (projectile-changed-test--git "commit" "-qm" "init")
+        (write-region ";; x\n" nil (expand-file-name "outside.el" repo))
+        (write-region ";; x\n" nil (expand-file-name "sub/inside.el" repo))
+        (spy-on 'projectile-project-vcs :and-return-value 'git)
+        (let* ((root (expand-file-name "sub/" repo))
+               (files (projectile-git-changed-files root)))
+          ;; git reports repo-relative paths; they must come back
+          ;; project-relative, and the file outside the project dropped
+          (expect files :to-equal '("inside.el")))))))
+
+  (it "returns nothing for a project that isn't under git"
+    (spy-on 'projectile-project-vcs :and-return-value 'hg)
+    (expect (projectile-git-changed-files "/proj/") :to-be nil)))
+
+(describe "projectile-find-changed-file"
+  (it "refuses outside a git project"
+    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    (spy-on 'projectile-project-vcs :and-return-value 'hg)
+    (expect (projectile-find-changed-file) :to-throw 'user-error))
+
+  (it "says so when nothing has changed"
+    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    (spy-on 'projectile-project-vcs :and-return-value 'git)
+    (spy-on 'projectile-git-changed-files :and-return-value nil)
+    (expect (projectile-find-changed-file) :to-throw 'user-error))
+
+  (it "visits the file picked from the changed ones"
+    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    (spy-on 'projectile-project-vcs :and-return-value 'git)
+    (spy-on 'projectile-git-changed-files :and-return-value '("a.el" "b.el"))
+    (spy-on 'projectile-completing-read :and-return-value "b.el")
+    (spy-on 'find-file)
+    (projectile-find-changed-file)
+    (expect 'find-file :to-have-been-called-with "/proj/b.el"))
+
+  (it "asks for a revision with a prefix argument"
+    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    (spy-on 'projectile-project-vcs :and-return-value 'git)
+    (spy-on 'projectile--read-git-ref :and-return-value "main")
+    (spy-on 'projectile-git-changed-files :and-return-value '("a.el"))
+    (spy-on 'projectile-completing-read :and-return-value "a.el")
+    (spy-on 'find-file)
+    (projectile-find-changed-file t)
+    (expect 'projectile-git-changed-files :to-have-been-called-with "/proj/" "main")))
+
 ;;; projectile-commands-test.el ends here

--- a/test/projectile-dashboard-test.el
+++ b/test/projectile-dashboard-test.el
@@ -147,7 +147,7 @@
     (spy-on 'projectile-project-vcs :and-return-value 'git)
     ;; Reaching the remote host at all is the thing under test.
     (spy-on 'hack-dir-local-variables-non-file-buffer)
-    (spy-on 'projectile-dashboard--git :and-call-fake
+    (spy-on 'projectile--git :and-call-fake
             (lambda (&rest _) (error "Must not shell out on a remote project")))
     (let* ((projectile--frecency-table (make-hash-table :test 'equal))
            (projectile-dashboard-sections '(vcs recent))
@@ -206,7 +206,7 @@
         (expect dashboard :to-match "3 modified, 1 untracked"))))
 
   (it "shows the branch alone when the status query failed"
-    (spy-on 'projectile-dashboard--git :and-call-fake
+    (spy-on 'projectile--git :and-call-fake
             (lambda (_root &rest args)
               (when (equal (car args) "rev-parse") "main\n")))
     (let ((status (projectile-dashboard--git-status "/tmp/p/")))
@@ -218,7 +218,7 @@
           (expect dashboard :to-match "unavailable")))))
 
   (it "does not pass off a detached HEAD as a branch"
-    (spy-on 'projectile-dashboard--git :and-call-fake
+    (spy-on 'projectile--git :and-call-fake
             (lambda (_root &rest args)
               (if (equal (car args) "rev-parse") "HEAD\n" "")))
     (expect (plist-get (projectile-dashboard--git-status "/tmp/p/") :branch)
@@ -226,13 +226,13 @@
 
   (it "scopes the status query to the project and takes no index lock"
     (spy-on 'process-file :and-return-value 0)
-    (projectile-dashboard--git "/tmp/p/" "status" "--porcelain")
+    (projectile--git "/tmp/p/" "status" "--porcelain")
     (expect (spy-calls-args-for 'process-file 0)
             :to-equal '("git" nil (t nil) nil "--no-optional-locks"
                         "status" "--porcelain"))
-    (spy-on 'projectile-dashboard--git :and-return-value "main\n")
+    (spy-on 'projectile--git :and-return-value "main\n")
     (projectile-dashboard--git-status "/tmp/p/")
-    (expect (spy-calls-args-for 'projectile-dashboard--git 1)
+    (expect (spy-calls-args-for 'projectile--git 1)
             :to-equal '("/tmp/p/" "status" "--porcelain"
                         "--untracked-files=normal" "--" ".")))
 
@@ -254,7 +254,7 @@
         (expect dashboard :not :to-match "branch"))))
 
   (it "counts modified and untracked entries out of the porcelain output"
-    (spy-on 'projectile-dashboard--git :and-call-fake
+    (spy-on 'projectile--git :and-call-fake
             (lambda (_root &rest args)
               (if (equal (car args) "rev-parse")
                   "main\n"
@@ -266,7 +266,7 @@
       (expect (plist-get status :untracked) :to-equal 1)))
 
   (it "reports git being unable to answer"
-    (spy-on 'projectile-dashboard--git :and-return-value nil)
+    (spy-on 'projectile--git :and-return-value nil)
     (expect (projectile-dashboard--git-status "/tmp/p/")
             :to-equal '(:vcs-state unavailable))
     (let ((projectile-dashboard-sections '(vcs)))


### PR DESCRIPTION
Jumping to a file you've been editing meant completing over every file in the
project. Git already knows the much shorter list, so `s-p C` completes over
that instead: staged, unstaged and untracked.

With a prefix argument it asks for a revision - completing over the project's
branches - and the candidates become everything that differs from it, plus
whatever isn't tracked yet. That's the "what did this branch touch" list.

Two things needed care, and both have specs against real git repositories
rather than canned output:

- Git reports porcelain and diff paths relative to the *repository* root
  regardless of where it ran. A project sitting below that root would have got
  paths that don't resolve, so they're translated and anything outside the
  project is dropped.
- A rename occupies two NUL-separated records - the new path and then the old
  one. Consuming them in step keeps the source path from reading as another
  changed file.

`--untracked-files=all` rather than the dashboard's `normal`, since here the
individual files under a new directory are the point.

The dashboard's git runner moves out of the dashboard so both can use it. It
was already shell-free and passing `--no-optional-locks`, so nothing about it
had to change.

One incidental fix: my first version of these specs wrote plain text into `.el`
files in `test/sandbox/`, which eldev then tries to *load* as test files on the
next run - the suite passed once and then failed. They write valid elisp now.