### PR TITLE
Don't let a corrupt known projects file take the projects with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New features
 
+- [#2135](https://github.com/bbatsov/projectile/pull/2135): Add `projectile-ignored-project-patterns`, the regexp-matching sibling of `projectile-ignored-projects` (exact paths) and `projectile-ignored-project-function` (a predicate), so keeping whole areas of a machine out of the known projects doesn't need a lambda.
 - [#2134](https://github.com/bbatsov/projectile/pull/2134): Add `projectile-find-changed-file` (`s-p C`), which completes over the files git reports as staged, unstaged or untracked - or, with a prefix argument, over everything that differs from a revision you pick.
 - [#2133](https://github.com/bbatsov/projectile/pull/2133): `projectile-doctor` findings you can act on now carry a button that does it - `[enable]` for a disabled `projectile-mode`, `[enable caching]` on a large uncached project, `[open dirconfig]` for a `.projectile` with prefix-less lines, `[edit .dir-locals.el]` for an undetected project type. Pressing one regenerates the report, so the finding answers for itself; findings Projectile can't act on stay plain advice.
 - [#2132](https://github.com/bbatsov/projectile/pull/2132): The dashboard gained a "Notable files" section linking the project's README, changelog, license, its type's own manifest and its `.projectile` (see `projectile-dashboard-link-files`), plus a count of its open buffers and a summary of the ignore rules in effect.
@@ -65,6 +66,8 @@
 - [#2099](https://github.com/bbatsov/projectile/pull/2099): Drop the standalone package headers (`Version`, `Package-Requires`) from `projectile-consult.el`, since the phantom `Package-Requires` made build tooling treat an in-package module as its own package.
 
 ### Bugs fixed
+
+- [#1927](https://github.com/bbatsov/projectile/issues/1927): A known projects file Projectile can't read is now moved aside with a `.corrupt` suffix and reported, instead of being read as an empty list - which made it look like another Emacs had removed every project, so the merge dropped the session's projects too and overwrote the file. Projectile also strips text properties when saving, since a propertized string whose properties don't read back is how the file gets corrupted in the first place.
 
 - [#2118](https://github.com/bbatsov/projectile/issues/2118): Fix `projectile-find-file` showing "Projectile is indexing" forever with `projectile-async-indexing` enabled: Projectile waited for the indexing process's sentinel, which Emacs doesn't guarantee to run while a command sits waiting on the process, and now collects the finished command's output itself instead (`projectile-async-index-sentinel-timeout`).
 - [#2097](https://github.com/bbatsov/projectile/issues/2097): Fix `projectile-compile-project` and `projectile-test-project` forgetting a command you edited at the prompt in a CMake project, where a command the project type registers as a function was never cached - the function's own answer still isn't, so a preset picker keeps prompting.

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -171,15 +171,29 @@ You can prevent certain projects from being added to the known projects list:
 (setq projectile-ignored-projects '("/tmp/" "~/.emacs.d/"))
 ----
 
-For more flexible filtering, set `projectile-ignored-project-function` to a
-predicate that receives a project root and returns non-nil if the project should
-be ignored:
+`projectile-ignored-project-patterns` takes regexps rather than exact paths,
+which is usually what you want for whole areas of a machine:
+
+[source,elisp]
+----
+;; Never remember anything under /tmp or in a Downloads directory
+(setq projectile-ignored-project-patterns '("\\`/tmp/" "/Downloads/"))
+----
+
+For anything the two lists can't express, set
+`projectile-ignored-project-function` to a predicate that receives a project
+root and returns non-nil if the project should be ignored:
 
 [source,elisp]
 ----
 ;; Ignore all remote (TRAMP) projects
 (setq projectile-ignored-project-function #'file-remote-p)
 ----
+
+NOTE: If Projectile can't read its known projects file - it has been seen
+happening when another package writes propertized strings into it - the file is
+moved aside with a `.corrupt` suffix and you get a warning, rather than the list
+being silently treated as empty and overwritten on the next save.
 
 === Automatic tracking
 

--- a/projectile.el
+++ b/projectile.el
@@ -1164,6 +1164,21 @@ synchronized with `projectile-known-projects-file'.")
   :type '(repeat :tag "Project list" directory)
   :package-version '(projectile . "0.11.0"))
 
+(defcustom projectile-ignored-project-patterns nil
+  "Regexps matching projects not to be added to `projectile-known-projects'.
+
+The pattern-matching sibling of `projectile-ignored-projects', which
+takes exact paths, and `projectile-ignored-project-function', which takes
+a predicate.  Each entry is matched against the project root with
+`string-match-p', so keeping the scratch areas of a machine out of the
+known projects is a line of configuration rather than a lambda:
+
+    (setq projectile-ignored-project-patterns
+          \\='(\"\\\\`/tmp/\" \"/Downloads/\"))"
+  :group 'projectile
+  :type '(repeat :tag "Regexps" regexp)
+  :package-version '(projectile . "3.4.0"))
+
 (defcustom projectile-ignored-project-function nil
   "Function to decide if a project is added to `projectile-known-projects'.
 
@@ -1172,7 +1187,8 @@ project root as argument and returns non-nil if the project is to
 be ignored or nil otherwise.
 
 This function is only called if the project is not listed in
-the variable `projectile-ignored-projects'.
+the variable `projectile-ignored-projects' and matches none of
+`projectile-ignored-project-patterns'.
 
 A suitable candidate would be `file-remote-p' to ignore remote
 projects."
@@ -12752,6 +12768,8 @@ that requiring exact paths is acceptable.  Local behavior is unchanged."
                           project-root
                         (file-truename project-root))))
     (or (member project-root (projectile-ignored-projects))
+        (seq-some (lambda (pattern) (string-match-p pattern project-root))
+                  projectile-ignored-project-patterns)
         (and (functionp projectile-ignored-project-function)
              (funcall projectile-ignored-project-function project-root)))))
 
@@ -12775,23 +12793,75 @@ This combines `projectile-add-known-project' and
 
 (defun projectile-load-known-projects ()
   "Load saved projects from `projectile-known-projects-file'.
-Also set `projectile-known-projects'."
-  (let ((data (projectile-unserialize projectile-known-projects-file)))
-    (setq projectile-known-projects
-          (if (proper-list-p data) data nil))
-    (unless (equal data projectile-known-projects)
-      (message "Warning: Projectile known projects file was corrupted, ignoring saved data"))
+Also set `projectile-known-projects'.
+
+An unreadable file is moved aside rather than silently overwritten on
+the next save, and the fact is reported - losing a list of projects
+built up over years to a stray byte is worse than being told about it."
+  (let ((data (projectile--read-known-projects-file)))
+    (if (eq data 'unreadable)
+        (progn
+          (projectile--quarantine-known-projects-file)
+          (setq projectile-known-projects nil))
+      (setq projectile-known-projects data))
     (setq projectile-known-projects-on-file
           (and (sequencep projectile-known-projects)
                (copy-sequence projectile-known-projects)))))
 
 (defun projectile-save-known-projects ()
-  "Save PROJECTILE-KNOWN-PROJECTS to PROJECTILE-KNOWN-PROJECTS-FILE."
-  (projectile-serialize projectile-known-projects
+  "Save PROJECTILE-KNOWN-PROJECTS to PROJECTILE-KNOWN-PROJECTS-FILE.
+Text properties are stripped on the way out: a propertized string
+serializes to `#(\"...\" 0 3 (face ...))\\=', whose properties can hold
+objects that don\\='t read back, which is how the file gets corrupted in
+the first place (see issue #1927)."
+  (projectile-serialize (mapcar (lambda (project)
+                                  ;; Anything that isn't a string is left
+                                  ;; alone: refusing to save at all would be
+                                  ;; a worse failure than the one being
+                                  ;; guarded against.
+                                  (if (stringp project)
+                                      (substring-no-properties project)
+                                    project))
+                                projectile-known-projects)
                         projectile-known-projects-file)
   (setq projectile-known-projects-on-file
         (and (sequencep projectile-known-projects)
              (copy-sequence projectile-known-projects))))
+
+(defun projectile--quarantine-known-projects-file ()
+  "Move an unreadable known projects file aside and say so.
+Returns non-nil when a file was moved.  Overwriting it would throw away
+whatever it holds, and merging against \"nothing\" would look exactly
+like every project having been removed elsewhere - so the file is kept
+under a `.corrupt\\=' name and the list carries on from memory."
+  (let ((file projectile-known-projects-file))
+    (when (file-exists-p file)
+      (let ((backup (concat file ".corrupt")))
+        (ignore-errors (rename-file file backup t))
+        (display-warning
+         'projectile
+         (format "Couldn't read %s, so it was moved to %s.  \
+Projectile is carrying on with the projects known to this session; \
+the file will be written afresh."
+                 file backup)
+         :warning)
+        t))))
+
+(defun projectile--read-known-projects-file ()
+  "Return the known projects on disk, or the symbol `unreadable\\='.
+Distinguishing the two matters: an absent file legitimately means no
+projects, while an unreadable one means the list on disk is unknown -
+and treating unknown as empty is how a corrupt file used to take the
+known projects with it (see issue #1927)."
+  (let ((file projectile-known-projects-file))
+    (cond
+     ((not (file-exists-p file)) nil)
+     (t (condition-case nil
+            (let ((data (with-temp-buffer
+                          (insert-file-contents file)
+                          (read (buffer-string)))))
+              (if (proper-list-p data) data 'unreadable))
+          (error 'unreadable))))))
 
 (defun projectile-merge-known-projects ()
   "Merge any change from `projectile-known-projects-file' and save to disk.
@@ -12799,17 +12869,24 @@ Also set `projectile-known-projects'."
 This enables multiple Emacs processes to make changes without
 overwriting each other's changes."
   (let* ((known-now projectile-known-projects)
+         (known-on-file-raw (projectile--read-known-projects-file))
+         (unreadable (eq known-on-file-raw 'unreadable))
          (known-on-last-sync projectile-known-projects-on-file)
-         (known-on-file
-          (let ((data (projectile-unserialize projectile-known-projects-file)))
-            (if (proper-list-p data) data nil)))
+         (known-on-file (if unreadable nil known-on-file-raw))
          (removed-after-sync (seq-difference known-on-last-sync known-now))
+         ;; An unreadable file says nothing about what another process
+         ;; removed.  Reading it as "nothing is on disk" is precisely how a
+         ;; corrupt file used to look like every project having been removed
+         ;; elsewhere, taking the session's list down with it (issue #1927).
          (removed-in-other-process
-          (seq-difference known-on-last-sync known-on-file))
+          (unless unreadable
+            (seq-difference known-on-last-sync known-on-file)))
          (result (seq-uniq
                   (seq-difference
                    (append known-now known-on-file)
                    (append removed-after-sync removed-in-other-process)))))
+    (when unreadable
+      (projectile--quarantine-known-projects-file))
     (setq projectile-known-projects result)
     (projectile-save-known-projects)))
 

--- a/test/projectile-known-projects-test.el
+++ b/test/projectile-known-projects-test.el
@@ -142,11 +142,10 @@
       (expect projectile-known-projects :to-equal '("~/b/" "~/project/")))))
 
 (describe "projectile-load-known-projects"
-  (it "loads known projects through serialization functions"
+  (it "loads known projects from the known projects file"
     (let ((projectile-known-projects-file (projectile-test-tmp-file-path)))
-      (spy-on 'projectile-unserialize :and-return-value '("a1" "a2"))
+      (spy-on 'projectile--read-known-projects-file :and-return-value '("a1" "a2"))
       (projectile-load-known-projects)
-      (expect 'projectile-unserialize :to-have-been-called-with projectile-known-projects-file)
       (expect projectile-known-projects :to-equal '("a1" "a2")))))
 
 (describe "projectile-merge-known-projects"
@@ -379,5 +378,99 @@
     ;; the switch is handed a directory-terminated root
     (expect 'projectile-switch-project-by-name
             :to-have-been-called-with "/tmp/some-project/")))
+
+(describe "a corrupted known projects file (#1927)"
+  (it "is moved aside rather than taken as an empty project list"
+    (projectile-test-with-temp-files ((file ".eld"))
+      (let ((projectile-known-projects-file file)
+            (projectile-known-projects nil)
+            (backup (concat file ".corrupt")))
+        (unwind-protect
+            (progn
+              ;; the shape helm-projectile used to leave behind: a
+              ;; propertized string whose properties don't read back
+              (write-region "(\"~/a/\" #(\"~/b/\" 0 5 (face #<subr foo>)))"
+                            nil file)
+              (projectile-load-known-projects)
+              ;; nothing was silently inherited from the unreadable file...
+              (expect projectile-known-projects :to-be nil)
+              ;; ...and its contents were kept rather than overwritten
+              (expect (file-exists-p backup) :to-be-truthy)
+              (expect (with-temp-buffer
+                        (insert-file-contents backup)
+                        (buffer-string))
+                      :to-match "~/a/"))
+          (dolist (f (list file backup))
+            (when (file-exists-p f) (delete-file f)))))))
+
+  (it "does not treat an unreadable file as every project having been removed"
+    ;; The bite of the old behaviour: a file that went bad after load looked
+    ;; like another Emacs had removed everything, so the merge dropped the
+    ;; session's projects too.
+    (projectile-test-with-temp-files ((file ".eld"))
+      (let ((projectile-known-projects-file file)
+            (backup (concat file ".corrupt")))
+        (unwind-protect
+            (progn
+              (projectile-serialize '("~/a/" "~/b/") file)
+              (projectile-load-known-projects)
+              (expect projectile-known-projects :to-equal '("~/a/" "~/b/"))
+              ;; something corrupts the file behind our back
+              (write-region "(\"~/a/\" #(garbage" nil file)
+              (projectile-merge-known-projects)
+              ;; the session's projects survive
+              (expect projectile-known-projects :to-contain "~/a/")
+              (expect projectile-known-projects :to-contain "~/b/")
+              (expect (file-exists-p backup) :to-be-truthy))
+          (dolist (f (list file backup))
+            (when (file-exists-p f) (delete-file f)))))))
+
+  (it "still reads a file that is merely absent as no projects"
+    (projectile-test-with-temp-files ((file ".eld"))
+      (let ((projectile-known-projects-file (concat file "-does-not-exist")))
+        (expect (projectile--read-known-projects-file) :to-be nil)
+        (projectile-load-known-projects)
+        (expect projectile-known-projects :to-be nil))))
+
+  (it "never writes propertized entries itself"
+    (projectile-test-with-temp-files ((file ".eld"))
+      (let ((projectile-known-projects-file file)
+            (projectile-known-projects
+             (list (propertize "~/a/" 'face 'bold) "~/b/")))
+        (projectile-save-known-projects)
+        (let ((written (with-temp-buffer
+                         (insert-file-contents file)
+                         (buffer-string))))
+          (expect written :not :to-match "#(")
+          (expect written :to-match "~/a/"))
+        ;; and it reads back cleanly
+        (expect (projectile--read-known-projects-file)
+                :to-equal '("~/a/" "~/b/"))))))
+
+(describe "projectile-ignored-project-patterns"
+  (it "keeps a matching project out of the known projects"
+    (let ((projectile-ignored-project-patterns '("/tmp/" "/Downloads/"))
+          (projectile-ignored-projects nil)
+          (projectile-ignored-project-function nil))
+      (expect (projectile-ignored-project-p "/tmp/scratch/") :to-be-truthy)
+      (expect (projectile-ignored-project-p "/home/me/Downloads/thing/")
+              :to-be-truthy)
+      (expect (projectile-ignored-project-p "/home/me/src/real/") :to-be nil)))
+
+  (it "leaves the exact list and the predicate working alongside it"
+    (let ((projectile-ignored-project-patterns '("/nope/"))
+          (projectile-ignored-projects (list (file-truename "/exact/")))
+          (projectile-ignored-project-function
+           (lambda (root) (string-suffix-p "generated/" root))))
+      (expect (projectile-ignored-project-p "/exact/") :to-be-truthy)
+      (expect (projectile-ignored-project-p "/x/generated/") :to-be-truthy)
+      (expect (projectile-ignored-project-p "/x/nope/y/") :to-be-truthy)
+      (expect (projectile-ignored-project-p "/x/fine/") :to-be nil)))
+
+  (it "is not consulted when it is empty"
+    (let ((projectile-ignored-project-patterns nil)
+          (projectile-ignored-projects nil)
+          (projectile-ignored-project-function nil))
+      (expect (projectile-ignored-project-p "/anything/") :to-be nil))))
 
 ;;; projectile-known-projects-test.el ends here


### PR DESCRIPTION
Reading #1927's thread turned up something more interesting than the feature I
went in for. The reporter's known projects file had been corrupted by another
package writing propertized strings into it, and the visible symptom was that
projects silently stopped being tracked.

The current code reads an unreadable file as an *empty list*. If the file goes
bad after load, that looks exactly like another Emacs having removed every
project, so the merge drops the session's projects too - and then writes the
result back over the file. A stray byte costs you a list built up over years.

So an unreadable file is now moved aside as `<file>.corrupt` and reported, and
it no longer contributes a removal list at all. `projectile-load-known-projects`
and `projectile-merge-known-projects` both go through one reader that tells
"absent" (legitimately no projects) apart from "unreadable" (we don't know).
Saving also strips text properties, so Projectile can't be the one writing a
file it won't read back.

The spec for the post-load case is what caught a hole in my own first attempt: I
neutralized `known-on-last-sync` but left `removed-in-other-process` still
computing against the empty list, so the projects were dropped anyway.

Then the feature I actually came for: `projectile-ignored-project-patterns`,
regexps sitting between the existing exact-path `projectile-ignored-projects`
and the `projectile-ignored-project-function` predicate. Keeping `/tmp` and
`Downloads` out of the known projects is a common enough want that it shouldn't
need a lambda.

Fixes #1927