### PR TITLE
Ship file-kinds tables for Phoenix, Laravel and Next.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### New features
 
+- [#2137](https://github.com/bbatsov/projectile/pull/2137): Ship `:file-kinds` tables for Phoenix, Laravel and Next.js, so `projectile-find-file-of-kind` (`s-p j`) and `projectile-toggle-related-file` (`s-p J`) work in those out of the box - Rails and Django were the only frameworks covered before.
+  - Phoenix keys a resource's modules on the name they share (`user_controller.ex`, `user_html.ex`, `user_live.ex`), Laravel on the model's class name, Next.js on the app router's directory.
+  - Adds a `nextjs` project type (`next.config.js` and friends) to hang the last of those on.
 - [#2136](https://github.com/bbatsov/projectile/pull/2136): `projectile-run-test-at-point` now knows Ruby (RSpec and Minitest), Rust, Elixir and Java, on top of the Python, Go and JS/TS rules it shipped with.
   - Ruby is written the same way whichever framework you use, so the project type picks the runner; Java's picks between Maven and Gradle, and takes the class name from the file.
   - ExUnit can't select a test by name from the command line, so Elixir tests are addressed as `FILE:LINE`.

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -202,6 +202,9 @@ are the configuration files of various build tools. Out of the box the following
 | `mkdocs`
 | `mkdocs.yml`
 
+| `nextjs`
+| `next.config.js` or `next.config.mjs` or `next.config.ts`
+
 | `nim-nimble`
 | `projectile-nimble-project-p` (predicate)
 
@@ -731,8 +734,8 @@ combined, so declarative and hand-written relations coexist.
 
 ==== Built-in examples
 
-The `rails-test`, `rails-rspec` and `django` project types ship with
-`:file-kinds` tables. Rails relates a resource's model, controller, views
+The `rails-test`, `rails-rspec`, `django`, `elixir` (Phoenix), `php-laravel`
+and `nextjs` project types ship with `:file-kinds` tables. Rails relates a resource's model, controller, views
 and helper by a shared singular key:
 
 [source,elisp]
@@ -751,7 +754,52 @@ English cases (a trailing `-ies` becomes `-y`, `-ses`/`-xes`/`-zes`/`-ches`/
 nouns (person/people, child/children) are not handled and would need a
 custom `:key-fn`.
 
-Django needs no inflection - all of an app's files live in the same
+The other four need no inflection, and between them they show the three shapes
+a key can take.
+
+Phoenix names a resource's modules after it but scatters them under a web
+directory named after the application, so the key is the base name with the
+role suffix removed and the directory ignored:
+
+[source,elisp]
+----
+;; lib/shop_web/controllers/user_controller.ex <-> :controller (key "user")
+;; lib/shop_web/controllers/user_html.ex       <-> :html       (key "user")
+;; lib/shop_web/live/user_live.ex              <-> :live       (key "user")
+----
+
+`:view` is the Phoenix 1.6 spelling that `:html` replaced in 1.7; a project
+will have one or the other.
+
+Laravel keys on the model's class name, which its companions are named after:
+
+[source,elisp]
+----
+;; app/Models/User.php                        <-> :model      (key "User")
+;; app/Http/Controllers/UserController.php    <-> :controller (key "User")
+;; database/factories/UserFactory.php         <-> :factory    (key "User")
+;; database/seeders/UserSeeder.php            <-> :seeder     (key "User")
+;; app/Policies/UserPolicy.php                <-> :policy     (key "User")
+----
+
+NOTE: Blade views are deliberately left out. They live in snake_case plural
+directories while the classes are StudlyCase singular, so relating them would
+need both inflection and case conversion, and would guess wrong often enough
+not to be worth it. Add them with a `:key-fn` of your own if your project is
+consistent about it.
+
+Next.js uses the app router's fixed file names in a shared directory, so the
+directory is the key - and each kind matches the name plus its dot, which
+covers `.js`, `.jsx`, `.ts` and `.tsx` alike:
+
+[source,elisp]
+----
+;; app/dashboard/page.tsx    <-> :page    (key "app/dashboard")
+;; app/dashboard/layout.tsx  <-> :layout  (key "app/dashboard")
+;; app/dashboard/loading.tsx <-> :loading (key "app/dashboard")
+----
+
+Django needs no inflection either - all of an app's files live in the same
 directory, so the key is simply that directory's name:
 
 [source,elisp]

--- a/projectile.el
+++ b/projectile.el
@@ -5539,6 +5539,118 @@ keys as \"apps/polls\" without colliding with a different \"polls\" app."
   (when-let* ((dir (file-name-directory rel-path)))
     (directory-file-name dir)))
 
+(defun projectile--parent-directory-key (rel-path)
+  "Return REL-PATH\\='s parent directory, without a trailing slash.
+A key for the frameworks that group a resource\\='s files in a directory
+rather than naming them after it, so \"polls/models.py\" keys as
+\"polls\" and a nested \"apps/polls/models.py\" as \"apps/polls\", without
+the two colliding."
+  (when-let* ((dir (file-name-directory rel-path)))
+    (directory-file-name dir)))
+
+(defalias 'projectile--django-app-key #'projectile--parent-directory-key
+  "Return the Django app directory of a path.
+An alias for `projectile--parent-directory-key\\=', kept because the
+Django reference table named it.")
+
+(defun projectile--basename-key (rel-path suffix)
+  "Return REL-PATH\\='s basename with SUFFIX removed, ignoring its directory.
+For the frameworks that name a resource\\='s files after it but scatter
+them across directories, so the directory can\\='t be part of the key."
+  (let ((name (file-name-nondirectory rel-path)))
+    (when (string-suffix-p suffix name)
+      (substring name 0 (- (length suffix))))))
+
+(defun projectile--phoenix-controller-key (rel-path)
+  "Return the Phoenix resource key of the controller REL-PATH."
+  (projectile--basename-key rel-path "_controller.ex"))
+
+(defun projectile--phoenix-html-key (rel-path)
+  "Return the Phoenix resource key of the HTML module REL-PATH."
+  (projectile--basename-key rel-path "_html.ex"))
+
+(defun projectile--phoenix-json-key (rel-path)
+  "Return the Phoenix resource key of the JSON module REL-PATH."
+  (projectile--basename-key rel-path "_json.ex"))
+
+(defun projectile--phoenix-view-key (rel-path)
+  "Return the Phoenix resource key of the view REL-PATH (Phoenix 1.6)."
+  (projectile--basename-key rel-path "_view.ex"))
+
+(defun projectile--phoenix-live-key (rel-path)
+  "Return the Phoenix resource key of the LiveView REL-PATH."
+  (projectile--basename-key rel-path "_live.ex"))
+
+(defvar projectile--phoenix-file-kinds
+  '((:controller . (:suffix "_controller.ex"
+                    :key-fn projectile--phoenix-controller-key))
+    (:html       . (:suffix "_html.ex"
+                    :key-fn projectile--phoenix-html-key))
+    (:json       . (:suffix "_json.ex"
+                    :key-fn projectile--phoenix-json-key))
+    (:view       . (:suffix "_view.ex"
+                    :key-fn projectile--phoenix-view-key))
+    (:live       . (:suffix "_live.ex"
+                    :key-fn projectile--phoenix-live-key)))
+  "Reference `:file-kinds\\=' table for Phoenix applications.
+Relates the modules of a resource by the name they share - user_controller.ex,
+user_html.ex, user_json.ex, user_live.ex - wherever under `lib/\\=' they
+live, since the web directory is named after the application.  `:view\\='
+is the Phoenix 1.6 spelling that `:html\\=' replaced in 1.7; a project
+will have one or the other.")
+
+(defun projectile--laravel-model-key (rel-path)
+  "Return the Laravel resource key of the model REL-PATH."
+  (projectile--basename-key rel-path ".php"))
+
+(defun projectile--laravel-controller-key (rel-path)
+  "Return the Laravel resource key of the controller REL-PATH."
+  (projectile--basename-key rel-path "Controller.php"))
+
+(defun projectile--laravel-factory-key (rel-path)
+  "Return the Laravel resource key of the factory REL-PATH."
+  (projectile--basename-key rel-path "Factory.php"))
+
+(defun projectile--laravel-seeder-key (rel-path)
+  "Return the Laravel resource key of the seeder REL-PATH."
+  (projectile--basename-key rel-path "Seeder.php"))
+
+(defun projectile--laravel-policy-key (rel-path)
+  "Return the Laravel resource key of the policy REL-PATH."
+  (projectile--basename-key rel-path "Policy.php"))
+
+(defvar projectile--laravel-file-kinds
+  '((:model      . (:path "app/Models/" :suffix ".php"
+                    :key-fn projectile--laravel-model-key))
+    (:controller . (:path "app/Http/Controllers/" :suffix "Controller.php"
+                    :key-fn projectile--laravel-controller-key))
+    (:factory    . (:path "database/factories/" :suffix "Factory.php"
+                    :key-fn projectile--laravel-factory-key))
+    (:seeder     . (:path "database/seeders/" :suffix "Seeder.php"
+                    :key-fn projectile--laravel-seeder-key))
+    (:policy     . (:path "app/Policies/" :suffix "Policy.php"
+                    :key-fn projectile--laravel-policy-key)))
+  "Reference `:file-kinds\\=' table for the Laravel project type.
+Relates the files named after an Eloquent model - User.php,
+UserController.php, UserFactory.php, UserSeeder.php, UserPolicy.php -
+by that class name.  Blade views are deliberately left out: they live in
+snake_case plural directories while the classes are StudlyCase singular,
+so relating them would need inflection and case conversion, and would
+guess wrong often enough not to be worth it.")
+
+(defvar projectile--nextjs-file-kinds
+  '((:page    . (:prefix "page." :key-fn projectile--parent-directory-key))
+    (:layout  . (:prefix "layout." :key-fn projectile--parent-directory-key))
+    (:loading . (:prefix "loading." :key-fn projectile--parent-directory-key))
+    (:error   . (:prefix "error." :key-fn projectile--parent-directory-key))
+    (:route   . (:prefix "route." :key-fn projectile--parent-directory-key)))
+  "Reference `:file-kinds\\=' table for Next.js applications.
+The app router gives a route\\='s files fixed names in a shared directory -
+page, layout, loading, error, route - so the directory is the key.  Each
+kind matches on the name plus its dot rather than a whole file name, so
+it covers whichever of .js, .jsx, .ts or .tsx the project uses without
+also matching something like `pageant.tsx\\='.")
+
 (defvar projectile--rails-file-kinds
   '((:model      . (:path "app/models/"))
     (:controller . (:path "app/controllers/"
@@ -6601,6 +6713,7 @@ a manual COMMAND-TYPE command is created with
                                   :test "rebar3 do eunit,ct"
                                   :test-suffix "_SUITE")
 (projectile-register-project-type 'elixir '("mix.exs")
+                                  :file-kinds projectile--phoenix-file-kinds
                                   :compile "mix compile"
                                   :src-dir "lib/"
                                   :test "mix test"
@@ -6661,6 +6774,14 @@ a manual COMMAND-TYPE command is created with
                                   :test-suffix ".spec")
 ;; JavaScript monorepo tools, which sit on top of one of the package
 ;; managers above and are what you actually build and test through.
+(projectile-register-project-type 'nextjs
+                                  '((:any "next.config.js" "next.config.mjs"
+                                          "next.config.ts"))
+                                  :compile "next build"
+                                  :test "npm test"
+                                  :run "next dev"
+                                  :test-suffix ".test"
+                                  :file-kinds projectile--nextjs-file-kinds)
 (projectile-register-project-type 'nx '("nx.json")
                                   :compile "npx nx run-many -t build"
                                   :test "npx nx run-many -t test"
@@ -6692,6 +6813,7 @@ a manual COMMAND-TYPE command is created with
                                   :test-dir "tests/"
                                   :test-suffix "Test")
 (projectile-register-project-type 'php-laravel '("composer.json" "artisan")
+                                  :file-kinds projectile--laravel-file-kinds
                                   :compile "composer install"
                                   :run "php artisan serve"
                                   :test "php artisan test"

--- a/test/projectile-file-kinds-test.el
+++ b/test/projectile-file-kinds-test.el
@@ -347,4 +347,137 @@
         (expect (functionp (projectile-related-files-fn 'sample-project)) :to-be-truthy)
         (expect (projectile--related-files-kinds "src/foo.c") :to-equal '(:doc))))))
 
+(describe "projectile--file-kind-match (Phoenix)"
+  (defun projectile-fk-test--phoenix (kind path)
+    (projectile--file-kind-match path (cdr (assq kind projectile--phoenix-file-kinds))))
+
+  (it "keys a resource's modules by the name they share"
+    (expect (projectile-fk-test--phoenix
+             :controller "lib/shop_web/controllers/user_controller.ex")
+            :to-equal "user")
+    (expect (projectile-fk-test--phoenix
+             :html "lib/shop_web/controllers/user_html.ex")
+            :to-equal "user")
+    (expect (projectile-fk-test--phoenix
+             :json "lib/shop_web/controllers/user_json.ex")
+            :to-equal "user")
+    (expect (projectile-fk-test--phoenix
+             :live "lib/shop_web/live/user_live.ex")
+            :to-equal "user"))
+
+  (it "ignores the directory, since the web dir is named after the app"
+    ;; Two projects, two different web directories, same key.
+    (expect (projectile-fk-test--phoenix
+             :controller "lib/other_app_web/controllers/user_controller.ex")
+            :to-equal "user"))
+
+  (it "still keys the Phoenix 1.6 view spelling"
+    (expect (projectile-fk-test--phoenix :view "lib/shop_web/views/user_view.ex")
+            :to-equal "user"))
+
+  (it "does not match an unrelated module"
+    (expect (projectile-fk-test--phoenix :controller "lib/shop/accounts.ex")
+            :to-be nil)))
+
+(describe "projectile--file-kind-match (Laravel)"
+  (defun projectile-fk-test--laravel (kind path)
+    (projectile--file-kind-match path (cdr (assq kind projectile--laravel-file-kinds))))
+
+  (it "keys the files named after a model by its class name"
+    (expect (projectile-fk-test--laravel :model "app/Models/User.php")
+            :to-equal "User")
+    (expect (projectile-fk-test--laravel
+             :controller "app/Http/Controllers/UserController.php")
+            :to-equal "User")
+    (expect (projectile-fk-test--laravel :factory "database/factories/UserFactory.php")
+            :to-equal "User")
+    (expect (projectile-fk-test--laravel :seeder "database/seeders/UserSeeder.php")
+            :to-equal "User")
+    (expect (projectile-fk-test--laravel :policy "app/Policies/UserPolicy.php")
+            :to-equal "User"))
+
+  (it "keeps a controller outside app/Http/Controllers out of the kind"
+    (expect (projectile-fk-test--laravel
+             :controller "vendor/pkg/Http/Controllers/UserController.php")
+            :to-be nil))
+
+  (it "does not confuse a model with a controller in the same tree"
+    (expect (projectile-fk-test--laravel :model "app/Models/Order.php")
+            :to-equal "Order")
+    (expect (projectile-fk-test--laravel
+             :controller "app/Http/Controllers/UserController.php")
+            :not :to-equal "Order")))
+
+(describe "projectile--file-kind-match (Next.js)"
+  (defun projectile-fk-test--nextjs (kind path)
+    (projectile--file-kind-match path (cdr (assq kind projectile--nextjs-file-kinds))))
+
+  (it "keys a route's files by their directory"
+    (expect (projectile-fk-test--nextjs :page "app/dashboard/page.tsx")
+            :to-equal "app/dashboard")
+    (expect (projectile-fk-test--nextjs :layout "app/dashboard/layout.tsx")
+            :to-equal "app/dashboard")
+    (expect (projectile-fk-test--nextjs :loading "app/dashboard/loading.tsx")
+            :to-equal "app/dashboard"))
+
+  (it "matches whichever extension the project uses"
+    (dolist (ext '("js" "jsx" "ts" "tsx"))
+      (expect (projectile-fk-test--nextjs :page (format "app/x/page.%s" ext))
+              :to-equal "app/x")))
+
+  (it "does not match a file that merely starts with the name"
+    (expect (projectile-fk-test--nextjs :page "app/x/pageant.tsx") :to-be nil)
+    (expect (projectile-fk-test--nextjs :error "app/x/errors.ts") :to-be nil))
+
+  (it "keeps nested routes distinct"
+    (expect (projectile-fk-test--nextjs :page "app/(shop)/cart/page.tsx")
+            :to-equal "app/(shop)/cart")
+    (expect (projectile-fk-test--nextjs :page "app/cart/page.tsx")
+            :to-equal "app/cart")))
+
+(describe "the new file-kinds tables end to end"
+  (it "relates a Phoenix controller to its html and live modules"
+    (let* ((fn (projectile--file-kinds-related-files-fn projectile--phoenix-file-kinds))
+           (plist (funcall fn "lib/shop_web/controllers/user_controller.ex")))
+      (expect (plist-member plist :controller) :to-equal nil)
+      (expect (funcall (plist-get plist :html)
+                       "lib/shop_web/controllers/user_html.ex")
+              :to-be-truthy)
+      (expect (funcall (plist-get plist :html)
+                       "lib/shop_web/controllers/product_html.ex")
+              :not :to-be-truthy)
+      (expect (funcall (plist-get plist :live) "lib/shop_web/live/user_live.ex")
+              :to-be-truthy)))
+
+  (it "relates a Laravel model to its controller and factory"
+    (let* ((fn (projectile--file-kinds-related-files-fn projectile--laravel-file-kinds))
+           (plist (funcall fn "app/Models/User.php")))
+      (expect (plist-member plist :model) :to-equal nil)
+      (expect (funcall (plist-get plist :controller)
+                       "app/Http/Controllers/UserController.php")
+              :to-be-truthy)
+      (expect (funcall (plist-get plist :controller)
+                       "app/Http/Controllers/OrderController.php")
+              :not :to-be-truthy)
+      (expect (funcall (plist-get plist :factory)
+                       "database/factories/UserFactory.php")
+              :to-be-truthy)))
+
+  (it "relates a Next.js page to the rest of its route"
+    (let* ((fn (projectile--file-kinds-related-files-fn projectile--nextjs-file-kinds))
+           (plist (funcall fn "app/dashboard/page.tsx")))
+      (expect (plist-member plist :page) :to-equal nil)
+      (expect (funcall (plist-get plist :layout) "app/dashboard/layout.tsx")
+              :to-be-truthy)
+      (expect (funcall (plist-get plist :layout) "app/settings/layout.tsx")
+              :not :to-be-truthy)))
+
+  (it "is wired into the project types that need it"
+    (expect (projectile-project-type-attribute 'elixir 'file-kinds)
+            :to-be projectile--phoenix-file-kinds)
+    (expect (projectile-project-type-attribute 'php-laravel 'file-kinds)
+            :to-be projectile--laravel-file-kinds)
+    (expect (projectile-project-type-attribute 'nextjs 'file-kinds)
+            :to-be projectile--nextjs-file-kinds)))
+
 ;;; projectile-file-kinds-test.el ends here


### PR DESCRIPTION
Rails and Django were the only frameworks with `:file-kinds` tables, which made
the feature look like a Rails special case rather than the general mechanism it
is. These three cover the other shapes a resource key can take:

- **Phoenix** names a resource's modules after it but scatters them under a web
  directory named for the application, so the key is the base name minus the
  role suffix, directory ignored: `user_controller.ex` <-> `user_html.ex` <->
  `user_live.ex`. `:view` is the 1.6 spelling `:html` replaced in 1.7; a project
  has one or the other.
- **Laravel** keys on the model's class name, which its companions are named
  after: `User.php` <-> `UserController.php` <-> `UserFactory.php` <->
  `UserSeeder.php` <-> `UserPolicy.php`.
- **Next.js** uses the app router's fixed names in a shared directory, so the
  directory is the key.

None of them needs inflection, so none inherits the fragility of the Rails
tables. Two deliberate omissions:

- Laravel's Blade views. They live in snake_case plural directories while the
  classes are StudlyCase singular, so relating them needs both inflection and
  case conversion and would guess wrong often enough to be worse than nothing.
- Test files anywhere. Projectile already relates implementations and tests
  through `:test-prefix`/`:test-suffix`; duplicating that here would be two
  mechanisms answering the same question.

Next.js gets a project type (`next.config.js` and friends, registered after the
package managers so it wins) to hang its table on. Its kinds match the file name
*plus its dot* rather than a whole name, which covers `.js`, `.jsx`, `.ts` and
`.tsx` in one entry without also matching `pageant.tsx` - there's a spec for
that, since my first attempt used `:suffix "page"`, which matches nothing at all
because the basename ends in the extension.

The generated project types table in the manual is regenerated for the new type.