### PR TITLE
Teach run-test-at-point four more languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### New features
 
+- [#2136](https://github.com/bbatsov/projectile/pull/2136): `projectile-run-test-at-point` now knows Ruby (RSpec and Minitest), Rust, Elixir and Java, on top of the Python, Go and JS/TS rules it shipped with.
+  - Ruby is written the same way whichever framework you use, so the project type picks the runner; Java's picks between Maven and Gradle, and takes the class name from the file.
+  - ExUnit can't select a test by name from the command line, so Elixir tests are addressed as `FILE:LINE`.
 - [#2135](https://github.com/bbatsov/projectile/pull/2135): Add `projectile-ignored-project-patterns`, the regexp-matching sibling of `projectile-ignored-projects` (exact paths) and `projectile-ignored-project-function` (a predicate), so keeping whole areas of a machine out of the known projects doesn't need a lambda.
 - [#2134](https://github.com/bbatsov/projectile/pull/2134): Add `projectile-find-changed-file` (`s-p C`), which completes over the files git reports as staged, unstaged or untracked - or, with a prefix argument, over everything that differs from a revision you pick.
 - [#2133](https://github.com/bbatsov/projectile/pull/2133): `projectile-doctor` findings you can act on now carry a button that does it - `[enable]` for a disabled `projectile-mode`, `[enable caching]` on a large uncached project, `[open dirconfig]` for a `.projectile` with prefix-less lines, `[edit .dir-locals.el]` for an undetected project type. Pressing one regenerates the report, so the finding answers for itself; findings Projectile can't act on stay plain advice.

--- a/doc/modules/ROOT/pages/tasks.adoc
+++ b/doc/modules/ROOT/pages/tasks.adoc
@@ -263,7 +263,30 @@ Out of the box the following languages are supported:
 | `js-ts-mode`, `typescript-ts-mode`, `tsx-ts-mode`
 | `it`/`test`/`describe` blocks (jest-style)
 | `npx jest FILE -t 'NAME'`
+
+| `ruby-ts-mode`
+| `it`/`describe` blocks (RSpec) and `test_`-prefixed methods (Minitest)
+| `bundle exec rspec FILE -e 'NAME'` or `bundle exec ruby -Itest FILE -n NAME`, whichever the project type calls for
+
+| `rust-ts-mode`
+| functions carrying a `#[test]` attribute
+| `cargo test -- --exact NAME`
+
+| `elixir-ts-mode`
+| `test`/`describe` blocks (ExUnit)
+| `mix test FILE:LINE`
+
+| `java-ts-mode`
+| methods annotated `@Test` (also `@ParameterizedTest`, `@RepeatedTest`)
+| `mvn test -Dtest=Class#NAME`, or the `./gradlew --tests` form in a Gradle project
 |===
+
+A few of these are decided at run time rather than by major mode. Ruby is
+written the same way whichever framework you use, so the project type picks
+between RSpec and Minitest; Java's is picked the same way between Maven and
+Gradle, and the class name comes from the file, since Java requires them to
+match. ExUnit has no way to select a test by name from the command line, so
+Elixir tests are addressed by line instead.
 
 The command runs from the same directory as `projectile-test-project`
 (normally the project root), with the same buffer-saving behavior, but

--- a/projectile.el
+++ b/projectile.el
@@ -113,6 +113,7 @@
 (declare-function treesit-node-type "treesit.c")
 (declare-function treesit-node-child "treesit.c")
 (declare-function treesit-node-child-by-field-name "treesit.c")
+(declare-function treesit-node-prev-sibling "treesit.c")
 (declare-function treesit-node-text "treesit")
 
 

--- a/projectile.el
+++ b/projectile.el
@@ -12029,6 +12029,116 @@ interpolation would let a hostile project inject shell code."
           (shell-quote-argument file-name)
           (shell-quote-argument test-name)))
 
+(defun projectile-test-at-point-ruby-name (node)
+  "Return the test name for the Ruby NODE at point.
+Handles both dialects: an RSpec `it'/`describe' call whose first
+argument is a string, and a Minitest `def test_foo' method."
+  (pcase (treesit-node-type node)
+    ("method"
+     (when-let* ((name-node (treesit-node-child-by-field-name node "name"))
+                 (name (treesit-node-text name-node t)))
+       (when (string-prefix-p "test_" name)
+         name)))
+    ((or "call" "method_call")
+     (when-let* ((method (treesit-node-child-by-field-name node "method"))
+                 (method-name (treesit-node-text method t)))
+       (when (member method-name '("it" "describe" "context" "specify"))
+         (when-let* ((args (treesit-node-child-by-field-name node "arguments"))
+                     (arg (treesit-node-child args 0 t)))
+           (when (equal (treesit-node-type arg) "string")
+             ;; Strip the surrounding quotes.
+             (let ((text (treesit-node-text arg t)))
+               (if (> (length text) 1) (substring text 1 -1) text)))))))))
+
+(defun projectile-test-at-point-ruby-command (test-name file-name)
+  "Return a command running Ruby\\='s TEST-NAME in FILE-NAME.
+
+Which runner to use is decided by the project type rather than by the
+buffer, since both dialects are written in the same major mode: an
+`rspec\\=' project gets `rspec -e\\=', anything else the Minitest
+invocation.  TEST-NAME and FILE-NAME are shell-quoted, as a test name is
+arbitrary source text."
+  (if (memq (projectile-project-type) '(rails-rspec ruby-rspec))
+      (format "bundle exec rspec %s -e %s"
+              (shell-quote-argument file-name)
+              (shell-quote-argument test-name))
+    (format "bundle exec ruby -Itest %s -n %s"
+            (shell-quote-argument file-name)
+            (shell-quote-argument test-name))))
+
+(defun projectile-test-at-point-rust-name (node)
+  "Return the test name for the Rust `function_item' NODE.
+Return nil unless the function carries a `#[test]\\=' (or
+`#[tokio::test]\\=', and friends) attribute, since an ordinary function
+isn\\='t something `cargo test\\=' would run."
+  (when-let* ((name-node (treesit-node-child-by-field-name node "name"))
+              (name (treesit-node-text name-node t)))
+    ;; Attributes are siblings preceding the function item.
+    (let ((sibling (treesit-node-prev-sibling node))
+          (test nil))
+      (while (and sibling
+                  (equal (treesit-node-type sibling) "attribute_item"))
+        (when (string-match-p "\\_<test\\_>" (treesit-node-text sibling t))
+          (setq test t))
+        (setq sibling (treesit-node-prev-sibling sibling)))
+      (when test name))))
+
+(defun projectile-test-at-point-rust-command (test-name _file-name)
+  "Return a `cargo test\\=' command running TEST-NAME.
+Cargo selects tests by name filter rather than by file, so the file
+isn\\='t part of the command.  `--\\=' separates the filter from cargo\\='s own
+arguments and `--exact\\=' keeps a short name from also matching longer
+ones."
+  (format "cargo test -- --exact %s" (shell-quote-argument test-name)))
+
+(defun projectile-test-at-point-elixir-name (node)
+  "Return the test name for the Elixir `call' NODE.
+Matches an ExUnit `test\\='/`describe\\=' call whose first argument is a
+string."
+  (when-let* ((target (treesit-node-child-by-field-name node "target"))
+              (target-name (treesit-node-text target t)))
+    (when (member target-name '("test" "describe"))
+      (when-let* ((args (treesit-node-child-by-field-name node "arguments"))
+                  (arg (treesit-node-child args 0 t)))
+        (when (equal (treesit-node-type arg) "string")
+          (let ((text (treesit-node-text arg t)))
+            (if (> (length text) 1) (substring text 1 -1) text)))))))
+
+(defun projectile-test-at-point-elixir-command (_test-name file-name)
+  "Return a `mix test\\=' command running the test at point in FILE-NAME.
+
+ExUnit has no way to select a test by name from the command line, so it
+is addressed by line instead - the `FILE:LINE\\=' form.  The line is the
+one point is on, which is where the test was found in the first place."
+  (format "mix test %s"
+          (shell-quote-argument (format "%s:%d" file-name (line-number-at-pos)))))
+
+(defun projectile-test-at-point-java-name (node)
+  "Return the test name for the Java `method_declaration' NODE.
+Return nil unless the method carries a `@Test\\=' annotation (JUnit\\='s
+`@ParameterizedTest\\=' and `@RepeatedTest\\=' count too)."
+  (when-let* ((name-node (treesit-node-child-by-field-name node "name"))
+              (name (treesit-node-text name-node t))
+              (modifiers (treesit-node-child node 0 t)))
+    (when (and (equal (treesit-node-type modifiers) "modifiers")
+               (string-match-p "@\\(Test\\|ParameterizedTest\\|RepeatedTest\\)\\_>"
+                               (treesit-node-text modifiers t)))
+      name)))
+
+(defun projectile-test-at-point-java-command (test-name file-name)
+  "Return a command running Java\\='s TEST-NAME from FILE-NAME.
+
+JUnit addresses a test as `Class#method\\=', and Java requires the public
+class to be named after its file, so the class comes from FILE-NAME.
+Gradle and Maven spell the selector differently, so the project type
+decides which one to emit."
+  (let ((class (file-name-base file-name)))
+    (if (memq (projectile-project-type) '(gradle gradlew))
+        (format "./gradlew test --tests %s"
+                (shell-quote-argument (format "%s.%s" class test-name)))
+      (format "mvn test -Dtest=%s"
+              (shell-quote-argument (format "%s#%s" class test-name))))))
+
 (defcustom projectile-test-at-point-rules
   (let ((jest-rule '(:node-types ("call_expression")
                      :name-fn projectile-test-at-point-jest-name
@@ -12043,7 +12153,24 @@ interpolation would let a hostile project inject shell code."
        :command-fn projectile-test-at-point-go-command)
       (js-ts-mode ,@jest-rule)
       (typescript-ts-mode ,@jest-rule)
-      (tsx-ts-mode ,@jest-rule)))
+      (tsx-ts-mode ,@jest-rule)
+      (ruby-ts-mode
+       ;; RSpec examples are calls, Minitest cases are methods.
+       :node-types ("call" "method_call" "method")
+       :name-fn projectile-test-at-point-ruby-name
+       :command-fn projectile-test-at-point-ruby-command)
+      (rust-ts-mode
+       :node-types ("function_item")
+       :name-fn projectile-test-at-point-rust-name
+       :command-fn projectile-test-at-point-rust-command)
+      (elixir-ts-mode
+       :node-types ("call")
+       :name-fn projectile-test-at-point-elixir-name
+       :command-fn projectile-test-at-point-elixir-command)
+      (java-ts-mode
+       :node-types ("method_declaration")
+       :name-fn projectile-test-at-point-java-name
+       :command-fn projectile-test-at-point-java-command)))
   "Rules telling `projectile-run-test-at-point' how to run a single test.
 
 An alist keyed by major mode symbol.  The current buffer's mode is

--- a/test/projectile-test-at-point-test.el
+++ b/test/projectile-test-at-point-test.el
@@ -50,7 +50,9 @@
                 (cdr (assoc field (plist-get node :fields)))))
              ((symbol-function 'treesit-node-child)
               (lambda (node n &optional _named)
-                (nth n (plist-get node :children)))))
+                (nth n (plist-get node :children))))
+             ((symbol-function 'treesit-node-prev-sibling)
+              (lambda (node &optional _named) (plist-get node :prev))))
      ,@body))
 
 (defun projectile-tap--function-node (type name)
@@ -339,5 +341,130 @@
       (expect (hash-table-count projectile-project-command-history) :to-equal 0))))
 
 (provide 'projectile-test-at-point-test)
+
+(describe "Ruby test-at-point"
+  (it "names an RSpec example by its description"
+    (projectile-tap--with-fake-treesit nil
+      (let ((node (list :type "call"
+                        :fields
+                        (list (cons "method" (list :type "identifier" :text "it"))
+                              (cons "arguments"
+                                    (list :type "argument_list"
+                                          :children
+                                          (list (list :type "string"
+                                                      :text "\"adds to the cart\""))))))))
+        (expect (projectile-test-at-point-ruby-name node)
+                :to-equal "adds to the cart"))))
+
+  (it "names a Minitest case by its method"
+    (projectile-tap--with-fake-treesit nil
+      (let ((node (projectile-tap--function-node "method" "test_adds_to_the_cart")))
+        (expect (projectile-test-at-point-ruby-name node)
+                :to-equal "test_adds_to_the_cart"))))
+
+  (it "ignores a method that isn't a test"
+    (projectile-tap--with-fake-treesit nil
+      (let ((node (projectile-tap--function-node "method" "helper")))
+        (expect (projectile-test-at-point-ruby-name node) :to-be nil))))
+
+  (it "ignores a call that isn't an example"
+    (projectile-tap--with-fake-treesit nil
+      (let ((node (list :type "call"
+                        :fields
+                        (list (cons "method" (list :type "identifier" :text "puts"))
+                              (cons "arguments"
+                                    (list :type "argument_list"
+                                          :children
+                                          (list (list :type "string" :text "\"hi\""))))))))
+        (expect (projectile-test-at-point-ruby-name node) :to-be nil))))
+
+  (it "runs rspec in an rspec project and minitest elsewhere"
+    (spy-on 'projectile-project-type :and-return-value 'rails-rspec)
+    (expect (projectile-test-at-point-ruby-command "adds it" "spec/cart_spec.rb")
+            :to-equal (format "bundle exec rspec spec/cart_spec.rb -e %s"
+                              (shell-quote-argument "adds it")))
+    (spy-on 'projectile-project-type :and-return-value 'rails-test)
+    (expect (projectile-test-at-point-ruby-command "test_adds" "test/cart_test.rb")
+            :to-equal "bundle exec ruby -Itest test/cart_test.rb -n test_adds"))
+
+  (it "quotes a name that would otherwise reach the shell"
+    (spy-on 'projectile-project-type :and-return-value 'ruby-rspec)
+    (expect (projectile-test-at-point-ruby-command "a; rm -rf /" "spec/a_spec.rb")
+            :not :to-match "; rm -rf /$")))
+
+(describe "Rust test-at-point"
+  (it "names a function carrying a #[test] attribute"
+    (projectile-tap--with-fake-treesit nil
+      (let ((node (append (projectile-tap--function-node "function_item" "adds_to_cart")
+                          (list :prev (list :type "attribute_item" :text "#[test]")))))
+        (expect (projectile-test-at-point-rust-name node) :to-equal "adds_to_cart"))))
+
+  (it "sees through the attributes stacked above a test"
+    (projectile-tap--with-fake-treesit nil
+      (let* ((test-attr (list :type "attribute_item" :text "#[test]"))
+             (ignore-attr (list :type "attribute_item" :text "#[ignore]"
+                                :prev test-attr))
+             (node (append (projectile-tap--function-node "function_item" "slow")
+                           (list :prev ignore-attr))))
+        (expect (projectile-test-at-point-rust-name node) :to-equal "slow"))))
+
+  (it "ignores a plain function"
+    (projectile-tap--with-fake-treesit nil
+      (let ((node (projectile-tap--function-node "function_item" "helper")))
+        (expect (projectile-test-at-point-rust-name node) :to-be nil))))
+
+  (it "selects the test by exact name, since cargo filters by substring"
+    (expect (projectile-test-at-point-rust-command "adds_to_cart" "src/cart.rs")
+            :to-equal "cargo test -- --exact adds_to_cart")))
+
+(describe "Elixir test-at-point"
+  (it "names a test by its description"
+    (projectile-tap--with-fake-treesit nil
+      (let ((node (list :type "call"
+                        :fields
+                        (list (cons "target" (list :type "identifier" :text "test"))
+                              (cons "arguments"
+                                    (list :type "arguments"
+                                          :children
+                                          (list (list :type "string"
+                                                      :text "\"adds to the cart\""))))))))
+        (expect (projectile-test-at-point-elixir-name node)
+                :to-equal "adds to the cart"))))
+
+  (it "addresses the test by line, which is all ExUnit accepts"
+    (with-temp-buffer
+      (insert "defmodule CartTest do\n  test \"adds\" do\n  end\nend\n")
+      (goto-char (point-min))
+      (forward-line 1)
+      (expect (projectile-test-at-point-elixir-command "adds" "test/cart_test.exs")
+              :to-equal (format "mix test %s"
+                                (shell-quote-argument "test/cart_test.exs:2"))))))
+
+(describe "Java test-at-point"
+  (it "names a method annotated @Test"
+    (projectile-tap--with-fake-treesit nil
+      (let ((node (append (projectile-tap--function-node "method_declaration" "addsToCart")
+                          (list :children (list (list :type "modifiers"
+                                                      :text "@Test"))))))
+        (expect (projectile-test-at-point-java-name node) :to-equal "addsToCart"))))
+
+  (it "ignores a method without a test annotation"
+    (projectile-tap--with-fake-treesit nil
+      (let ((node (append (projectile-tap--function-node "method_declaration" "helper")
+                          (list :children (list (list :type "modifiers"
+                                                      :text "@Override"))))))
+        (expect (projectile-test-at-point-java-name node) :to-be nil))))
+
+  (it "addresses the test as Class#method, taking the class from the file"
+    (spy-on 'projectile-project-type :and-return-value 'maven)
+    (expect (projectile-test-at-point-java-command
+             "addsToCart" "src/test/java/CartTest.java")
+            :to-equal (format "mvn test -Dtest=%s"
+                              (shell-quote-argument "CartTest#addsToCart")))
+    (spy-on 'projectile-project-type :and-return-value 'gradlew)
+    (expect (projectile-test-at-point-java-command
+             "addsToCart" "src/test/java/CartTest.java")
+            :to-equal (format "./gradlew test --tests %s"
+                              (shell-quote-argument "CartTest.addsToCart")))))
 
 ;;; projectile-test-at-point-test.el ends here


### PR DESCRIPTION
Ruby, Rust, Elixir and Java join the Python, Go and JS/TS rules the feature
shipped with.

Three of them needed more than the `(name, file)` the rule contract hands to a
command function, and the ways round that are the interesting part:

- **Ruby** writes RSpec and Minitest in the same major mode, so one rule matches
  both an `it` block and a `test_`-prefixed method, and the *project type*
  decides whether to spell `rspec -e` or `ruby -Itest -n`.
- **Java** addresses a test as `Class#method`. Java requires the public class to
  be named after its file, so the class comes from the file name; the project
  type again picks between Maven's and Gradle's selector syntax.
- **ExUnit** has no way to select a test by name from the command line at all,
  so Elixir tests are addressed as `FILE:LINE`. The command function runs in the
  buffer with point still on the test, so the line is there for the taking.
- **Rust** needs the `#[test]` attribute to tell a test from an ordinary
  function, which means walking back over however many attributes are stacked
  above it - `#[ignore]` on top of `#[test]` still counts. The fake-treesit test
  harness grew `treesit-node-prev-sibling` for this.

All the specs use the existing fake-node harness, so they run without
tree-sitter or any grammar installed.

One thing the specs caught: I'd written the expected commands with shell
*quoting* (`-e 'adds it'`), but `shell-quote-argument` escapes (`-e adds\ it`).
The expectations go through `shell-quote-argument` now, which also keeps them
honest on a platform that quotes differently.

package-lint gains more "needs Emacs 29.1" notes for the treesit calls - the
same ones the existing rules already produce, and that step is report-only.
relint, the hard gate, stays clean.