### PR TITLE
Support OCaml, Erlang and F# properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### New features
 
+- [#2138](https://github.com/bbatsov/projectile/pull/2138): Better support for OCaml, Erlang and F#.
+  - `projectile-run-test-at-point` learns `erlang-ts-mode` (EUnit's `_test`/`_test_` functions, run as `rebar3 eunit --test=module:name`) and `fsharp-ts-mode` (bindings attributed `[<Fact>]`, `[<Theory>]`, `[<Test>]`, `[<TestCase>]` or `[<Property>]`, run through `dotnet test --filter`).
+  - The `ocaml-dune` and `rebar` project types gained their run, install, package and source/test directory attributes, and a new `erlang-mk` type covers the other common Erlang build tool.
+  - OCaml deliberately gets no test-at-point rule: its tests are ordinary values registered with Alcotest or OUnit rather than anything the syntax marks out, so there is nothing to recognize.
 - [#2137](https://github.com/bbatsov/projectile/pull/2137): Ship `:file-kinds` tables for Phoenix, Laravel and Next.js, so `projectile-find-file-of-kind` (`s-p j`) and `projectile-toggle-related-file` (`s-p J`) work in those out of the box - Rails and Django were the only frameworks covered before.
   - Phoenix keys a resource's modules on the name they share (`user_controller.ex`, `user_html.ex`, `user_live.ex`), Laravel on the model's class name, Next.js on the app router's directory.
   - Adds a `nextjs` project type (`next.config.js` and friends) to hang the last of those on.

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -118,6 +118,9 @@ are the configuration files of various build tools. Out of the box the following
 | `emacs-eldev`
 | `projectile-eldev-project-p` (predicate)
 
+| `erlang-mk`
+| `erlang.mk`
+
 | `flutter`
 | `projectile-flutter-project-p` (predicate)
 

--- a/doc/modules/ROOT/pages/tasks.adoc
+++ b/doc/modules/ROOT/pages/tasks.adoc
@@ -279,6 +279,14 @@ Out of the box the following languages are supported:
 | `java-ts-mode`
 | methods annotated `@Test` (also `@ParameterizedTest`, `@RepeatedTest`)
 | `mvn test -Dtest=Class#NAME`, or the `./gradlew --tests` form in a Gradle project
+
+| `erlang-ts-mode`
+| functions whose name ends in `_test` or `_test_` (EUnit)
+| `rebar3 eunit --test=module:NAME`
+
+| `fsharp-ts-mode`
+| bindings attributed `[<Fact>]`, `[<Theory>]`, `[<Test>]`, `[<TestCase>]` or `[<Property>]`
+| `dotnet test --filter FullyQualifiedName~NAME`
 |===
 
 A few of these are decided at run time rather than by major mode. Ruby is
@@ -286,7 +294,9 @@ written the same way whichever framework you use, so the project type picks
 between RSpec and Minitest; Java's is picked the same way between Maven and
 Gradle, and the class name comes from the file, since Java requires them to
 match. ExUnit has no way to select a test by name from the command line, so
-Elixir tests are addressed by line instead.
+Elixir tests are addressed by line instead. Erlang takes the module from the
+file name, the way EUnit addresses a test, and F# unwraps a name written
+between double backticks, since that is what the test framework sees.
 
 The command runs from the same directory as `projectile-test-project`
 (normally the project root), with the same buffer-saving behavior, but

--- a/projectile.el
+++ b/projectile.el
@@ -114,6 +114,7 @@
 (declare-function treesit-node-child "treesit.c")
 (declare-function treesit-node-child-by-field-name "treesit.c")
 (declare-function treesit-node-prev-sibling "treesit.c")
+(declare-function treesit-node-children "treesit")
 (declare-function treesit-node-text "treesit")
 
 
@@ -6711,6 +6712,20 @@ a manual COMMAND-TYPE command is created with
 (projectile-register-project-type 'rebar '("rebar.config")
                                   :compile "rebar3 compile"
                                   :test "rebar3 do eunit,ct"
+                                  :run "rebar3 shell"
+                                  :install "rebar3 release"
+                                  :package "rebar3 tar"
+                                  :src-dir "src/"
+                                  :test-dir "test/"
+                                  :test-suffix "_SUITE")
+;; erlang.mk is the other common Erlang build tool; it drives everything
+;; through make, so the commands are make targets.
+(projectile-register-project-type 'erlang-mk '("erlang.mk")
+                                  :compile "make"
+                                  :test "make tests"
+                                  :run "make run"
+                                  :src-dir "src/"
+                                  :test-dir "test/"
                                   :test-suffix "_SUITE")
 (projectile-register-project-type 'elixir '("mix.exs")
                                   :file-kinds projectile--phoenix-file-kinds
@@ -7087,7 +7102,12 @@ a manual COMMAND-TYPE command is created with
 ;; OCaml
 (projectile-register-project-type 'ocaml-dune '("dune-project")
                                   :compile "dune build"
-                                  :test "dune runtest")
+                                  :test "dune runtest"
+                                  :run "dune exec"
+                                  :install "dune install"
+                                  :package "dune build @install"
+                                  :src-dir "lib/"
+                                  :test-dir "test/")
 
 ;; Zig
 ;; `build.zig' is the build script; `build.zig.zon' only shows up once a
@@ -12201,7 +12221,8 @@ isn\\='t something `cargo test\\=' would run."
           (test nil))
       (while (and sibling
                   (equal (treesit-node-type sibling) "attribute_item"))
-        (when (string-match-p "\\_<test\\_>" (treesit-node-text sibling t))
+        (when (projectile--test-at-point-annotated-p
+               (treesit-node-text sibling t) '("test"))
           (setq test t))
         (setq sibling (treesit-node-prev-sibling sibling)))
       (when test name))))
@@ -12244,8 +12265,9 @@ Return nil unless the method carries a `@Test\\=' annotation (JUnit\\='s
               (name (treesit-node-text name-node t))
               (modifiers (treesit-node-child node 0 t)))
     (when (and (equal (treesit-node-type modifiers) "modifiers")
-               (string-match-p "@\\(Test\\|ParameterizedTest\\|RepeatedTest\\)\\_>"
-                               (treesit-node-text modifiers t)))
+               (projectile--test-at-point-annotated-p
+                (treesit-node-text modifiers t)
+                '("Test" "ParameterizedTest" "RepeatedTest")))
       name)))
 
 (defun projectile-test-at-point-java-command (test-name file-name)
@@ -12261,6 +12283,73 @@ decides which one to emit."
                 (shell-quote-argument (format "%s.%s" class test-name)))
       (format "mvn test -Dtest=%s"
               (shell-quote-argument (format "%s#%s" class test-name))))))
+
+(defun projectile--test-at-point-annotated-p (text names)
+  "Return non-nil when TEXT mentions one of NAMES as a whole word.
+
+Deliberately not the symbol-boundary operators: those consult the
+buffer's syntax table, under which the `<' and `>' of an F# `[<Fact>]'
+count as part of the symbol, so the boundary never matches.  Bracketing
+on non-alphanumerics is the same test without the dependency."
+  (string-match-p
+   (format "\\(?:^\\|[^[:alnum:]_]\\)\\(?:%s\\)\\(?:$\\|[^[:alnum:]_]\\)"
+           (mapconcat #'regexp-quote names "\\|"))
+   text))
+
+(defun projectile-test-at-point-erlang-name (node)
+  "Return the test name for the Erlang `fun_decl\\=' NODE.
+EUnit picks up functions whose name ends in `_test\\=' (a plain test) or
+`_test_\\=' (a test generator), which is the only thing marking one out
+from any other function."
+  (when-let* ((clause (treesit-node-child-by-field-name node "clause"))
+              (name-node (treesit-node-child-by-field-name clause "name"))
+              (name (treesit-node-text name-node t)))
+    (when (or (string-suffix-p "_test" name)
+              (string-suffix-p "_test_" name))
+      name)))
+
+(defun projectile-test-at-point-erlang-command (test-name file-name)
+  "Return a `rebar3 eunit\\=' command running TEST-NAME from FILE-NAME.
+EUnit addresses a test as `module:function\\=', and an Erlang module is
+named after its file, so the module comes from FILE-NAME."
+  (format "rebar3 eunit --test=%s"
+          (shell-quote-argument
+           (format "%s:%s" (file-name-base file-name) test-name))))
+
+(defun projectile-test-at-point-fsharp-name (node)
+  "Return the test name for the F# `function_or_value_defn\\=' NODE.
+
+Return nil unless the binding carries a test attribute - xUnit\\='s
+`[<Fact>]\\=' or `[<Theory>]\\=', NUnit\\='s `[<Test>]\\=' or FsCheck\\='s
+`[<Property>]\\='.  The attributes are a sibling of the definition under
+its enclosing `declaration_expression\\=', not a child of it.
+
+A name written between double backticks - which is how F# tests usually
+get readable names - is returned without them, since that is what the
+test framework sees."
+  (when-let* ((parent (treesit-node-parent node))
+              ;; `attributes' is a positional child of the enclosing
+              ;; `declaration_expression', not a field of it.
+              (attributes
+               (seq-find (lambda (child)
+                           (equal (treesit-node-type child) "attributes"))
+                         (treesit-node-children parent t))))
+    (when (projectile--test-at-point-annotated-p
+           (treesit-node-text attributes t)
+           '("Fact" "Theory" "Test" "TestCase" "Property"))
+      (when-let* ((left (treesit-node-child node 0 t))
+                  (name (treesit-node-text (treesit-node-child left 0 t) t)))
+        (if (and (string-prefix-p "``" name) (string-suffix-p "``" name))
+            (substring name 2 -2)
+          name)))))
+
+(defun projectile-test-at-point-fsharp-command (test-name _file-name)
+  "Return a `dotnet test\\=' command running TEST-NAME.
+The .NET test runners select by a filter expression rather than by file,
+so the file plays no part.  `FullyQualifiedName~\\=' matches on a
+substring, which keeps the filter working without the namespace."
+  (format "dotnet test --filter %s"
+          (shell-quote-argument (format "FullyQualifiedName~%s" test-name))))
 
 (defcustom projectile-test-at-point-rules
   (let ((jest-rule '(:node-types ("call_expression")
@@ -12293,7 +12382,15 @@ decides which one to emit."
       (java-ts-mode
        :node-types ("method_declaration")
        :name-fn projectile-test-at-point-java-name
-       :command-fn projectile-test-at-point-java-command)))
+       :command-fn projectile-test-at-point-java-command)
+      (erlang-ts-mode
+       :node-types ("fun_decl")
+       :name-fn projectile-test-at-point-erlang-name
+       :command-fn projectile-test-at-point-erlang-command)
+      (fsharp-ts-mode
+       :node-types ("function_or_value_defn")
+       :name-fn projectile-test-at-point-fsharp-name
+       :command-fn projectile-test-at-point-fsharp-command)))
   "Rules telling `projectile-run-test-at-point' how to run a single test.
 
 An alist keyed by major mode symbol.  The current buffer's mode is

--- a/test/projectile-test-at-point-test.el
+++ b/test/projectile-test-at-point-test.el
@@ -52,7 +52,9 @@
               (lambda (node n &optional _named)
                 (nth n (plist-get node :children))))
              ((symbol-function 'treesit-node-prev-sibling)
-              (lambda (node &optional _named) (plist-get node :prev))))
+              (lambda (node &optional _named) (plist-get node :prev)))
+             ((symbol-function 'treesit-node-children)
+              (lambda (node &optional _named) (plist-get node :children))))
      ,@body))
 
 (defun projectile-tap--function-node (type name)
@@ -466,5 +468,115 @@
              "addsToCart" "src/test/java/CartTest.java")
             :to-equal (format "./gradlew test --tests %s"
                               (shell-quote-argument "CartTest.addsToCart")))))
+
+(describe "projectile--test-at-point-annotated-p"
+  ;; `\_<'/`\_>' consult the syntax table, under which F#'s `[<Fact>]'
+  ;; has no symbol boundary around `Fact' - this is the replacement.
+  (it "matches a whole word whatever brackets it"
+    (expect (projectile--test-at-point-annotated-p "[<Fact>]" '("Fact"))
+            :to-be-truthy)
+    (expect (projectile--test-at-point-annotated-p "#[test]" '("test"))
+            :to-be-truthy)
+    (expect (projectile--test-at-point-annotated-p "@Test" '("Test"))
+            :to-be-truthy))
+
+  (it "does not match a longer word containing one of the names"
+    (expect (projectile--test-at-point-annotated-p "[<Factory>]" '("Fact"))
+            :to-be nil)
+    (expect (projectile--test-at-point-annotated-p "#[testable]" '("test"))
+            :to-be nil))
+
+  (it "picks the right alternative when one name prefixes another"
+    (expect (projectile--test-at-point-annotated-p
+             "[<TestCase(1)>]" '("Test" "TestCase"))
+            :to-be-truthy)))
+
+(describe "Erlang test-at-point"
+  (it "names a function EUnit would pick up"
+    (projectile-tap--with-fake-treesit nil
+      (let ((node (list :type "fun_decl"
+                        :fields
+                        (list (cons "clause"
+                                    (list :type "function_clause"
+                                          :fields (list (cons "name"
+                                                              (list :type "atom"
+                                                                    :text "adds_item_test")))))))))
+        (expect (projectile-test-at-point-erlang-name node)
+                :to-equal "adds_item_test"))))
+
+  (it "names a test generator too"
+    (projectile-tap--with-fake-treesit nil
+      (let ((node (list :type "fun_decl"
+                        :fields
+                        (list (cons "clause"
+                                    (list :type "function_clause"
+                                          :fields (list (cons "name"
+                                                              (list :type "atom"
+                                                                    :text "adds_test_")))))))))
+        (expect (projectile-test-at-point-erlang-name node)
+                :to-equal "adds_test_"))))
+
+  (it "ignores an ordinary function"
+    (projectile-tap--with-fake-treesit nil
+      (let ((node (list :type "fun_decl"
+                        :fields
+                        (list (cons "clause"
+                                    (list :type "function_clause"
+                                          :fields (list (cons "name"
+                                                              (list :type "atom"
+                                                                    :text "helper")))))))))
+        (expect (projectile-test-at-point-erlang-name node) :to-be nil))))
+
+  (it "addresses the test as module:function, taking the module from the file"
+    (expect (projectile-test-at-point-erlang-command
+             "adds_item_test" "test/cart_tests.erl")
+            :to-equal (format "rebar3 eunit --test=%s"
+                              (shell-quote-argument "cart_tests:adds_item_test")))))
+
+(describe "F# test-at-point"
+  (defun projectile-fs-test--node (attr-text name)
+    "Return a fake F# defn node under a declaration carrying ATTR-TEXT."
+    (let* ((left (list :type "function_declaration_left"
+                       :children (list (list :type "identifier" :text name))))
+           (defn (list :type "function_or_value_defn" :children (list left)))
+           (parent (list :type "declaration_expression"
+                         :children (append
+                                    (when attr-text
+                                      (list (list :type "attributes"
+                                                  :text attr-text)))
+                                    (list defn)))))
+      (append defn (list :parent parent))))
+
+  (it "names a binding carrying a test attribute"
+    (projectile-tap--with-fake-treesit nil
+      (expect (projectile-test-at-point-fsharp-name
+               (projectile-fs-test--node "[<Fact>]" "addsTwo"))
+              :to-equal "addsTwo")
+      (expect (projectile-test-at-point-fsharp-name
+               (projectile-fs-test--node "[<Theory>]" "addsMore"))
+              :to-equal "addsMore")))
+
+  (it "unwraps a name written between double backticks"
+    (projectile-tap--with-fake-treesit nil
+      (expect (projectile-test-at-point-fsharp-name
+               (projectile-fs-test--node "[<Fact>]" "``adds two numbers``"))
+              :to-equal "adds two numbers")))
+
+  (it "ignores a binding with no attributes at all"
+    (projectile-tap--with-fake-treesit nil
+      (expect (projectile-test-at-point-fsharp-name
+               (projectile-fs-test--node nil "helper"))
+              :to-be nil)))
+
+  (it "ignores a binding whose attribute isn't a test one"
+    (projectile-tap--with-fake-treesit nil
+      (expect (projectile-test-at-point-fsharp-name
+               (projectile-fs-test--node "[<Obsolete>]" "old"))
+              :to-be nil)))
+
+  (it "filters by name, since the .NET runners don't select by file"
+    (expect (projectile-test-at-point-fsharp-command "adds two" "Tests.fs")
+            :to-equal (format "dotnet test --filter %s"
+                              (shell-quote-argument "FullyQualifiedName~adds two")))))
 
 ;;; projectile-test-at-point-test.el ends here


### PR DESCRIPTION
Test-at-point rules for `erlang-ts-mode` and `fsharp-ts-mode`, plus fuller
project types for all three languages.

Both rules are written against the **real grammars**, not inferred: the F#
grammar was already installed here, and I installed the Erlang one and parsed
sample sources for both. That's how the F# rule got right that `attributes` is a
*positional sibling* of the definition under the enclosing
`declaration_expression`, rather than a field of it - my first attempt used
`treesit-node-child-by-field-name` and silently matched nothing.

It also turned up a latent trap in the Rust and Java rules from #2136. Both
tested for their attribute with `\_<`/`\_>`, which consult the buffer's syntax
table - and under it the `<` and `>` of F#'s `[<Fact>]` count as part of the
symbol, so the boundary never matches. It happened to work for `#[test]` and
`@Test`. All three now share one syntax-independent check, with specs for the
bracket forms and for not matching `[<Factory>]` when looking for `Fact`.

Erlang addresses a test as `module:function` and an Erlang module is named after
its file, so the module comes from the file name. F# unwraps a name written
between double backticks, which is how F# tests usually get readable names, and
filters with `FullyQualifiedName~` so the filter works without the namespace.

**OCaml gets no test-at-point rule, deliberately.** Its tests are ordinary values
handed to Alcotest or OUnit - nothing in the syntax marks one out, and `dune
runtest` runs the lot - so any rule would be guesswork dressed up as support.
The effort went into its project type instead: `dune exec`, `dune install`,
`dune build @install` and the source/test directories. `rebar` gained the same
treatment, and `erlang-mk` is a new type for the other common Erlang build tool.