### PR TITLE
Let a project type name its tests' extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 
 ### Bugs fixed
 
+- [#2142](https://github.com/bbatsov/projectile/pull/2142): Project types can declare `:src-extension` and `:test-extension`, for the languages whose tests don't carry the same extension as their sources. The bundled `elixir` type sets them, so toggling from `lib/foo.ex` now offers to create `test/foo_test.exs` - a script ExUnit will actually run - rather than `test/foo_test.ex`.
 - [#2141](https://github.com/bbatsov/projectile/pull/2141): The messages Projectile emits without being asked are now prefixed with `[Projectile]`, so it's clear where they came from; the ones that answer a command you just invoked stay unprefixed. Five different conventions across the file (a `Projectile:` prefix, a bare `Projectile` one, the project name in brackets, plain passthrough, and no prefix at all) become one rule.
   - The indexing notice follows the manual's `Operating...`/`Operating...done` idiom, so a long index no longer leaves the echo area claiming to still be working.
   - `projectile-project-info` reads `Project: /path/ (npm, git)` rather than separating its three fields with `##`.

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -373,6 +373,21 @@ What this does is:
 . add _run-command_, in this case it is `npm start`.
 . add test files suffix for toggling between implementation/test files, in this case it is `.spec`, so the implementation/test file pair could be `service.js`/`service.spec.js` for example.
 
+Some languages give their tests a different extension from their sources - an
+Elixir module in `lib/foo.ex` is tested by the script `test/foo_test.exs`. Say so
+with `:src-extension` and `:test-extension`, and toggling between the two will
+name the file it offers to create correctly:
+
+[source,elisp]
+----
+(projectile-update-project-type 'elixir
+                                :src-extension "ex"
+                                :test-extension "exs")
+----
+
+When a type says nothing about them, a test keeps the extension of the file it
+belongs to, which is what most languages want.
+
 Let's see a couple of more complex examples.
 
 [source,elisp]

--- a/projectile.el
+++ b/projectile.el
@@ -6095,7 +6095,7 @@ of its FILEs; see `projectile-register-project-type'."
   (and (consp marker) (eq (car marker) :any)))
 
 (cl-defun projectile--build-project-plist
-    (marker-files &key project-file compilation-dir configure compile install package test run test-suffix test-prefix src-dir test-dir related-files-fn file-kinds tasks)
+    (marker-files &key project-file compilation-dir configure compile install package test run test-suffix test-prefix src-dir test-dir src-extension test-extension related-files-fn file-kinds tasks)
   "Return a project type plist with the provided arguments.
 
 A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
@@ -6132,6 +6132,11 @@ TEST-SUFFIX which specifies test file suffix, and
 TEST-PREFIX which specifies test file prefix.
 SRC-DIR which specifies the path to the source relative to the project root.
 TEST-DIR which specifies the path to the tests relative to the project root.
+SRC-EXTENSION which specifies the file extension implementation files use,
+    when it differs from the one their tests use.
+TEST-EXTENSION which specifies the file extension test files use, when it
+    differs from the implementation's (Elixir tests are scripts: `foo.ex\\='
+    is tested by `foo_test.exs\\=').
 RELATED-FILES-FN which specifies a custom function to find the related
 files such as test/impl/other files as below:
     CUSTOM-FUNCTION accepts FILE as relative path from the project root and
@@ -6184,6 +6189,10 @@ TASKS an alist of named tasks of the form (TASK-NAME . COMMAND); see
       (plist-put project-plist 'src-dir src-dir))
     (when test-dir
       (plist-put project-plist 'test-dir test-dir))
+    (when src-extension
+      (plist-put project-plist 'src-extension src-extension))
+    (when test-extension
+      (plist-put project-plist 'test-extension test-extension))
     (when related-files-fn
       (plist-put project-plist 'related-files-fn related-files-fn))
     (when file-kinds
@@ -6193,7 +6202,7 @@ TASKS an alist of named tasks of the form (TASK-NAME . COMMAND); see
     project-plist))
 
 (cl-defun projectile-register-project-type
-    (project-type marker-files &key project-file compilation-dir configure compile install package test run test-suffix test-prefix src-dir test-dir related-files-fn file-kinds tasks)
+    (project-type marker-files &key project-file compilation-dir configure compile install package test run test-suffix test-prefix src-dir test-dir src-extension test-extension related-files-fn file-kinds tasks)
   "Register a project type with projectile.
 
 A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
@@ -6231,6 +6240,11 @@ TEST-SUFFIX which specifies test file suffix, and
 TEST-PREFIX which specifies test file prefix.
 SRC-DIR which specifies the path to the source relative to the project root.
 TEST-DIR which specifies the path to the tests relative to the project root.
+SRC-EXTENSION which specifies the file extension implementation files use,
+    when it differs from the one their tests use.
+TEST-EXTENSION which specifies the file extension test files use, when it
+    differs from the implementation's (Elixir tests are scripts: `foo.ex\\='
+    is tested by `foo_test.exs\\=').
 RELATED-FILES-FN which specifies a custom function to find the related
 files such as test/impl/other files as below:
     CUSTOM-FUNCTION accepts FILE as relative path from the project root and
@@ -6266,6 +6280,8 @@ with the project name at execution time."
                                 :test-prefix test-prefix
                                 :src-dir src-dir
                                 :test-dir test-dir
+                                :src-extension src-extension
+                                :test-extension test-extension
                                 :related-files-fn related-files-fn
                                 :file-kinds file-kinds
                                 :tasks tasks))
@@ -6287,6 +6303,8 @@ with the project name at execution time."
      (test-prefix nil test-prefix-specified)
      (src-dir nil src-dir-specified)
      (test-dir nil test-dir-specified)
+     (src-extension nil src-extension-specified)
+     (test-extension nil test-extension-specified)
      (related-files-fn nil related-files-fn-specified)
      (file-kinds nil file-kinds-specified)
      (tasks nil tasks-specified))
@@ -6323,6 +6341,8 @@ arguments - have the same meaning as for
              (when test-prefix-specified `(test-prefix ,test-prefix))
              (when src-dir-specified `(src-dir ,src-dir))
              (when test-dir-specified `(test-dir ,test-dir))
+             (when src-extension-specified `(src-extension ,src-extension))
+             (when test-extension-specified `(test-extension ,test-extension))
              (when related-files-fn-specified
                `(related-files-fn ,related-files-fn))
              (when file-kinds-specified `(file-kinds ,file-kinds))
@@ -6833,7 +6853,11 @@ a manual COMMAND-TYPE command is created with
                                   :compile "mix compile"
                                   :src-dir "lib/"
                                   :test "mix test"
-                                  :test-suffix "_test")
+                                  :test-suffix "_test"
+                                  ;; ExUnit tests are scripts, so `lib/foo.ex'
+                                  ;; is tested by `test/foo_test.exs'.
+                                  :src-extension "ex"
+                                  :test-extension "exs")
 ;; Gleam
 (projectile-register-project-type 'gleam '("gleam.toml")
                                   :compile "gleam build"
@@ -7448,10 +7472,14 @@ IMPL-FILE-PATH may be an absolute path, relative path or a file name."
          (impl-file-name (file-name-sans-extension (file-name-nondirectory impl-file-path)))
          (impl-file-ext (file-name-extension impl-file-path))
          (test-prefix (funcall projectile-test-prefix-function project-type))
-         (test-suffix (funcall projectile-test-suffix-function project-type)))
+         (test-suffix (funcall projectile-test-suffix-function project-type))
+         ;; A test usually carries the implementation's extension; a type
+         ;; that says otherwise (Elixir's scripts) is taken at its word.
+         (test-file-ext (or (projectile-test-extension project-type)
+                            impl-file-ext)))
     (cond
-     (test-prefix (concat test-prefix impl-file-name "." impl-file-ext))
-     (test-suffix (concat impl-file-name test-suffix "." impl-file-ext))
+     (test-prefix (concat test-prefix impl-file-name "." test-file-ext))
+     (test-suffix (concat impl-file-name test-suffix "." test-file-ext))
      (t (user-error "Cannot determine a test file name, one of \"test-suffix\" or \"test-prefix\" must be set for project type `%s'" project-type)))))
 
 (defun projectile--impl-name-for-test-name (test-file-path)
@@ -7462,12 +7490,14 @@ TEST-FILE-PATH may be an absolute path, relative path or a file name."
          (test-file-name (file-name-sans-extension (file-name-nondirectory test-file-path)))
          (test-file-ext (file-name-extension test-file-path))
          (test-prefix (funcall projectile-test-prefix-function project-type))
-         (test-suffix (funcall projectile-test-suffix-function project-type)))
+         (test-suffix (funcall projectile-test-suffix-function project-type))
+         (impl-file-ext (or (projectile-src-extension project-type)
+                            test-file-ext)))
     (cond
      (test-prefix
-      (concat (string-remove-prefix test-prefix test-file-name) "." test-file-ext))
+      (concat (string-remove-prefix test-prefix test-file-name) "." impl-file-ext))
      (test-suffix
-      (concat (string-remove-suffix test-suffix test-file-name) "." test-file-ext))
+      (concat (string-remove-suffix test-suffix test-file-name) "." impl-file-ext))
      (t (user-error "Cannot determine an implementation file name, one of \"test-suffix\" or \"test-prefix\" must be set for project type `%s'" project-type)))))
 
 (defun projectile--test-to-impl-dir (test-dir-path)
@@ -7635,6 +7665,19 @@ Fallback to DEFAULT-VALUE for missing attributes."
   "Find default test files suffix based on PROJECT-TYPE."
   (or projectile-project-test-suffix
       (projectile-project-type-attribute project-type 'test-suffix)))
+
+(defun projectile-test-extension (project-type)
+  "Find the extension test files use in PROJECT-TYPE, or nil.
+Nil means a test file carries the same extension as the implementation
+it belongs to, which is true of most languages - Elixir, whose tests are
+scripts (`.exs\\=') beside sources (`.ex\\='), is why this exists."
+  (projectile-project-type-attribute project-type 'test-extension))
+
+(defun projectile-src-extension (project-type)
+  "Find the extension implementation files use in PROJECT-TYPE, or nil.
+The counterpart of `projectile-test-extension\\=', for naming the
+implementation belonging to a test."
+  (projectile-project-type-attribute project-type 'src-extension))
 
 (defun projectile-related-files-fn (project-type)
   "Find relative file based on PROJECT-TYPE.

--- a/test/projectile-relation-test.el
+++ b/test/projectile-relation-test.el
@@ -702,4 +702,66 @@
     (expect (projectile-group-file-candidates "src/foo/test.el" nil)
             :to-equal nil)))
 
+(describe "test files with an extension of their own (#1686)"
+  :var ((elixir-types
+         '((elixir test-suffix "_test" src-extension "ex" test-extension "exs")
+           (plain  test-suffix "_test"))))
+
+  (it "names the test with the type's test extension"
+    ;; ExUnit tests are scripts: lib/foo.ex is tested by test/foo_test.exs,
+    ;; not test/foo_test.ex, which mix would not run.
+    (cl-letf (((symbol-function 'projectile-project-type) (lambda (&optional _d) 'elixir))
+              (projectile-project-types elixir-types))
+      (expect (projectile--test-name-for-impl-name "lib/foo.ex")
+              :to-equal "foo_test.exs")))
+
+  (it "names the implementation with the type's source extension"
+    (cl-letf (((symbol-function 'projectile-project-type) (lambda (&optional _d) 'elixir))
+              (projectile-project-types elixir-types))
+      (expect (projectile--impl-name-for-test-name "test/foo_test.exs")
+              :to-equal "foo.ex")))
+
+  (it "still mirrors the file's own extension for a type that says nothing"
+    (cl-letf (((symbol-function 'projectile-project-type) (lambda (&optional _d) 'plain))
+              (projectile-project-types elixir-types))
+      (expect (projectile--test-name-for-impl-name "src/foo.rb")
+              :to-equal "foo_test.rb")
+      (expect (projectile--impl-name-for-test-name "test/foo_test.rb")
+              :to-equal "foo.rb")))
+
+  (it "works with a test prefix as well as a suffix"
+    (cl-letf (((symbol-function 'projectile-project-type) (lambda (&optional _d) 'prefixed))
+              (projectile-project-types
+               '((prefixed test-prefix "test_" src-extension "ex"
+                          test-extension "exs"))))
+      (expect (projectile--test-name-for-impl-name "lib/foo.ex")
+              :to-equal "test_foo.exs")
+      (expect (projectile--impl-name-for-test-name "test/test_foo.exs")
+              :to-equal "foo.ex")))
+
+  (it "is declared by the bundled elixir project type"
+    (expect (projectile-test-extension 'elixir) :to-equal "exs")
+    (expect (projectile-src-extension 'elixir) :to-equal "ex")
+    ;; and round-trips through it
+    (cl-letf (((symbol-function 'projectile-project-type) (lambda (&optional _d) 'elixir)))
+      (expect (projectile--test-name-for-impl-name "lib/shop/cart.ex")
+              :to-equal "cart_test.exs")
+      (expect (projectile--impl-name-for-test-name "test/shop/cart_test.exs")
+              :to-equal "cart.ex")))
+
+  (it "can be registered and updated like the other attributes"
+    (let ((projectile-project-types projectile-project-types)
+          (projectile-project-root-files projectile-project-root-files))
+      (projectile-register-project-type 'ext-demo '("Extfile")
+                                        :test-suffix "_test"
+                                        :src-extension "a"
+                                        :test-extension "b")
+      (expect (projectile-test-extension 'ext-demo) :to-equal "b")
+      (expect (projectile-src-extension 'ext-demo) :to-equal "a")
+      (projectile-update-project-type 'ext-demo :test-extension "c")
+      (expect (projectile-test-extension 'ext-demo) :to-equal "c")
+      ;; nil clears it, like every other updatable attribute
+      (projectile-update-project-type 'ext-demo :test-extension nil)
+      (expect (projectile-test-extension 'ext-demo) :to-be nil))))
+
 ;;; projectile-relation-test.el ends here


### PR DESCRIPTION
Both directions of the implementation/test toggle took the extension from the
file they started with. So in a mix project, toggling from `lib/foo.ex` offered
to create `test/foo_test.ex` - which `mix test` will not run, ExUnit tests being
scripts. `:test-suffix` only reaches the part of the name before the extension,
as the reporter found.

`:src-extension` and `:test-extension` let a type say otherwise, and default to
the old behaviour when it doesn't - so nothing changes for the languages where a
test carries its implementation's extension, which is most of them. Both
directions are covered, since going back from `foo_test.exs` needs to know the
implementation is `.ex`.

The bundled `elixir` type sets them, so the toggle round-trips
`lib/foo.ex` <-> `test/foo_test.exs`. They register and update like every other
type attribute, `nil` clearing them as usual - there's a spec for that, and for
the prefix form as well as the suffix one.

Fixes #1686