### PR TITLE
Make the configuration options uniform and compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### Bugs fixed
 
+- [#2146](https://github.com/bbatsov/projectile/pull/2146): The default `projectile-globally-ignored-buffers` entries are matched as regexps, so `*scratch*` only matched by accident and `*scratchhh*` matched too; the asterisks are now escaped.
 - [#2146](https://github.com/bbatsov/projectile/pull/2146): `projectile-svn-command` filtered directories out of `svn list -R` with `grep -v '$/'`, where the `$` is a literal rather than an anchor, so it never dropped anything and svn projects listed their directories among their files.
 
 ## 3.3.0 (2026-07-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@
   - `projectile-report-copy` (`w` in either buffer) copies the buffer as plain text, without the faces and buttons - a doctor report usually ends up in an issue.
 - [#2130](https://github.com/bbatsov/projectile/pull/2130): `projectile-run-task` now also discovers rake tasks, read out of the project's `Rakefile` and its `.rake` files (in `rakelib`, `tasks` and `lib/tasks`) rather than by running `rake -T`, which would load the whole application. Tasks are qualified with their `namespace` (`rake:db:migrate`) and run through `bundle exec` when the project has a `Gemfile`.
 
+### Changes
+
+- [#2146](https://github.com/bbatsov/projectile/pull/2146): The six `projectile-<cmd>-use-comint-mode` options fold into one `projectile-use-comint-mode`, taking `t` or a list of the phases to make interactive.
+- [#2146](https://github.com/bbatsov/projectile/pull/2146): `projectile-per-project-compilation-buffer` and `projectile-per-command-compilation-buffer` fold into `projectile-compilation-buffer-scope`, a list of `project` and/or `command` - which is what setting both booleans already meant.
+- [#2146](https://github.com/bbatsov/projectile/pull/2146): Rename the options that broke their own naming schemes: `projectile-global-ignore-file-patterns` to `projectile-globally-ignored-file-regexps`, `projectile-cmd-hist-ignoredups` to `projectile-command-history-ignore-duplicates`, `projectile-related-files-fn-function` to `projectile-related-files-function`, `projectile-auto-discover` to `projectile-auto-discover-projects`, and the three reviewable-search options named after replace (`projectile-replace-max-matches`, `-async` and `-scan-chunk-size`) to the `projectile-search-` prefix their siblings already used.
+- [#2146](https://github.com/bbatsov/projectile/pull/2146): `projectile-tags-file-name` and `projectile-go-project-test-function` are obsolete; both were only ever read as Projectile loaded, so setting them from your init file afterwards did nothing. List the tags file in `projectile-globally-ignored-files`, and re-register the `go` project type to change how it's detected.
+- [#2146](https://github.com/bbatsov/projectile/pull/2146): Every renamed or folded option is still honored under its old name, so existing configuration keeps working.
+- [#2146](https://github.com/bbatsov/projectile/pull/2146): Make the options' Customize metadata uniform - seven options that document `nil` as meaningful had a `:type` that rejected it, so Customize refused to edit them, and the `:safe` predicates now cover all the ignore lists rather than four of the nine.
+
+### Bugs fixed
+
+- [#2146](https://github.com/bbatsov/projectile/pull/2146): `projectile-svn-command` filtered directories out of `svn list -R` with `grep -v '$/'`, where the `$` is a literal rather than an anchor, so it never dropped anything and svn projects listed their directories among their files.
+
 ## 3.3.0 (2026-07-27)
 
 ### New features

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -358,6 +358,9 @@ be qualified by:
 
 ;; *compilation*<my-project:test>
 (setq projectile-compilation-buffer-scope '(project command))
+
+;; the same, spelled shorter
+(setq projectile-compilation-buffer-scope t)
 ----
 
 All of these degrade properly when not inside a project. Running the test at

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -343,29 +343,30 @@ This affects all commands built on top of `projectile--run-project-cmd` like:
 - `projectile-package-project`
 
 Normally, the buffers created by those commands would be shared (overwritten)
-between projects, but it's also possible to make the compilation buffer names
-project-specific. This requires that the user set:
+between projects, and within a project they'd also overwrite each other since
+they all use `compilation-mode` - so running the tests discards the build
+output. `projectile-compilation-buffer-scope` says what the buffer name should
+be qualified by:
 
 [source,elisp]
 ----
-(setq projectile-per-project-compilation-buffer t)
+;; *compilation*<my-project>
+(setq projectile-compilation-buffer-scope '(project))
+
+;; *compilation*<test> and *compilation*<compile>
+(setq projectile-compilation-buffer-scope '(command))
+
+;; *compilation*<my-project:test>
+(setq projectile-compilation-buffer-scope '(project command))
 ----
 
-Both of these degrade properly when not inside a project.
-
-Within one project those commands still share a buffer, since they all use
-`compilation-mode` - so running the tests discards the build output. To keep
-them apart, name the buffer after the command as well:
-
-[source,elisp]
-----
-(setq projectile-per-command-compilation-buffer t)
-----
-
-That gives you `+*compilation*<test>+` and `+*compilation*<compile>+`, or
-`+*compilation*<my-project:test>+` with both options enabled. Running the test
-at point shares the test buffer. Named tasks already get a buffer each, named
+All of these degrade properly when not inside a project. Running the test at
+point shares the test buffer. Named tasks already get a buffer each, named
 after the task.
+
+NOTE: This replaces the older `projectile-per-project-compilation-buffer` and
+`projectile-per-command-compilation-buffer`, which are obsolete but still
+honored.
 
 == Limit the number of project file buffers
 

--- a/doc/modules/ROOT/pages/configuration_index.adoc
+++ b/doc/modules/ROOT/pages/configuration_index.adoc
@@ -53,14 +53,11 @@ and the other reference pages.
 | `projectile-cmd-hist-ignoredups`
 | Controls when inputs are added to projectile’s command history.
 
-| `projectile-compile-use-comint-mode`
-| Make the output buffer of ‘projectile-compile-project’ interactive.
+| `projectile-compilation-buffer-scope`
+| What a lifecycle command’s compilation buffer is named after.
 
 | `projectile-completion-system`
 | The completion system to be used by Projectile.
-
-| `projectile-configure-use-comint-mode`
-| Make the output buffer of ‘projectile-configure-project’ interactive.
 
 | `projectile-create-missing-test-files`
 | During toggling, if non-nil enables creating test files if not found.
@@ -70,6 +67,9 @@ and the other reference pages.
 
 | `projectile-darcs-command`
 | Command used by projectile to get the files in a darcs project.
+
+| `projectile-dashboard-link-files`
+| Base names the dashboard offers as links when the project has them.
 
 | `projectile-dashboard-recent-files`
 | How many recently visited files ‘projectile-dashboard’ lists.
@@ -99,7 +99,7 @@ and the other reference pages.
 | When t enables project files caching.
 
 | `projectile-enable-cmake-presets`
-| Enables configuration with CMake presets.
+| Whether CMake projects use presets for their lifecycle commands.
 
 | `projectile-enable-frecency`
 | When non-nil, rank project files by frecency in completion.
@@ -159,7 +159,7 @@ and the other reference pages.
 | A list of file regexp patterns ignored by Projectile.
 
 | `projectile-globally-ignored-buffers`
-| A list of buffer-names ignored by projectile.
+| A list of buffer names ignored by projectile.
 
 | `projectile-globally-ignored-directories`
 | A list of directories globally ignored by projectile.
@@ -194,20 +194,20 @@ and the other reference pages.
 | `projectile-ignored-project-function`
 | Function to decide if a project is added to ‘projectile-known-projects’.
 
+| `projectile-ignored-project-patterns`
+| Regexps matching projects not to be added to ‘projectile-known-projects’.
+
 | `projectile-ignored-projects`
 | A list of projects not to be added to ‘projectile-known-projects’.
 
 | `projectile-indexing-method`
 | Specifies the indexing method used by Projectile.
 
-| `projectile-install-use-comint-mode`
-| Make the output buffer of ‘projectile-install-project’ interactive.
-
 | `projectile-jj-command`
 | Command used by projectile to get the files in a Jujutsu project.
 
 | `projectile-keymap-prefix`
-| Projectile keymap prefix.
+| The key sequence ‘projectile-command-map’ is bound to, if any.
 
 | `projectile-kill-buffers-filter`
 | Determine which buffers are killed by ‘projectile-kill-buffers’.
@@ -231,16 +231,7 @@ and the other reference pages.
 | Mode line lighter prefix for Projectile.
 
 | `projectile-other-file-alist`
-| Alist of extensions for switching to file with the same name,
-
-| `projectile-package-use-comint-mode`
-| Make the output buffer of ‘projectile-package-project’ interactive.
-
-| `projectile-per-command-compilation-buffer`
-| When non-nil, each lifecycle command gets its own compilation buffer.
-
-| `projectile-per-project-compilation-buffer`
-| When non-nil, the compilation command makes the per-project compilation buffer.
+| Alist of extensions to try when switching to a file’s counterpart.
 
 | `projectile-pijul-command`
 | Command used by projectile to get the files in a pijul project.
@@ -283,9 +274,6 @@ and the other reference pages.
 
 | `projectile-require-project-root`
 | Require the presence of a project root to operate when true.
-
-| `projectile-run-use-comint-mode`
-| Make the output buffer of ‘projectile-run-project’ interactive.
 
 | `projectile-sapling-command`
 | Command used by projectile to get the files in a Sapling project.
@@ -371,17 +359,17 @@ and the other reference pages.
 | `projectile-test-suffix-function`
 | Function to find test files suffix based on PROJECT-TYPE.
 
-| `projectile-test-use-comint-mode`
-| Make the output buffer of ‘projectile-test-project’ interactive.
-
 | `projectile-todo-keywords`
 | Annotation keywords ‘projectile-todos’ collects across the project.
 
 | `projectile-track-known-projects-automatically`
 | Controls whether Projectile will automatically register known projects.
 
+| `projectile-use-comint-mode`
+| Which lifecycle commands get an interactive output buffer.
+
 | `projectile-use-git-grep`
-| If true, use ‘vc-git-grep’ in git projects.
+| Whether ‘projectile-grep’ delegates to ‘vc-git-grep’ in git projects.
 
 | `projectile-vcs-markers`
 | Alist of (MARKER . VCS) pairs probed by ‘projectile-project-vcs’.

--- a/doc/modules/ROOT/pages/configuration_index.adoc
+++ b/doc/modules/ROOT/pages/configuration_index.adoc
@@ -179,9 +179,6 @@ and the other reference pages.
 | `projectile-globally-unignored-files`
 | A list of files globally unignored by projectile.
 
-| `projectile-go-project-test-function`
-| Function to determine if project’s type is go.
-
 | `projectile-grep-finished-hook`
 | Hooks run when ‘projectile-grep’ finishes.
 
@@ -340,9 +337,6 @@ and the other reference pages.
 
 | `projectile-switch-project-other-window-action`
 | Action run by ‘projectile-switch-project-other-window’ after switching.
-
-| `projectile-tags-file-name`
-| The name of the tags file Projectile excludes from indexing.
 
 | `projectile-task-providers`
 | Functions that discover the tasks a project’s tooling defines.

--- a/doc/modules/ROOT/pages/configuration_index.adoc
+++ b/doc/modules/ROOT/pages/configuration_index.adoc
@@ -26,7 +26,7 @@ and the other reference pages.
 | `projectile-auto-cleanup-known-projects`
 | Whether to cleanup projects when project switching commands are invoked.
 
-| `projectile-auto-discover`
+| `projectile-auto-discover-projects`
 | Whether to discover projects under ‘projectile-project-search-path’.
 
 | `projectile-auto-update-cache`
@@ -50,7 +50,7 @@ and the other reference pages.
 | `projectile-cache-file`
 | The name of Projectile’s cache.
 
-| `projectile-cmd-hist-ignoredups`
+| `projectile-command-history-ignore-duplicates`
 | Controls when inputs are added to projectile’s command history.
 
 | `projectile-compilation-buffer-scope`
@@ -155,14 +155,14 @@ and the other reference pages.
 | `projectile-git-use-fd`
 | Non-nil means use fd to implement git ls-files.
 
-| `projectile-global-ignore-file-patterns`
-| A list of file regexp patterns ignored by Projectile.
-
 | `projectile-globally-ignored-buffers`
 | A list of buffer names ignored by projectile.
 
 | `projectile-globally-ignored-directories`
 | A list of directories globally ignored by projectile.
+
+| `projectile-globally-ignored-file-regexps`
+| A list of regexps matching files ignored by Projectile.
 
 | `projectile-globally-ignored-file-suffixes`
 | A list of file suffixes globally ignored by projectile.
@@ -260,17 +260,8 @@ and the other reference pages.
 | `projectile-project-search-path`
 | List of folders where projectile is automatically going to look for projects.
 
-| `projectile-related-files-fn-function`
+| `projectile-related-files-function`
 | Function to find related files based on PROJECT-TYPE.
-
-| `projectile-replace-async`
-| Whether the reviewable search/replace commands scan asynchronously.
-
-| `projectile-replace-max-matches`
-| Upper bound on how many matches ‘projectile-replace-review’ collects.
-
-| `projectile-replace-scan-chunk-size`
-| Number of candidate files scanned per async chunk before yielding.
 
 | `projectile-require-project-root`
 | Require the presence of a project root to operate when true.
@@ -278,8 +269,17 @@ and the other reference pages.
 | `projectile-sapling-command`
 | Command used by projectile to get the files in a Sapling project.
 
+| `projectile-search-async`
+| Whether the reviewable search/replace commands scan asynchronously.
+
 | `projectile-search-backend`
 | The backend ‘projectile-search’ uses to search the project.
+
+| `projectile-search-max-matches`
+| Upper bound on how many matches a review buffer collects.
+
+| `projectile-search-scan-chunk-size`
+| Number of candidate files scanned per async chunk before yielding.
 
 | `projectile-search-use-ripgrep`
 | Whether ‘projectile-search-review’ accelerates literal search with ripgrep.

--- a/doc/modules/ROOT/pages/ignoring.adoc
+++ b/doc/modules/ROOT/pages/ignoring.adoc
@@ -231,7 +231,7 @@ way to further adjust what you want to see in Projectile.
 
 In addition to per-project ignores, Projectile provides several variables for
 globally ignoring files and directories.  Except for
-`projectile-global-ignore-file-patterns` (see below) their entries are the
+`projectile-globally-ignored-file-regexps` (see below) their entries are the
 gitignore patterns described xref:pattern-language[above], and they take effect
 with every indexing method; under `alien` they are pushed down into the external
 indexing tool.
@@ -263,7 +263,7 @@ that project's `.projectile` to get it back for that project alone.
         "*.egg-info"))  ; any directory whose name ends in .egg-info
 ----
 
-`projectile-global-ignore-file-patterns` is the odd one out: its entries are
+`projectile-globally-ignored-file-regexps` is the odd one out: its entries are
 Emacs regexps, matched against absolute file names, not patterns. They can't be
 handed to an external tool or expressed as a glob, so they only apply under
 `native` indexing.
@@ -271,7 +271,7 @@ handed to an external tool or expressed as a glob, so they only apply under
 [source,elisp]
 ----
 ;; Ignore files matching regexp patterns (native indexing only)
-(setq projectile-global-ignore-file-patterns '("\\.min\\.js$" "\\.map$"))
+(setq projectile-globally-ignored-file-regexps '("\\.min\\.js$" "\\.map$"))
 ----
 
 NOTE: Before Projectile 3.3 a leading `*` in

--- a/doc/modules/ROOT/pages/indexing.adoc
+++ b/doc/modules/ROOT/pages/indexing.adoc
@@ -207,7 +207,7 @@ below summarises which configuration knobs take effect under which mode:
 | Yes
 | Yes
 
-| Honors `projectile-global-ignore-file-patterns` (Emacs regexps)
+| Honors `projectile-globally-ignored-file-regexps` (Emacs regexps)
 | Yes
 | No
 | No

--- a/doc/modules/ROOT/pages/projects.adoc
+++ b/doc/modules/ROOT/pages/projects.adoc
@@ -1257,16 +1257,22 @@ your project, you could customize it with the following:
 ----
 
 By default, compilation buffers are not writable, which allows you to
-e.g.  press `g` to restart the last command. Setting
-`projectile-<cmd>-use-comint-mode` (where `<cmd>` is `configure`,
-`compile`, `test`, `install`, `package`, or `run`) to a non-nil value
-allows you to make projectile compilation buffers interactive, letting
-you e.g. test a command-line program with `projectile-run-project`.
+e.g.  press `g` to restart the last command. `projectile-use-comint-mode`
+makes them interactive instead, letting you e.g. test a command-line
+program with `projectile-run-project`. Set it to `t` for every lifecycle
+command, or to a list of the ones you want:
 
 [source,elisp]
 ----
-(setq projectile-compile-use-comint-mode t)
+;; only the compile buffer is interactive
+(setq projectile-use-comint-mode '(compile))
+
+;; all of them are
+(setq projectile-use-comint-mode t)
 ----
+
+The phases you can name are `configure`, `compile`, `test`, `install`,
+`package` and `run`.
 
 == Project buffers
 

--- a/doc/modules/ROOT/pages/tasks.adoc
+++ b/doc/modules/ROOT/pages/tasks.adoc
@@ -68,8 +68,8 @@ with `projectile-run-task` (kbd:[s-p c x]), which prompts for a task with
 completion and executes its command exactly like the lifecycle commands (in
 `projectile-compilation-dir`, with `%p` expanded to the project name). Each
 task gets its own compilation buffer, named `+*projectile-task: NAME*+` (with
-the project name appended when `projectile-per-project-compilation-buffer` is
-non-nil), so several tasks can run side by side.
+the project name appended when `projectile-compilation-buffer-scope` includes
+`project`), so several tasks can run side by side.
 
 image::projectile-run-task.png[projectile-run-task prompting for one of the project's tasks]
 

--- a/doc/modules/ROOT/pages/tasks.adoc
+++ b/doc/modules/ROOT/pages/tasks.adoc
@@ -47,7 +47,7 @@ edited command is remembered like any other, and `projectile-discard-command-cac
 hands the project back to the function.
 
 By default, Projectile will not add consecutive duplicate commands to its
-command history.  To alter this behaviour you can use `projectile-cmd-hist-ignoredups`.
+command history.  To alter this behaviour you can use `projectile-command-history-ignore-duplicates`.
   The default value of `t` means consecutive duplicates are ignored, a value
 of `nil` means nothing is ignored, and a value of `'erase'` means only
 the last duplicate is kept in the command history.

--- a/doc/modules/ROOT/pages/upgrading_to_projectile_3.adoc
+++ b/doc/modules/ROOT/pages/upgrading_to_projectile_3.adoc
@@ -60,8 +60,10 @@ Modern code navigation is better served by `xref` (kbd:[M-.]) backed by a
 language server (Eglot/LSP) or `etags`/`ggtags` directly, plus
 `projectile-find-references` (kbd:[s-p s x]) for textual references.
 
-NOTE: `projectile-tags-file-name` is kept, but only so that a project's `TAGS`
-file can be excluded from the index. It no longer drives any command.
+NOTE: `projectile-tags-file-name` was kept, but only so that a project's
+`TAGS` file could be excluded from the index. It no longer drives any command,
+and as of 3.4 it's obsolete - `projectile-globally-ignored-files` lists `TAGS`
+directly, and that's where to name a different tags file.
 
 === The ido / ivy / helm completion systems
 

--- a/doc/modules/ROOT/pages/upgrading_to_projectile_3_1.adoc
+++ b/doc/modules/ROOT/pages/upgrading_to_projectile_3_1.adoc
@@ -63,7 +63,9 @@ xref:projects.adoc[the Projects page]).
 
 == Automatic project discovery is on by default
 
-`projectile-auto-discover` now defaults to `t`. It has no effect unless you've
+`projectile-auto-discover` now defaults to `t` (the option was renamed to
+`projectile-auto-discover-projects` in 3.4; the old name still works). It has
+no effect unless you've
 also set `projectile-project-search-path`, so nothing changes out of the box -
 but if you _had_ set a search path and deliberately left auto-discovery off,
 you'll now get it.
@@ -77,7 +79,7 @@ To keep the old behavior:
 
 [source,elisp]
 ----
-(setq projectile-auto-discover nil)
+(setq projectile-auto-discover-projects nil)
 ----
 
 == `projectile-find-file` orders by frecency

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -121,7 +121,7 @@ Recursive discovery is configured by specifying the search depth in a cons cell:
 (setq projectile-project-search-path '("~/projects/" "~/work/" ("~/github" . 1)))
 ----
 
-Automatic discovery is controlled by `projectile-auto-discover`, which
+Automatic discovery is controlled by `projectile-auto-discover-projects`, which
 is enabled by default. The search path is scanned the first time a
 project-switching command runs in an Emacs session (not on every switch),
 so pointing `projectile-project-search-path` at your projects directory
@@ -129,7 +129,7 @@ is all you need. To turn the automatic scan off:
 
 [source,elisp]
 ----
-(setq projectile-auto-discover nil)
+(setq projectile-auto-discover-projects nil)
 ----
 
 You can always trigger a fresh scan manually with `M-x
@@ -306,7 +306,7 @@ disturb later ones, edits already-open buffers in place under a single undo
 step (and saves them), and writes closed files back to disk preserving their
 coding system. A buffer that was modified after the search is skipped rather
 than risk a bad edit; re-run the search (kbd:[g]) to pick up its current
-state. Very large searches are capped at `projectile-replace-max-matches`.
+state. Very large searches are capped at `projectile-search-max-matches`.
 
 The project is scanned asynchronously: the `+*projectile-replace*+` buffer
 opens right away and matches stream in as they are found (the status line
@@ -315,7 +315,7 @@ freezes Emacs. The scan is cancelable with kbd:[q], kbd:[C-g], or by killing
 the buffer. While it is still running, kbd:[!] and kbd:[e] refuse until it
 finishes, so the write-back never runs against a partial match set; starting a
 new scan (kbd:[g], kbd:[c], kbd:[x]) first cancels any in-flight one. Set
-`projectile-replace-async` to nil to force the old synchronous single-pass
+`projectile-search-async` to nil to force the old synchronous single-pass
 scan instead; batch (`noninteractive`) runs always scan synchronously.
 
 kbd:[!] applies the enabled matches with no external dependency. If you'd
@@ -408,14 +408,14 @@ The results buffer supports these keys:
 |===
 
 The status line, the case/regexp toggles, the filter keys, the grep export
-and the asynchronous, cancelable scanning (including `projectile-replace-async`)
+and the asynchronous, cancelable scanning (including `projectile-search-async`)
 behave exactly as in the replace reviewer above; only the preview, per-match
 toggle and apply are absent. kbd:[r] is the search-to-replace
 bridge: it carries over the same term, literal-ness and case setting and
 opens the `+*projectile-replace*+` reviewer, prompting only for the
 replacement. It re-runs the search from scratch, so any filtering you did
 in the search buffer is not carried into the replacement. Very large
-searches are capped at `projectile-replace-max-matches`.
+searches are capped at `projectile-search-max-matches`.
 
 When `projectile-search-use-ripgrep` is non-nil (the default) and the
 `rg` (ripgrep) executable is installed, a *literal* `projectile-search-review`

--- a/projectile.el
+++ b/projectile.el
@@ -892,7 +892,10 @@ Any function that does not take arguments will do."
   :package-version '(projectile . "0.10.0"))
 
 (defcustom projectile-use-git-grep nil
-  "If true, use `vc-git-grep' in git projects."
+  "Whether `projectile-grep' delegates to `vc-git-grep' in git projects.
+
+Only affects `projectile-grep'; the other search commands and the
+backends of `projectile-search' ignore this."
   :group 'projectile
   :type 'boolean
   :package-version '(projectile . "0.11.0"))
@@ -1073,7 +1076,7 @@ project cache was invalidated while it was still running.")
      (remhash project-root projectile--async-index-processes))))
 
 (defvar projectile-project-root-cache (make-hash-table :test 'equal)
-  "Cached value of function `projectile-project-root`.")
+  "Cached value of function `projectile-project-root'.")
 
 ;;; Project path spelling helpers
 ;;
@@ -1434,16 +1437,16 @@ back to running it as a shell command."
   :type 'string
   :package-version '(projectile . "0.9.0"))
 
-(defcustom projectile-darcs-command "darcs show files -0 . "
+(defcustom projectile-darcs-command "darcs show files -0 ."
   "Command used by projectile to get the files in a darcs project."
   :group 'projectile
   :type 'string
   :package-version '(projectile . "0.9.0"))
 
 (defcustom projectile-pijul-command "pijul list | tr '\\n' '\\0'"
-   "Command used by projectile to get the files in a pijul project."
-   :group 'projectile
-   :type 'string
+  "Command used by projectile to get the files in a pijul project."
+  :group 'projectile
+  :type 'string
   :package-version '(projectile . "2.6.0"))
 
 (defcustom projectile-svn-command "svn list -R . | grep -v '$/' | tr '\\n' '\\0'"
@@ -1534,7 +1537,14 @@ It assumes the test/ folder is at the same level as src/."
   :package-version '(projectile . "0.13.0"))
 
 (defcustom projectile-per-project-compilation-buffer nil
-  "When non-nil, the compilation command makes the per-project compilation buffer."
+  "When non-nil, each project gets its own compilation buffer.
+
+Compiling, testing and running all use `compilation-mode' and so share
+one buffer across every project.  With this enabled the project name is
+part of the buffer name (`*compilation*<my-project>'), so working on two
+projects at once doesn't have them overwrite each other's output.
+
+Composes with `projectile-per-command-compilation-buffer'."
   :group 'projectile
   :type 'boolean
   :package-version '(projectile . "2.6.0"))
@@ -2887,7 +2897,7 @@ Return the first (topmost) matched directory or nil if not found."
      (lambda (dir) (projectile--directory-marker dir markers 'files-only)))))
 
 (defun projectile-root-marked (dir)
-  "Identify a project root in DIR by search for `projectile-dirconfig-file`."
+  "Identify a project root in DIR by search for `projectile-dirconfig-file'."
   (projectile-root-bottom-up dir (list projectile-dirconfig-file)))
 
 (defun projectile-root-bottom-up (dir &optional list)
@@ -6621,10 +6631,11 @@ it acts on the current project."
           (projectile--cmake-all-command-presets command-type)))
 
 (defcustom projectile-enable-cmake-presets nil
-  "Enables configuration with CMake presets.
+  "Whether CMake projects use presets for their lifecycle commands.
 
-When `projectile-enable-cmake-presets' is non-nil, CMake projects can
-be configured, built and tested using presets."
+When non-nil, CMake projects are configured, built and tested through
+the presets their `CMakePresets.json' and `CMakeUserPresets.json'
+declare, rather than through Projectile's own default commands."
   :group 'projectile
   :type 'boolean
   :package-version '(projectile . "2.4.0"))

--- a/projectile.el
+++ b/projectile.el
@@ -318,7 +318,10 @@ A value of nil means the cache never expires."
                  (natnum :tag "Seconds"))
   :package-version '(projectile . "1.0.0"))
 
-(defcustom projectile-auto-discover t
+(define-obsolete-variable-alias 'projectile-auto-discover
+  'projectile-auto-discover-projects "3.4.0")
+
+(defcustom projectile-auto-discover-projects t
   "Whether to discover projects under `projectile-project-search-path'.
 When non-nil, the projects under the search path are discovered and
 remembered the first time a project-switching command runs in an Emacs
@@ -777,7 +780,7 @@ an entry to `projectile-globally-unignored-directories' to get one of
 them back, or a `!' line to a project's `.projectile' to get it back
 for that project only.
 
-See also `projectile-global-ignore-file-patterns'."
+See also `projectile-globally-ignored-file-regexps'."
   :group 'projectile
   :type '(repeat string)
   :safe #'projectile-string-list-p
@@ -793,9 +796,12 @@ entries."
   :safe #'projectile-string-list-p
   :package-version '(projectile . "0.14.0"))
 
-(defcustom projectile-global-ignore-file-patterns
+(define-obsolete-variable-alias 'projectile-global-ignore-file-patterns
+  'projectile-globally-ignored-file-regexps "3.4.0")
+
+(defcustom projectile-globally-ignored-file-regexps
   nil
-  "A list of file regexp patterns ignored by Projectile.
+  "A list of regexps matching files ignored by Projectile.
 
 Unlike `projectile-globally-ignored-files' and
 `projectile-globally-ignored-directories', which speak gitignore
@@ -953,7 +959,10 @@ to pick the first available backend, or `prompt' to be asked each time."
   :type 'function
   :package-version '(projectile . "0.11.0"))
 
-(defcustom projectile-related-files-fn-function 'projectile-related-files-fn
+(define-obsolete-variable-alias 'projectile-related-files-fn-function
+  'projectile-related-files-function "3.4.0")
+
+(defcustom projectile-related-files-function 'projectile-related-files-fn
   "Function to find related files based on PROJECT-TYPE."
   :group 'projectile
   :type 'function
@@ -1623,7 +1632,10 @@ If the value is nil, there is no limit to the opened buffers count."
                  (natnum :tag "Buffers"))
   :package-version '(projectile . "2.2.0"))
 
-(defcustom projectile-cmd-hist-ignoredups t
+(define-obsolete-variable-alias 'projectile-cmd-hist-ignoredups
+  'projectile-command-history-ignore-duplicates "3.4.0")
+
+(defcustom projectile-command-history-ignore-duplicates t
   "Controls when inputs are added to projectile's command history.
 
 A value of t means consecutive duplicates are ignored.
@@ -2756,7 +2768,7 @@ project-switch command.")
 (defun projectile-discover-projects-in-search-path ()
   "Discover projects in `projectile-project-search-path'.
 When called interactively, always re-scans; the automatic scan (see
-`projectile-auto-discover') runs this once per session."
+`projectile-auto-discover-projects') runs this once per session."
   (interactive)
   (setq projectile--search-path-discovered t)
   (dolist (path projectile-project-search-path)
@@ -3148,13 +3160,13 @@ Files are returned as relative paths to DIRECTORY."
                                         progress-reporter))))
 
 (defun projectile--global-ignore-regexp-p (path)
-  "Return non-nil when PATH matches `projectile-global-ignore-file-patterns'.
+  "Return non-nil when PATH matches `projectile-globally-ignored-file-regexps'.
 PATH is an absolute file name.  Those patterns are Emacs regexps rather
 than globs, which is why they are a separate mechanism from the ignore
 patterns proper; matching is case-sensitive."
   (seq-some (lambda (re) (let ((case-fold-search nil))
                            (string-match-p re path)))
-            projectile-global-ignore-file-patterns))
+            projectile-globally-ignored-file-regexps))
 
 (defun projectile--glob-to-regexp (glob)
   "Translate the dirconfig GLOB into a regexp fragment.
@@ -4554,7 +4566,7 @@ slash) can match it.  ROOT defaults to the current project's root.
 
 The check is the one indexing performs: PATH's root-relative name is
 matched against `projectile--ignore-patterns', `!' ensure patterns
-rescue it, and `projectile-global-ignore-file-patterns' is applied to
+rescue it, and `projectile-globally-ignored-file-regexps' is applied to
 the absolute name.  Because an ignored directory covers its whole
 subtree, a path inside one is reported as ignored too."
   (let* ((path (expand-file-name path))
@@ -4670,7 +4682,7 @@ list, so they all apply the same rules the same way.  It merges
   written in this language
 
 The `projectile-globally-unignored-*' options cancel out the matching
-entries.  `projectile-global-ignore-file-patterns' is deliberately not
+entries.  `projectile-globally-ignored-file-regexps' is deliberately not
 part of this: those are Emacs regexps, not patterns, and can't be handed
 to an external tool.
 
@@ -5460,7 +5472,7 @@ PROJECT-ROOT is the project root."
   (if-let* ((rel-path (if (file-name-absolute-p file)
                          (file-relative-name file project-root)
                        file))
-           (custom-function (funcall projectile-related-files-fn-function (projectile-project-type))))
+           (custom-function (funcall projectile-related-files-function (projectile-project-type))))
       (funcall (cond ((functionp custom-function)
                       custom-function)
                      ((consp custom-function)
@@ -9060,10 +9072,14 @@ to run the replacement."
 ;; place under a single `atomic-change-group', and buffers modified since the
 ;; scan are skipped rather than corrupted.
 
-(defcustom projectile-replace-max-matches 5000
-  "Upper bound on how many matches `projectile-replace-review' collects.
-When a search would exceed this, only the first that many matches are
-shown and a note is displayed."
+(define-obsolete-variable-alias 'projectile-replace-max-matches
+  'projectile-search-max-matches "3.4.0")
+
+(defcustom projectile-search-max-matches 5000
+  "Upper bound on how many matches a review buffer collects.
+Applies to `projectile-search-review' and `projectile-replace-review'
+alike.  When a search would exceed this, only the first that many
+matches are shown and a note is displayed."
   :group 'projectile
   :type 'natnum
   :package-version '(projectile . "3.2.0"))
@@ -9078,7 +9094,10 @@ binds it for a single invocation."
   :type 'boolean
   :package-version '(projectile . "3.2.0"))
 
-(defcustom projectile-replace-async t
+(define-obsolete-variable-alias 'projectile-replace-async
+  'projectile-search-async "3.4.0")
+
+(defcustom projectile-search-async t
   "Whether the reviewable search/replace commands scan asynchronously.
 When non-nil (the default) `projectile-replace-review',
 `projectile-search-review' and their in-buffer re-scan commands (`g',
@@ -9144,7 +9163,10 @@ string or in prose is reported too."
   :type '(repeat string)
   :package-version '(projectile . "3.3.0"))
 
-(defcustom projectile-replace-scan-chunk-size 24
+(define-obsolete-variable-alias 'projectile-replace-scan-chunk-size
+  'projectile-search-scan-chunk-size "3.4.0")
+
+(defcustom projectile-search-scan-chunk-size 24
   "Number of candidate files scanned per async chunk before yielding.
 Each chunk scans this many files, delivers the matches into the results
 buffer and re-renders, then yields to redisplay via a zero-delay timer
@@ -9241,7 +9263,7 @@ search has no known ripgrep equivalent.")
 (defvar-local projectile-replace--matches nil
   "List of `projectile-replace--match' structs shown in the results buffer.")
 (defvar-local projectile-replace--truncated nil
-  "Non-nil when the match list was capped at `projectile-replace-max-matches'.")
+  "Non-nil when the match list was capped at `projectile-search-max-matches'.")
 (defvar-local projectile-replace--filtered nil
   "Non-nil when the shown match list was pruned by a filter command.
 Re-searching (\\<projectile-replace-mode-map>\\[projectile-replace--refresh]) gathers from scratch and clears this.")
@@ -9387,11 +9409,11 @@ Binary-looking and unreadable files are skipped."
         (error nil)))))
 
 (defun projectile-replace--gather (candidates regexp)
-  "Scan CANDIDATES for REGEXP, capped at `projectile-replace-max-matches'.
+  "Scan CANDIDATES for REGEXP, capped at `projectile-search-max-matches'.
 Return a plist with `:matches' (the collected structs, in file order)
 and `:truncated' (non-nil when the cap was hit)."
   (let ((all nil)
-        (budget projectile-replace-max-matches)
+        (budget projectile-search-max-matches)
         (truncated nil))
     (dolist (file candidates)
       (if (> budget 0)
@@ -9417,10 +9439,10 @@ and `:truncated' (non-nil when the cap was hit)."
 
 (defun projectile-replace--async-p ()
   "Return non-nil when scanning should run asynchronously.
-True when `projectile-replace-async' is set and we are interactive;
+True when `projectile-search-async' is set and we are interactive;
 batch (`noninteractive') always scans synchronously so scripted runs stay
 deterministic."
-  (and projectile-replace-async (not noninteractive)))
+  (and projectile-search-async (not noninteractive)))
 
 (defun projectile-replace--cancel-scan ()
   "Cancel any in-flight async scan in the current results buffer.
@@ -9443,11 +9465,11 @@ on re-scan, on quit, and from `kill-buffer-hook'."
 (defun projectile-replace--gather-async (candidates regexp buffer on-done)
   "Scan CANDIDATES for REGEXP into BUFFER incrementally, then call ON-DONE.
 Resets BUFFER's match list and scanning state, then processes CANDIDATES
-in `projectile-replace-scan-chunk-size' batches, each batch delivering
+in `projectile-search-scan-chunk-size' batches, each batch delivering
 its matches and re-rendering before yielding to redisplay via a
 zero-delay timer.  Matches accumulate in file order, so the final list is
 identical to `projectile-replace--gather' over the same CANDIDATES and
-REGEXP; `projectile-replace-max-matches' and the `:truncated' note are
+REGEXP; `projectile-search-max-matches' and the `:truncated' note are
 honored the same way.  ON-DONE (or nil) is called in BUFFER once the scan
 finishes.  A scan already running in BUFFER should be canceled first (see
 `projectile-replace--cancel-scan')."
@@ -9460,7 +9482,7 @@ finishes.  A scan already running in BUFFER should be canceled first (see
                  projectile-replace--scan-timer nil)
            (cl-incf projectile-replace--scan-generation))))
     (projectile-replace--scan-step
-     buffer candidates regexp projectile-replace-max-matches on-done generation)))
+     buffer candidates regexp projectile-search-max-matches on-done generation)))
 
 (defun projectile-replace--scan-step (buffer remaining regexp budget on-done generation)
   "Scan one chunk of REMAINING candidates for REGEXP into BUFFER.
@@ -9486,7 +9508,7 @@ killed BUFFER (leaving no work behind) and against \\`C-g' during a chunk
           ;; a file is scanned while budget remains; the first file reached
           ;; with the budget exhausted marks the list truncated and stops.
           (while (and remaining (not stop)
-                      (< count projectile-replace-scan-chunk-size))
+                      (< count projectile-search-scan-chunk-size))
             (if (> budget 0)
                 (let ((ms (let ((case-fold-search fold))
                             (projectile-replace--scan-file
@@ -9671,7 +9693,7 @@ async scan streams matches in."
           (insert (projectile-replace--render-line m replacement literal)))))
     (when projectile-replace--truncated
       (insert (format "\n(showing the first %d matches)\n"
-                      projectile-replace-max-matches)))
+                      projectile-search-max-matches)))
     (goto-char (point-min))))
 
 (defun projectile-replace--render-preserve ()
@@ -10482,7 +10504,7 @@ submatches yields one struct per submatch, in order."
 
 (defun projectile-search--rg-ingest (buffer lines root)
   "Parse rg NDJSON LINES into BUFFER's match list, render, honor the cap.
-Appends up to `projectile-replace-max-matches' matches in arrival order;
+Appends up to `projectile-search-max-matches' matches in arrival order;
 when the cap is reached the surplus is dropped and the truncated flag is
 set.  Returns non-nil when the cap has been reached, so the caller can
 finish the scan."
@@ -10493,7 +10515,7 @@ finish the scan."
         (dolist (l lines)
           (unless (string-empty-p l)
             (setq new (nconc new (projectile-search--rg-parse-line l root)))))
-        (let ((room (- projectile-replace-max-matches
+        (let ((room (- projectile-search-max-matches
                        (length projectile-replace--matches))))
           (when (> (length new) room)
             (setq new (take (max 0 room) new)
@@ -10527,7 +10549,7 @@ ripgrep-syntax regexp is searched for instead of the literal TERM.
 Resets BUFFER's match list and scanning state, launches `rg' as a
 subprocess reading ROOT, CASE-FOLD and the ignore globs from BUFFER's
 buffer-locals, and streams parsed matches into the buffer as ripgrep
-emits them, re-rendering per output chunk.  `projectile-replace-max-matches'
+emits them, re-rendering per output chunk.  `projectile-search-max-matches'
 is honored (the process is killed when the cap is hit) and the scan is
 cancelable and kill-safe exactly like the elisp async engine: the process
 is registered in `projectile-replace--scan-process' so
@@ -10652,7 +10674,7 @@ plain regexp search always take the elisp path below."
       (message "%s"
                (projectile-prepend-project-name
                 (format "showing the first %d matches"
-                        projectile-replace-max-matches))))))
+                        projectile-search-max-matches))))))
 
 (defun projectile-replace--open (mode buf-name root term regexp replacement
                                       literal case-fold candidates no-match-msg
@@ -10672,7 +10694,7 @@ state."
   (if (or (projectile-replace--async-p)
           ;; the read-only search reviewer's ripgrep fast-path is inherently
           ;; async, so it opens the streaming buffer even when the elisp async
-          ;; engine is off (`projectile-replace-async' nil); `--start' then
+          ;; engine is off (`projectile-search-async' nil); `--start' then
           ;; dispatches it to ripgrep
           (and (eq mode #'projectile-search-mode)
                (projectile-search--rg-fastpath-p literal rg-pattern)))
@@ -10706,7 +10728,7 @@ state."
             (message "%s"
                      (projectile-prepend-project-name
                       (format "showing the first %d matches"
-                              projectile-replace-max-matches))))
+                              projectile-search-max-matches))))
           (pop-to-buffer buf)
           buf)))))
 
@@ -10863,7 +10885,7 @@ property so the shared navigation, visit and filter commands find it."
           (insert (projectile-search--render-line m)))))
     (when projectile-replace--truncated
       (insert (format "\n(showing the first %d matches)\n"
-                      projectile-replace-max-matches)))
+                      projectile-search-max-matches)))
     (goto-char (point-min))))
 
 (defun projectile-search--to-replace ()
@@ -12076,12 +12098,13 @@ reads."
 
 (defun projectile--command-history-insert (history command)
   "Insert COMMAND into the ring HISTORY.
-Duplicates are handled according to `projectile-cmd-hist-ignoredups'."
+Duplicates are handled according to
+`projectile-command-history-ignore-duplicates'."
   (cond
-   ((eq projectile-cmd-hist-ignoredups t)
+   ((eq projectile-command-history-ignore-duplicates t)
     (unless (string= (car-safe (ring-elements history)) command)
       (ring-insert history command)))
-   ((eq projectile-cmd-hist-ignoredups 'erase)
+   ((eq projectile-command-history-ignore-duplicates 'erase)
     (let ((idx (ring-member history command)))
       (while idx
         (ring-remove history idx)
@@ -12974,15 +12997,15 @@ An open project is a project with any open buffers."
 (defun projectile-known-projects ()
   "Initialize the known projects.
 
-This might potentially clean up redundant projects and discover new ones if
-`projectile-auto-cleanup-known-projects' or `projectile-auto-discover' are
-enabled."
+This might potentially clean up redundant projects and discover new ones
+if `projectile-auto-cleanup-known-projects' or
+`projectile-auto-discover-projects' are enabled."
   ;; load the known projects
   (unless projectile-known-projects
     (projectile-load-known-projects))
   (when projectile-auto-cleanup-known-projects
     (projectile--cleanup-known-projects))
-  (when (and projectile-auto-discover
+  (when (and projectile-auto-discover-projects
              projectile-project-search-path
              (not projectile--search-path-discovered))
     (projectile-discover-projects-in-search-path))

--- a/projectile.el
+++ b/projectile.el
@@ -835,8 +835,8 @@ family of them."
   :package-version '(projectile . "0.10.0"))
 
 (defcustom projectile-globally-ignored-buffers
-  '("*scratch*"
-    "*lsp-log*")
+  '("\\*scratch\\*"
+    "\\*lsp-log\\*")
   "A list of buffer names ignored by projectile.
 
 If a buffer matches one of these, projectile will ignore it for
@@ -844,7 +844,11 @@ functions working with buffers.
 
 Each entry is a regular expression, matched anywhere in the buffer
 name - unlike `projectile-globally-ignored-modes', which matches whole
-mode names.  Anchor an entry yourself when you mean an exact name."
+mode names.  Anchor an entry yourself when you mean an exact name.
+
+Note that the `*' of a buffer name like `*scratch*' has to be escaped
+to be matched literally, as in the default value; unescaped it is a
+repetition operator."
   :group 'projectile
   :type '(repeat regexp)
   :safe #'list-of-strings-p

--- a/projectile.el
+++ b/projectile.el
@@ -454,13 +454,17 @@ It's relative to the project root."
   :type 'string
   :package-version '(projectile . "2.9.0"))
 
-(defcustom projectile-tags-file-name "TAGS"
+(defvar projectile-tags-file-name "TAGS"
   "The name of the tags file Projectile excludes from indexing.
 Listed in `projectile-globally-ignored-files' so a generated tags
-file doesn't show up among the project files."
-  :group 'projectile
-  :type 'string
-  :package-version '(projectile . "0.12.0"))
+file doesn't show up among the project files.")
+
+;; Only ever read to seed `projectile-globally-ignored-files' below, which
+;; happens as this file loads - so setting it afterwards never did anything.
+;; Naming the file in the ignore list is the same thing said once.
+(make-obsolete-variable 'projectile-tags-file-name
+                        "add the file name to `projectile-globally-ignored-files' instead."
+                        "3.4.0")
 
 (defcustom projectile-sort-order 'default
   "The sort order used for a project's files.
@@ -670,7 +674,7 @@ so a project is free to set them from its .dir-locals.el."
   (and (proper-list-p value) (seq-every-p #'stringp value)))
 
 (defcustom projectile-globally-ignored-files
-  (list projectile-tags-file-name projectile-cache-file)
+  (list (with-no-warnings projectile-tags-file-name) projectile-cache-file)
   "A list of files globally ignored by projectile.
 
 Entries are gitignore patterns: a plain name matches a file with that
@@ -6537,11 +6541,15 @@ it acts on the current project."
   (or (projectile-verify-file "build.mill" dir)
       (projectile-verify-file "build.sc" dir)))
 
-(defcustom projectile-go-project-test-function #'projectile-go-project-p
-  "Function to determine if project's type is go."
-  :group 'projectile
-  :type 'function
-  :package-version '(projectile . "1.0.0"))
+(defvar projectile-go-project-test-function #'projectile-go-project-p
+  "Function to determine if project's type is go.")
+
+;; The only project type with a detection hook of its own, and only read
+;; when the `go' type is registered as this file loads.  Registering the
+;; type again with your own predicate is the general way to do this.
+(make-obsolete-variable 'projectile-go-project-test-function
+                        "re-register the `go' project type with your own predicate instead."
+                        "3.4.0")
 
 (defun projectile-terraform-project-p (&optional dir)
   "Check if a project contains Terraform configuration files.
@@ -6915,7 +6923,7 @@ a manual COMMAND-TYPE command is created with
                                   :test "task test"
                                   :install "task install")
 ;; Go should take higher precedence than Make because Go projects often have a Makefile.
-(projectile-register-project-type 'go projectile-go-project-test-function
+(projectile-register-project-type 'go (with-no-warnings projectile-go-project-test-function)
                                   ;; The type is detected by predicate (a
                                   ;; project can be Go without a go.mod), but
                                   ;; the module file is still what marks a Go

--- a/projectile.el
+++ b/projectile.el
@@ -454,14 +454,11 @@ It's relative to the project root."
   :type 'string
   :package-version '(projectile . "2.9.0"))
 
+;; Remove in 4.0.  This was only ever read to seed the default of
+;; `projectile-globally-ignored-files' as this file loaded, so setting it
+;; from an init file never did anything; that list now names TAGS itself.
 (defvar projectile-tags-file-name "TAGS"
-  "The name of the tags file Projectile excludes from indexing.
-Listed in `projectile-globally-ignored-files' so a generated tags
-file doesn't show up among the project files.")
-
-;; Only ever read to seed `projectile-globally-ignored-files' below, which
-;; happens as this file loads - so setting it afterwards never did anything.
-;; Naming the file in the ignore list is the same thing said once.
+  "The name of the tags file Projectile excludes from indexing.")
 (make-obsolete-variable 'projectile-tags-file-name
                         "add the file name to `projectile-globally-ignored-files' instead."
                         "3.4.0")
@@ -665,16 +662,12 @@ such line, listing the offending entries."
   :type 'boolean
   :package-version '(projectile . "3.0.0"))
 
-(defun projectile-string-list-p (value)
-  "Return non-nil when VALUE is a list of strings.
-
-The `:safe' predicate of the options holding a list of names, patterns
-or regexps.  None of them can do more than widen or narrow a listing,
-so a project is free to set them from its .dir-locals.el."
-  (and (proper-list-p value) (seq-every-p #'stringp value)))
+;; The options below hold nothing but a list of names, patterns or regexps,
+;; and none of them can do more than widen or narrow a listing - so a project
+;; is free to set any of them from its .dir-locals.el.
 
 (defcustom projectile-globally-ignored-files
-  (list (with-no-warnings projectile-tags-file-name) projectile-cache-file)
+  (list "TAGS" projectile-cache-file)
   "A list of files globally ignored by projectile.
 
 Entries are gitignore patterns: a plain name matches a file with that
@@ -683,7 +676,7 @@ root, and `*', `**', `?' and `[...]' are the usual wildcards.  See
 `projectile-globally-ignored-directories' for the full pattern language."
   :group 'projectile
   :type '(repeat string)
-  :safe #'projectile-string-list-p
+  :safe #'list-of-strings-p
   :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-globally-unignored-files nil
@@ -693,7 +686,7 @@ Entries cancel out the matching `projectile-globally-ignored-files'
 entries."
   :group 'projectile
   :type '(repeat string)
-  :safe #'projectile-string-list-p
+  :safe #'list-of-strings-p
   :package-version '(projectile . "0.14.0"))
 
 (defcustom projectile-globally-ignored-file-suffixes
@@ -704,7 +697,7 @@ were the gitignore pattern `*SUFFIX' (e.g. \".elc\" ignores every
 `.elc' file in the project)."
   :group 'projectile
   :type '(repeat string)
-  :safe #'projectile-string-list-p
+  :safe #'list-of-strings-p
   :package-version '(projectile . "0.12.0"))
 
 (defcustom projectile-globally-ignored-directories
@@ -787,7 +780,7 @@ for that project only.
 See also `projectile-globally-ignored-file-regexps'."
   :group 'projectile
   :type '(repeat string)
-  :safe #'projectile-string-list-p
+  :safe #'list-of-strings-p
   :package-version '(projectile . "3.3.0"))
 
 (defcustom projectile-globally-unignored-directories nil
@@ -797,7 +790,7 @@ Entries cancel out the matching `projectile-globally-ignored-directories'
 entries."
   :group 'projectile
   :type '(repeat string)
-  :safe #'projectile-string-list-p
+  :safe #'list-of-strings-p
   :package-version '(projectile . "0.14.0"))
 
 (define-obsolete-variable-alias 'projectile-global-ignore-file-patterns
@@ -818,7 +811,7 @@ See also `projectile-ignored-file-p' and
 `projectile-ignored-directory-p'."
   :group 'projectile
   :type '(repeat string)
-  :safe #'projectile-string-list-p
+  :safe #'list-of-strings-p
   :package-version '(projectile . "2.9.0"))
 
 (defcustom projectile-globally-ignored-modes
@@ -838,7 +831,7 @@ ignores that mode and nothing else, while \"gnus-.*-mode\" ignores a
 family of them."
   :group 'projectile
   :type '(repeat regexp)
-  :safe #'projectile-string-list-p
+  :safe #'list-of-strings-p
   :package-version '(projectile . "0.10.0"))
 
 (defcustom projectile-globally-ignored-buffers
@@ -854,7 +847,7 @@ name - unlike `projectile-globally-ignored-modes', which matches whole
 mode names.  Anchor an entry yourself when you mean an exact name."
   :group 'projectile
   :type '(repeat regexp)
-  :safe #'projectile-string-list-p
+  :safe #'list-of-strings-p
   :package-version '(projectile . "0.12.0"))
 
 (defcustom projectile-find-file-hook nil
@@ -1567,25 +1560,27 @@ Qualifying the buffer name keeps them apart.  The value is a list of:
   and a test run don't overwrite each other.
 
 The two compose: with both, the buffer is `*compilation*<my-project:test>'.
-With nil there's a single shared compilation buffer, as in plain Emacs."
+Setting this to t is the same as naming both.  With nil there's a single
+shared compilation buffer, as in plain Emacs."
   :group 'projectile
-  :type '(set (const :tag "Project" project)
-              (const :tag "Lifecycle command" command))
+  :type '(choice (const :tag "One shared buffer" nil)
+                 (const :tag "Project and command" t)
+                 (set :tag "Selected aspects"
+                      (const :tag "Project" project)
+                      (const :tag "Lifecycle command" command)))
   :package-version '(projectile . "3.4.0"))
 
-;; Superseded by the single `projectile-compilation-buffer-scope', but still
-;; honored so that an existing configuration keeps working.
+;; Remove in 4.0.  Superseded by `projectile-compilation-buffer-scope', which
+;; folds them in - setting both booleans is what its two-element list means.
 (defvar projectile-per-project-compilation-buffer nil
   "When non-nil, each project gets its own compilation buffer.")
 (defvar projectile-per-command-compilation-buffer nil
   "When non-nil, each lifecycle command gets its own compilation buffer.")
 
-(make-obsolete-variable 'projectile-per-project-compilation-buffer
-                        "use `projectile-compilation-buffer-scope' instead."
-                        "3.4.0")
-(make-obsolete-variable 'projectile-per-command-compilation-buffer
-                        "use `projectile-compilation-buffer-scope' instead."
-                        "3.4.0")
+(dolist (var '(projectile-per-project-compilation-buffer
+               projectile-per-command-compilation-buffer))
+  (make-obsolete-variable var "use `projectile-compilation-buffer-scope' instead."
+                          "3.4.0"))
 
 (defcustom projectile-after-switch-project-hook nil
   "Hooks run right after project is switched."
@@ -6541,12 +6536,11 @@ it acts on the current project."
   (or (projectile-verify-file "build.mill" dir)
       (projectile-verify-file "build.sc" dir)))
 
+;; Remove in 4.0.  The only project type with a detection hook of its own,
+;; and only read when the `go' type was registered as this file loaded.
+;; Re-registering the type is how every other type is customized.
 (defvar projectile-go-project-test-function #'projectile-go-project-p
   "Function to determine if project's type is go.")
-
-;; The only project type with a detection hook of its own, and only read
-;; when the `go' type is registered as this file loads.  Registering the
-;; type again with your own predicate is the general way to do this.
 (make-obsolete-variable 'projectile-go-project-test-function
                         "re-register the `go' project type with your own predicate instead."
                         "3.4.0")
@@ -6923,7 +6917,7 @@ a manual COMMAND-TYPE command is created with
                                   :test "task test"
                                   :install "task install")
 ;; Go should take higher precedence than Make because Go projects often have a Makefile.
-(projectile-register-project-type 'go (with-no-warnings projectile-go-project-test-function)
+(projectile-register-project-type 'go #'projectile-go-project-p
                                   ;; The type is detected by predicate (a
                                   ;; project can be Go without a go.mod), but
                                   ;; the module file is still what marks a Go
@@ -11306,38 +11300,32 @@ Acts on the current project if not specified explicitly."
      :cmd-map projectile-configure-cmd-map
      :dir-local-var projectile-project-configure-cmd
      :default-fn projectile--expand-configure-command
-     :command-fn projectile-configure-command
-     :use-comint-var projectile-configure-use-comint-mode)
+     :command-fn projectile-configure-command)
     (:name compile :prompt "Compile command: " :save-buffers t
      :cmd-map projectile-compilation-cmd-map
      :dir-local-var projectile-project-compilation-cmd
      :default-fn projectile-default-compilation-command
-     :command-fn projectile-compilation-command
-     :use-comint-var projectile-compile-use-comint-mode)
+     :command-fn projectile-compilation-command)
     (:name test :prompt "Test command: " :save-buffers t
      :cmd-map projectile-test-cmd-map
      :dir-local-var projectile-project-test-cmd
      :default-fn projectile-default-test-command
-     :command-fn projectile-test-command
-     :use-comint-var projectile-test-use-comint-mode)
+     :command-fn projectile-test-command)
     (:name install :prompt "Install command: " :save-buffers t
      :cmd-map projectile-install-cmd-map
      :dir-local-var projectile-project-install-cmd
      :default-fn projectile-default-install-command
-     :command-fn projectile-install-command
-     :use-comint-var projectile-install-use-comint-mode)
+     :command-fn projectile-install-command)
     (:name package :prompt "Package command: " :save-buffers t
      :cmd-map projectile-package-cmd-map
      :dir-local-var projectile-project-package-cmd
      :default-fn projectile-default-package-command
-     :command-fn projectile-package-command
-     :use-comint-var projectile-package-use-comint-mode)
+     :command-fn projectile-package-command)
     (:name run :prompt "Run command: " :save-buffers nil
      :cmd-map projectile-run-cmd-map
      :dir-local-var projectile-project-run-cmd
      :default-fn projectile-default-run-command
-     :command-fn projectile-run-command
-     :use-comint-var projectile-run-use-comint-mode))
+     :command-fn projectile-run-command))
   "Descriptors for the project lifecycle phases.
 
 Each entry is a plist with the phase symbol (`:name', also used as the
@@ -11345,11 +11333,8 @@ command type for the per-type command history), the variable caching
 the last command per project (`:cmd-map'), the .dir-locals.el override
 variable (`:dir-local-var'), a function of the project type returning
 the default command (`:default-fn'), the public command resolver
-\(`:command-fn'), the obsolete option making the output buffer
-interactive (`:use-comint-var', superseded by
-`projectile-use-comint-mode'), the prompt prefix (`:prompt') and
-whether to save the project's buffers before running the command
-\(`:save-buffers').")
+\(`:command-fn'), the prompt prefix (`:prompt') and whether to save the
+project's buffers before running the command (`:save-buffers').")
 
 (defun projectile--phase-descriptor (phase)
   "Return the lifecycle descriptor for PHASE (a symbol like `compile')."
@@ -11848,15 +11833,20 @@ Bound by `projectile--run-project-cmd' for the duration of the call, so
 `projectile-compilation-buffer-name' - which `compile' calls with nothing
 but the mode name - can tell a test run from a build.")
 
-(defun projectile-compilation-buffer-scope-p (kind)
-  "Return non-nil when the compilation buffer name is qualified by KIND.
-KIND is `project' or `command'.  Reads
-`projectile-compilation-buffer-scope', falling back to the obsolete
-boolean it replaced for a configuration that still sets one."
-  (or (memq kind projectile-compilation-buffer-scope)
-      (pcase kind
-        ('project (with-no-warnings projectile-per-project-compilation-buffer))
-        ('command (with-no-warnings projectile-per-command-compilation-buffer)))))
+(defun projectile-compilation-buffer-scope ()
+  "Return the aspects a compilation buffer's name is qualified by.
+A list of `project' and/or `command'.  Normalizes the t shorthand of
+`projectile-compilation-buffer-scope' and folds in the two obsolete
+booleans it replaced, for a configuration that still sets one."
+  (let ((scope (if (eq projectile-compilation-buffer-scope t)
+                   '(project command)
+                 projectile-compilation-buffer-scope)))
+    (with-no-warnings
+      (append (unless (memq 'project scope)
+                (and projectile-per-project-compilation-buffer '(project)))
+              (unless (memq 'command scope)
+                (and projectile-per-command-compilation-buffer '(command)))
+              scope))))
 
 (defun projectile-compilation-buffer-name (compilation-mode)
   "Meant to be used for `compilation-buffer-name-function'.
@@ -11865,14 +11855,15 @@ compilation buffer.
 
 The name is qualified by the project and/or the lifecycle command type,
 according to `projectile-compilation-buffer-scope'."
-  (let ((qualifiers
-         (delq nil
-               (list (and (projectile-compilation-buffer-scope-p 'project)
-                          (projectile-project-p)
-                          (projectile-project-name))
-                     (and (projectile-compilation-buffer-scope-p 'command)
-                          projectile--compilation-command-type
-                          (symbol-name projectile--compilation-command-type))))))
+  (let* ((scope (projectile-compilation-buffer-scope))
+         (qualifiers
+          (delq nil
+                (list (and (memq 'project scope)
+                           (projectile-project-p)
+                           (projectile-project-name))
+                      (and (memq 'command scope)
+                           projectile--compilation-command-type
+                           (symbol-name projectile--compilation-command-type))))))
     (concat "*" (downcase compilation-mode) "*"
             (if qualifiers
                 (concat "<" (string-join qualifiers ":") ">")
@@ -12192,13 +12183,14 @@ The command actually run is returned."
                          (lambda ()
                            (projectile-project-buffer-p (current-buffer)
                                                         project-root))))
-    (when (projectile-compilation-buffer-scope-p 'project)
-      (setq compilation-save-buffers-predicate #'projectile-current-project-buffer-p))
-    (when (or (projectile-compilation-buffer-scope-p 'project)
-              (projectile-compilation-buffer-scope-p 'command))
-      (setq compilation-buffer-name-function #'projectile-compilation-buffer-name))
-    (when buffer-name-function
-      (setq compilation-buffer-name-function buffer-name-function))
+    (let ((scope (projectile-compilation-buffer-scope)))
+      (when (memq 'project scope)
+        (setq compilation-save-buffers-predicate #'projectile-current-project-buffer-p))
+      (cond (buffer-name-function
+             (setq compilation-buffer-name-function buffer-name-function))
+            (scope
+             (setq compilation-buffer-name-function
+                   #'projectile-compilation-buffer-name))))
     (unless command
       (user-error "No %scommand configured for project type `%s'"
                   (or prompt-prefix "") (projectile-project-type)))
@@ -12233,8 +12225,9 @@ list naming the ones that are - `configure', `compile', `test',
                       (const :tag "Run" run)))
   :package-version '(projectile . "3.4.0"))
 
-;; Superseded by the single `projectile-use-comint-mode', but still honored
-;; so that an existing configuration keeps working.
+;; Remove in 4.0, this block and the fallback in
+;; `projectile-use-comint-mode-p' together.  Superseded by the single
+;; `projectile-use-comint-mode', which folds them in.
 (defvar projectile-configure-use-comint-mode nil
   "Make the output buffer of `projectile-configure-project' interactive.")
 (defvar projectile-compile-use-comint-mode nil
@@ -12248,13 +12241,17 @@ list naming the ones that are - `configure', `compile', `test',
 (defvar projectile-run-use-comint-mode nil
   "Make the output buffer of `projectile-run-project' interactive.")
 
-(dolist (var '(projectile-configure-use-comint-mode
-               projectile-compile-use-comint-mode
-               projectile-test-use-comint-mode
-               projectile-install-use-comint-mode
-               projectile-package-use-comint-mode
-               projectile-run-use-comint-mode))
-  (make-obsolete-variable var "use `projectile-use-comint-mode' instead."
+(defconst projectile--obsolete-comint-vars
+  '((configure . projectile-configure-use-comint-mode)
+    (compile   . projectile-compile-use-comint-mode)
+    (test      . projectile-test-use-comint-mode)
+    (install   . projectile-install-use-comint-mode)
+    (package   . projectile-package-use-comint-mode)
+    (run       . projectile-run-use-comint-mode))
+  "The per-phase option `projectile-use-comint-mode' replaced, by phase.")
+
+(dolist (var projectile--obsolete-comint-vars)
+  (make-obsolete-variable (cdr var) "use `projectile-use-comint-mode' instead."
                           "3.4.0"))
 
 (defun projectile-use-comint-mode-p (phase)
@@ -12262,11 +12259,10 @@ list naming the ones that are - `configure', `compile', `test',
 PHASE is a lifecycle phase symbol such as `compile'.  Reads
 `projectile-use-comint-mode', falling back to the obsolete per-phase
 option it replaced for a configuration that still sets one."
-  (or (if (listp projectile-use-comint-mode)
-          (memq phase projectile-use-comint-mode)
-        projectile-use-comint-mode)
-      (symbol-value (plist-get (projectile--phase-descriptor phase)
-                               :use-comint-var))))
+  (or (eq projectile-use-comint-mode t)
+      (memq phase projectile-use-comint-mode)
+      (when-let* ((var (alist-get phase projectile--obsolete-comint-vars)))
+        (symbol-value var))))
 
 (defun projectile--phase-command-dynamic-p (phase)
   "Non-nil when PHASE's command comes from a function for the current project.
@@ -12313,8 +12309,7 @@ root (see `projectile-compilation-dir')."
                                  :prompt-prefix (projectile--lifecycle-prompt descriptor base)
                                  :save-buffers (plist-get descriptor :save-buffers)
                                  :no-cache (projectile--phase-command-dynamic-p phase)
-                                 :use-comint-mode (projectile-use-comint-mode-p
-                                                   (plist-get descriptor :name)))))
+                                 :use-comint-mode (projectile-use-comint-mode-p phase))))
 
 ;;;###autoload
 (defun projectile-configure-project (arg)
@@ -12885,7 +12880,7 @@ the `%p' placeholder still intact."
     ;; `projectile--run-project-cmd' from prompting a second time.
     (let ((compilation-read-command nil)
           (buffer-name (concat "*projectile-task: " task-name "*"
-                               (when (projectile-compilation-buffer-scope-p 'project)
+                               (when (memq 'project (projectile-compilation-buffer-scope))
                                  (concat "<" (projectile-project-name project-root) ">")))))
       (projectile--run-project-cmd command nil
                                    :save-buffers t

--- a/projectile.el
+++ b/projectile.el
@@ -157,12 +157,12 @@ in Emacs Lisp only for the few tools that can't express them (see
 The disadvantage of the hybrid and alien methods is that they are not well
 supported on Windows systems.  That's why by default alien indexing is the
 default on all operating systems, except Windows."
-  :safe (lambda (x) (memq x '(native hybrid alien)))
   :group 'projectile
-  :type '(radio
+  :type '(choice
           (const :tag "Native" native)
           (const :tag "Hybrid" hybrid)
           (const :tag "Alien" alien))
+  :safe (lambda (x) (memq x '(native hybrid alien)))
   :package-version '(projectile . "2.0.0"))
 
 (defcustom projectile-alien-honors-ignores t
@@ -197,13 +197,13 @@ separate mechanism and remain `hybrid'/`native' only."
   "When t enables project files caching.
 
 Normally the cache lasts for the duration of your Emacs session.
-If you want to cache to persist between Emacs sessions you
-should set this option to `'persistent'.
+If you want the cache to persist between Emacs sessions you
+should set this option to `persistent'.
 
 Project caching is automatically enabled by default if you're
 using the native indexing method."
   :group 'projectile
-  :type '(radio
+  :type '(choice
           (const :tag "Disabled" nil)
           (const :tag "Transient" t)
           (const :tag "Persistent" persistent))
@@ -295,7 +295,7 @@ A value of nil disables this cache.
 See `projectile-file-exists-p' for details."
   :group 'projectile
   :type '(choice (const :tag "Disabled" nil)
-                 (integer :tag "Seconds"))
+                 (natnum :tag "Seconds"))
   :package-version '(projectile . "0.11.0"))
 
 (defcustom projectile-file-exists-remote-cache-expire (* 5 60)
@@ -306,7 +306,7 @@ A value of nil disables this cache.
 See `projectile-file-exists-p' for details."
   :group 'projectile
   :type '(choice (const :tag "Disabled" nil)
-                 (integer :tag "Seconds"))
+                 (natnum :tag "Seconds"))
   :package-version '(projectile . "0.11.0"))
 
 (defcustom projectile-files-cache-expire nil
@@ -314,8 +314,8 @@ See `projectile-file-exists-p' for details."
 
 A value of nil means the cache never expires."
   :group 'projectile
-  :type '(choice (const :tag "Disabled" nil)
-                 (integer :tag "Seconds"))
+  :type '(choice (const :tag "Never expires" nil)
+                 (natnum :tag "Seconds"))
   :package-version '(projectile . "1.0.0"))
 
 (defcustom projectile-auto-discover t
@@ -397,7 +397,7 @@ count against the same limit.
 Only relevant when `projectile-auto-update-cache-with-watches' is
 enabled."
   :group 'projectile
-  :type 'integer
+  :type 'natnum
   :package-version '(projectile . "3.1.0"))
 
 (defcustom projectile-require-project-root 'prompt
@@ -428,9 +428,20 @@ of those legacy values now behaves like `default'."
   :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-keymap-prefix nil
-  "Projectile keymap prefix."
+  "The key sequence `projectile-command-map' is bound to, if any.
+
+A key sequence in the form `kbd' returns, e.g. (kbd \"C-c p\").  There
+is no prefix by default - Projectile binds none of its commands until
+you ask for it.
+
+The value is read once, when `projectile-mode-map' is built as
+Projectile loads, so it has to be set before that - which rules out
+Customize and `setopt'.  Binding the map directly works whenever:
+
+  (define-key projectile-mode-map (kbd \"C-c p\") \\='projectile-command-map)"
   :group 'projectile
-  :type 'string
+  :type '(choice (const :tag "None" nil)
+                 (key-sequence :tag "Prefix"))
   :package-version '(projectile . "0.7"))
 
 (defcustom projectile-cache-file  ".projectile-cache.eld"
@@ -458,12 +469,11 @@ Note that files aren't sorted if `projectile-indexing-method'
 is set to `alien'."
   :group 'projectile
   :type '(choice
-          (radio
-           (const :tag "Default (no sorting)" default)
-           (const :tag "Recently opened files" recentf)
-           (const :tag "Recently active buffers, then recently opened files" recently-active)
-           (const :tag "Access time (atime)" access-time)
-           (const :tag "Modification time (mtime)" modification-time))
+          (const :tag "Default (no sorting)" default)
+          (const :tag "Recently opened files" recentf)
+          (const :tag "Recently active buffers, then recently opened files" recently-active)
+          (const :tag "Access time (atime)" access-time)
+          (const :tag "Modification time (mtime)" modification-time)
           (function :tag "Custom sort function"))
   :package-version '(projectile . "3.1.0"))
 
@@ -517,7 +527,8 @@ Two example filter functions are shipped by default -
 `projectile-buffers-with-file' and
 `projectile-buffers-with-file-or-process'."
   :group 'projectile
-  :type 'function
+  :type '(choice (const :tag "No filtering" nil)
+                 (function :tag "Filter function"))
   :package-version '(projectile . "0.11.0"))
 
 (defcustom projectile-project-name nil
@@ -525,7 +536,8 @@ Two example filter functions are shipped by default -
 
 It has precedence over function `projectile-project-name-function'."
   :group 'projectile
-  :type 'string
+  :type '(choice (const :tag "Derive from the project root" nil)
+                 (string :tag "Name"))
   :safe (lambda (v) (or (null v)
                         (and (stringp v)
                              (not (string-blank-p v)))))
@@ -626,12 +638,13 @@ This should _not_ be set via .dir-locals.el."
 
 (defcustom projectile-dirconfig-comment-prefix
   nil
-  "`projectile-dirconfig-file` comment start marker.
+  "`projectile-dirconfig-file' comment start marker.
 If specified, starting a line in a project's .projectile file with this
 character marks that line as a comment instead of a pattern.
 Similar to '#' in .gitignore files."
   :group 'projectile
-  :type 'character
+  :type '(choice (const :tag "No comment syntax" nil)
+                 (character :tag "Comment character"))
   :package-version '(projectile . "2.2.0"))
 
 (defcustom projectile-warn-on-prefixless-dirconfig-lines t
@@ -645,6 +658,14 @@ such line, listing the offending entries."
   :type 'boolean
   :package-version '(projectile . "3.0.0"))
 
+(defun projectile-string-list-p (value)
+  "Return non-nil when VALUE is a list of strings.
+
+The `:safe' predicate of the options holding a list of names, patterns
+or regexps.  None of them can do more than widen or narrow a listing,
+so a project is free to set them from its .dir-locals.el."
+  (and (proper-list-p value) (seq-every-p #'stringp value)))
+
 (defcustom projectile-globally-ignored-files
   (list projectile-tags-file-name projectile-cache-file)
   "A list of files globally ignored by projectile.
@@ -653,9 +674,9 @@ Entries are gitignore patterns: a plain name matches a file with that
 name at any depth, a name containing a slash is anchored at the project
 root, and `*', `**', `?' and `[...]' are the usual wildcards.  See
 `projectile-globally-ignored-directories' for the full pattern language."
-  :safe (lambda (x) (not (remq t (mapcar #'stringp x))))
   :group 'projectile
   :type '(repeat string)
+  :safe #'projectile-string-list-p
   :package-version '(projectile . "3.0.0"))
 
 (defcustom projectile-globally-unignored-files nil
@@ -665,6 +686,7 @@ Entries cancel out the matching `projectile-globally-ignored-files'
 entries."
   :group 'projectile
   :type '(repeat string)
+  :safe #'projectile-string-list-p
   :package-version '(projectile . "0.14.0"))
 
 (defcustom projectile-globally-ignored-file-suffixes
@@ -675,6 +697,7 @@ were the gitignore pattern `*SUFFIX' (e.g. \".elc\" ignores every
 `.elc' file in the project)."
   :group 'projectile
   :type '(repeat string)
+  :safe #'projectile-string-list-p
   :package-version '(projectile . "0.12.0"))
 
 (defcustom projectile-globally-ignored-directories
@@ -755,9 +778,9 @@ them back, or a `!' line to a project's `.projectile' to get it back
 for that project only.
 
 See also `projectile-global-ignore-file-patterns'."
-  :safe (lambda (x) (not (remq t (mapcar #'stringp x))))
   :group 'projectile
   :type '(repeat string)
+  :safe #'projectile-string-list-p
   :package-version '(projectile . "3.3.0"))
 
 (defcustom projectile-globally-unignored-directories nil
@@ -767,6 +790,7 @@ Entries cancel out the matching `projectile-globally-ignored-directories'
 entries."
   :group 'projectile
   :type '(repeat string)
+  :safe #'projectile-string-list-p
   :package-version '(projectile . "0.14.0"))
 
 (defcustom projectile-global-ignore-file-patterns
@@ -782,9 +806,9 @@ only applied by `native' indexing.
 
 See also `projectile-ignored-file-p' and
 `projectile-ignored-directory-p'."
-  :safe (lambda (x) (not (remq t (mapcar #'stringp x))))
   :group 'projectile
   :type '(repeat string)
+  :safe #'projectile-string-list-p
   :package-version '(projectile . "2.9.0"))
 
 (defcustom projectile-globally-ignored-modes
@@ -797,21 +821,30 @@ See also `projectile-ignored-file-p' and
   "A list of regular expressions for major modes ignored by projectile.
 
 If a buffer is using a given major mode, projectile will ignore
-it for functions working with buffers."
+it for functions working with buffers.
+
+Each entry is matched against the whole mode name, so \"occur-mode\"
+ignores that mode and nothing else, while \"gnus-.*-mode\" ignores a
+family of them."
   :group 'projectile
-  :type '(repeat string)
+  :type '(repeat regexp)
+  :safe #'projectile-string-list-p
   :package-version '(projectile . "0.10.0"))
 
 (defcustom projectile-globally-ignored-buffers
   '("*scratch*"
     "*lsp-log*")
-  "A list of buffer-names ignored by projectile.
+  "A list of buffer names ignored by projectile.
 
-You can use either exact buffer names or regular expressions.
-If a buffer is in the list projectile will ignore it for
-functions working with buffers."
+If a buffer matches one of these, projectile will ignore it for
+functions working with buffers.
+
+Each entry is a regular expression, matched anywhere in the buffer
+name - unlike `projectile-globally-ignored-modes', which matches whole
+mode names.  Anchor an entry yourself when you mean an exact name."
   :group 'projectile
-  :type '(repeat string)
+  :type '(repeat regexp)
+  :safe #'projectile-string-list-p
   :package-version '(projectile . "0.12.0"))
 
 (defcustom projectile-find-file-hook nil
@@ -887,15 +920,15 @@ Either a backend name registered in `projectile-shell-backends'
 you registered yourself with `projectile-register-shell-backend'), `auto'
 to pick the first available backend, or `prompt' to be asked each time."
   :group 'projectile
-  :type '(choice (const :tag "shell" shell)
+  :type '(choice (const :tag "Automatic" auto)
+                 (const :tag "Prompt each time" prompt)
+                 (const :tag "shell" shell)
                  (const :tag "eshell" eshell)
                  (const :tag "ielm" ielm)
                  (const :tag "term" term)
                  (const :tag "vterm" vterm)
                  (const :tag "eat" eat)
                  (const :tag "ghostel" ghostel)
-                 (const :tag "Automatic" auto)
-                 (const :tag "Prompt each time" prompt)
                  (symbol :tag "Other registered backend"))
   :package-version '(projectile . "3.0.0"))
 
@@ -1197,7 +1230,7 @@ your Emacs state wherever that is - including `~/.config/emacs\\=' for a
 configuration kept there, which a hand-rolled `user-emacs-directory\\='
 path would have missed."
   :group 'projectile
-  :type 'string
+  :type 'file
   :package-version '(projectile . "3.4.0"))
 
 (defcustom projectile-ignored-projects nil
@@ -1275,7 +1308,8 @@ projects on a TRAMP host fd is detected separately on the remote (and
 cached per host), since whatever is on the local box may not exist on
 the remote.  See `projectile-fd-executable-for'."
   :group 'projectile
-  :type 'string
+  :type '(choice (const :tag "Don't use fd" nil)
+                 (string :tag "Path or name"))
   :package-version '(projectile . "2.8.0"))
 
 (defvar projectile--remote-fd-executable-cache (make-hash-table :test 'equal)
@@ -1351,7 +1385,8 @@ default value the submodules are listed by running git directly, with
 no shell involved (see issue #1600).  Customizing the variable switches
 back to running it as a shell command."
   :group 'projectile
-  :type 'string
+  :type '(choice (const :tag "Don't list submodules" nil)
+                 (string :tag "Command"))
   :package-version '(projectile . "0.12.0"))
 
 (defcustom projectile-git-ignored-command "git ls-files -zcoi --exclude-standard"
@@ -1476,11 +1511,16 @@ fails with an authentication error.  See URL
     ("lock" . (""))
     ("gpg"  . (""))
     )
-  "Alist of extensions for switching to file with the same name,
-  using other extensions based on the extension of current
-  file."
+  "Alist of extensions to try when switching to a file's counterpart.
+
+Keys and values are extensions without the leading dot; the key nil
+stands for a file with no extension at all.  Each value lists the
+extensions `projectile-find-other-file' offers for a file with that
+key's extension, in the order they are tried."
   :group 'projectile
-  :type 'alist
+  :type '(alist :key-type (choice (string :tag "Extension")
+                                  (const :tag "No extension" nil))
+                :value-type (repeat (string :tag "Extension")))
   :package-version '(projectile . "0.12.0"))
 
 (defcustom projectile-create-missing-test-files nil
@@ -1548,7 +1588,7 @@ will display current project and the end of the list of known
 projects, `keep' will leave the current project at the default
 position."
   :group 'projectile
-  :type '(radio
+  :type '(choice
           (const :tag "Remove" remove)
           (const :tag "Move to end" move-to-end)
           (const :tag "Keep" keep))
@@ -1559,7 +1599,8 @@ position."
 
 If the value is nil, there is no limit to the opened buffers count."
   :group 'projectile
-  :type 'integer
+  :type '(choice (const :tag "No limit" nil)
+                 (natnum :tag "Buffers"))
   :package-version '(projectile . "2.2.0"))
 
 (defcustom projectile-cmd-hist-ignoredups t

--- a/projectile.el
+++ b/projectile.el
@@ -1449,8 +1449,11 @@ back to running it as a shell command."
   :type 'string
   :package-version '(projectile . "2.6.0"))
 
-(defcustom projectile-svn-command "svn list -R . | grep -v '$/' | tr '\\n' '\\0'"
+(defcustom projectile-svn-command "svn list -R . | grep -v '/$' | tr '\\n' '\\0'"
   "Command used by projectile to get the files in a svn project.
+
+`svn list -R' reports directories too, with a trailing slash, so they
+are filtered out - the project files are what Projectile is after.
 
 The command runs non-interactively (its output is piped), so `svn'
 can't prompt for credentials.  For projects on an authenticated remote

--- a/projectile.el
+++ b/projectile.el
@@ -1536,33 +1536,40 @@ It assumes the test/ folder is at the same level as src/."
   :type 'boolean
   :package-version '(projectile . "0.13.0"))
 
-(defcustom projectile-per-project-compilation-buffer nil
-  "When non-nil, each project gets its own compilation buffer.
-
-Compiling, testing and running all use `compilation-mode' and so share
-one buffer across every project.  With this enabled the project name is
-part of the buffer name (`*compilation*<my-project>'), so working on two
-projects at once doesn't have them overwrite each other's output.
-
-Composes with `projectile-per-command-compilation-buffer'."
-  :group 'projectile
-  :type 'boolean
-  :package-version '(projectile . "2.6.0"))
-
-(defcustom projectile-per-command-compilation-buffer nil
-  "When non-nil, each lifecycle command gets its own compilation buffer.
+(defcustom projectile-compilation-buffer-scope nil
+  "What a lifecycle command's compilation buffer is named after.
 
 Compiling, testing and running a project all use `compilation-mode' and
 therefore share one buffer, so running the tests discards the build
-output and vice versa.  With this enabled the command type is part of the
-buffer name (`*compilation*<test>'), which keeps them apart.
+output and vice versa - across projects as well as within one.
+Qualifying the buffer name keeps them apart.  The value is a list of:
 
-Composes with `projectile-per-project-compilation-buffer': with both
-enabled the buffer is named after the project and the command
-\(`*compilation*<my-project:test>')."
+- `project' - the project name (`*compilation*<my-project>'), so two
+  projects don't overwrite each other's output.  This also narrows the
+  buffers offered for saving before a command runs to the project's own.
+- `command' - the lifecycle command (`*compilation*<test>'), so a build
+  and a test run don't overwrite each other.
+
+The two compose: with both, the buffer is `*compilation*<my-project:test>'.
+With nil there's a single shared compilation buffer, as in plain Emacs."
   :group 'projectile
-  :type 'boolean
-  :package-version '(projectile . "3.3.0"))
+  :type '(set (const :tag "Project" project)
+              (const :tag "Lifecycle command" command))
+  :package-version '(projectile . "3.4.0"))
+
+;; Superseded by the single `projectile-compilation-buffer-scope', but still
+;; honored so that an existing configuration keeps working.
+(defvar projectile-per-project-compilation-buffer nil
+  "When non-nil, each project gets its own compilation buffer.")
+(defvar projectile-per-command-compilation-buffer nil
+  "When non-nil, each lifecycle command gets its own compilation buffer.")
+
+(make-obsolete-variable 'projectile-per-project-compilation-buffer
+                        "use `projectile-compilation-buffer-scope' instead."
+                        "3.4.0")
+(make-obsolete-variable 'projectile-per-command-compilation-buffer
+                        "use `projectile-compilation-buffer-scope' instead."
+                        "3.4.0")
 
 (defcustom projectile-after-switch-project-hook nil
   "Hooks run right after project is switched."
@@ -11305,9 +11312,11 @@ command type for the per-type command history), the variable caching
 the last command per project (`:cmd-map'), the .dir-locals.el override
 variable (`:dir-local-var'), a function of the project type returning
 the default command (`:default-fn'), the public command resolver
-\(`:command-fn'), the option making the output buffer interactive
-\(`:use-comint-var'), the prompt prefix (`:prompt') and whether to save
-the project's buffers before running the command (`:save-buffers').")
+\(`:command-fn'), the obsolete option making the output buffer
+interactive (`:use-comint-var', superseded by
+`projectile-use-comint-mode'), the prompt prefix (`:prompt') and
+whether to save the project's buffers before running the command
+\(`:save-buffers').")
 
 (defun projectile--phase-descriptor (phase)
   "Return the lifecycle descriptor for PHASE (a symbol like `compile')."
@@ -11806,20 +11815,29 @@ Bound by `projectile--run-project-cmd' for the duration of the call, so
 `projectile-compilation-buffer-name' - which `compile' calls with nothing
 but the mode name - can tell a test run from a build.")
 
+(defun projectile-compilation-buffer-scope-p (kind)
+  "Return non-nil when the compilation buffer name is qualified by KIND.
+KIND is `project' or `command'.  Reads
+`projectile-compilation-buffer-scope', falling back to the obsolete
+boolean it replaced for a configuration that still sets one."
+  (or (memq kind projectile-compilation-buffer-scope)
+      (pcase kind
+        ('project (with-no-warnings projectile-per-project-compilation-buffer))
+        ('command (with-no-warnings projectile-per-command-compilation-buffer)))))
+
 (defun projectile-compilation-buffer-name (compilation-mode)
-  "Meant to be used for `compilation-buffer-name-function`.
+  "Meant to be used for `compilation-buffer-name-function'.
 Argument COMPILATION-MODE is the name of the major mode used for the
 compilation buffer.
 
 The name is qualified by the project and/or the lifecycle command type,
-according to `projectile-per-project-compilation-buffer' and
-`projectile-per-command-compilation-buffer'."
+according to `projectile-compilation-buffer-scope'."
   (let ((qualifiers
          (delq nil
-               (list (and projectile-per-project-compilation-buffer
+               (list (and (projectile-compilation-buffer-scope-p 'project)
                           (projectile-project-p)
                           (projectile-project-name))
-                     (and projectile-per-command-compilation-buffer
+                     (and (projectile-compilation-buffer-scope-p 'command)
                           projectile--compilation-command-type
                           (symbol-name projectile--compilation-command-type))))))
     (concat "*" (downcase compilation-mode) "*"
@@ -12098,8 +12116,7 @@ running the command.
 
 BUFFER-NAME-FUNCTION, when non-nil, is used as the
 `compilation-buffer-name-function' for the compilation, taking
-precedence over the `projectile-per-project-compilation-buffer'
-naming.
+precedence over the `projectile-compilation-buffer-scope' naming.
 
 The placeholder `%p' in COMMAND is replaced with the project name.
 
@@ -12141,10 +12158,10 @@ The command actually run is returned."
                          (lambda ()
                            (projectile-project-buffer-p (current-buffer)
                                                         project-root))))
-    (when projectile-per-project-compilation-buffer
+    (when (projectile-compilation-buffer-scope-p 'project)
       (setq compilation-save-buffers-predicate #'projectile-current-project-buffer-p))
-    (when (or projectile-per-project-compilation-buffer
-              projectile-per-command-compilation-buffer)
+    (when (or (projectile-compilation-buffer-scope-p 'project)
+              (projectile-compilation-buffer-scope-p 'command))
       (setq compilation-buffer-name-function #'projectile-compilation-buffer-name))
     (when buffer-name-function
       (setq compilation-buffer-name-function buffer-name-function))
@@ -12159,41 +12176,63 @@ The command actually run is returned."
     (projectile-run-compilation command use-comint-mode)
     command))
 
-(defcustom projectile-configure-use-comint-mode nil
-  "Make the output buffer of `projectile-configure-project' interactive."
-  :group 'projectile
-  :type 'boolean
-  :package-version '(projectile . "2.5.0"))
+(defcustom projectile-use-comint-mode nil
+  "Which lifecycle commands get an interactive output buffer.
 
-(defcustom projectile-compile-use-comint-mode nil
-  "Make the output buffer of `projectile-compile-project' interactive."
-  :group 'projectile
-  :type 'boolean
-  :package-version '(projectile . "2.5.0"))
+The lifecycle commands report through `compilation-mode', which is
+read-only.  For a command covered here Projectile uses `comint-mode'
+instead, so a build that asks a question, or a test runner that drops
+into a debugger, can be typed at.
 
-(defcustom projectile-test-use-comint-mode nil
-  "Make the output buffer of `projectile-test-project' interactive."
+The value is nil (no command is interactive), t (all of them), or a
+list naming the ones that are - `configure', `compile', `test',
+`install', `package' and `run'."
   :group 'projectile
-  :type 'boolean
-  :package-version '(projectile . "2.5.0"))
+  :type '(choice (const :tag "No command" nil)
+                 (const :tag "Every command" t)
+                 (set :tag "Selected commands"
+                      (const :tag "Configure" configure)
+                      (const :tag "Compile" compile)
+                      (const :tag "Test" test)
+                      (const :tag "Install" install)
+                      (const :tag "Package" package)
+                      (const :tag "Run" run)))
+  :package-version '(projectile . "3.4.0"))
 
-(defcustom projectile-install-use-comint-mode nil
-  "Make the output buffer of `projectile-install-project' interactive."
-  :group 'projectile
-  :type 'boolean
-  :package-version '(projectile . "2.5.0"))
+;; Superseded by the single `projectile-use-comint-mode', but still honored
+;; so that an existing configuration keeps working.
+(defvar projectile-configure-use-comint-mode nil
+  "Make the output buffer of `projectile-configure-project' interactive.")
+(defvar projectile-compile-use-comint-mode nil
+  "Make the output buffer of `projectile-compile-project' interactive.")
+(defvar projectile-test-use-comint-mode nil
+  "Make the output buffer of `projectile-test-project' interactive.")
+(defvar projectile-install-use-comint-mode nil
+  "Make the output buffer of `projectile-install-project' interactive.")
+(defvar projectile-package-use-comint-mode nil
+  "Make the output buffer of `projectile-package-project' interactive.")
+(defvar projectile-run-use-comint-mode nil
+  "Make the output buffer of `projectile-run-project' interactive.")
 
-(defcustom projectile-package-use-comint-mode nil
-  "Make the output buffer of `projectile-package-project' interactive."
-  :group 'projectile
-  :type 'boolean
-  :package-version '(projectile . "2.5.0"))
+(dolist (var '(projectile-configure-use-comint-mode
+               projectile-compile-use-comint-mode
+               projectile-test-use-comint-mode
+               projectile-install-use-comint-mode
+               projectile-package-use-comint-mode
+               projectile-run-use-comint-mode))
+  (make-obsolete-variable var "use `projectile-use-comint-mode' instead."
+                          "3.4.0"))
 
-(defcustom projectile-run-use-comint-mode nil
-  "Make the output buffer of `projectile-run-project' interactive."
-  :group 'projectile
-  :type 'boolean
-  :package-version '(projectile . "2.5.0"))
+(defun projectile-use-comint-mode-p (phase)
+  "Return non-nil when PHASE's output buffer should be interactive.
+PHASE is a lifecycle phase symbol such as `compile'.  Reads
+`projectile-use-comint-mode', falling back to the obsolete per-phase
+option it replaced for a configuration that still sets one."
+  (or (if (listp projectile-use-comint-mode)
+          (memq phase projectile-use-comint-mode)
+        projectile-use-comint-mode)
+      (symbol-value (plist-get (projectile--phase-descriptor phase)
+                               :use-comint-var))))
 
 (defun projectile--phase-command-dynamic-p (phase)
   "Non-nil when PHASE's command comes from a function for the current project.
@@ -12240,7 +12279,8 @@ root (see `projectile-compilation-dir')."
                                  :prompt-prefix (projectile--lifecycle-prompt descriptor base)
                                  :save-buffers (plist-get descriptor :save-buffers)
                                  :no-cache (projectile--phase-command-dynamic-p phase)
-                                 :use-comint-mode (symbol-value (plist-get descriptor :use-comint-var)))))
+                                 :use-comint-mode (projectile-use-comint-mode-p
+                                                   (plist-get descriptor :name)))))
 
 ;;;###autoload
 (defun projectile-configure-project (arg)
@@ -12700,7 +12740,7 @@ a prefix ARG you can edit the command before it's run."
                                      :show-prompt arg
                                      :prompt-prefix "Test at point command: "
                                      :save-buffers t
-                                     :use-comint-mode projectile-test-use-comint-mode)))))
+                                     :use-comint-mode (projectile-use-comint-mode-p 'test))))))
 
 ;;;###autoload
 (defun projectile-install-project (arg)
@@ -12811,7 +12851,7 @@ the `%p' placeholder still intact."
     ;; `projectile--run-project-cmd' from prompting a second time.
     (let ((compilation-read-command nil)
           (buffer-name (concat "*projectile-task: " task-name "*"
-                               (when projectile-per-project-compilation-buffer
+                               (when (projectile-compilation-buffer-scope-p 'project)
                                  (concat "<" (projectile-project-name project-root) ">")))))
       (projectile--run-project-cmd command nil
                                    :save-buffers t

--- a/test/projectile-buffers-test.el
+++ b/test/projectile-buffers-test.el
@@ -71,7 +71,20 @@
     (let ((projectile-globally-ignored-buffers '("*nrepl messages*" "*something*")))
       (expect (projectile-ignored-buffer-p (get-buffer-create "*nrepl messages*")) :to-be-truthy)
       (expect (projectile-ignored-buffer-p (get-buffer-create "*something*")) :to-be-truthy)
-      (expect (projectile-ignored-buffer-p (get-buffer-create "test")) :not :to-be-truthy))))
+      (expect (projectile-ignored-buffer-p (get-buffer-create "test")) :not :to-be-truthy)))
+
+  ;; The entries are matched with `string-match-p', so a buffer name has to
+  ;; be spelled as a regexp - an unescaped `*scratch*' matched only by
+  ;; accident (leading `*' literal, trailing `h*' a repetition).
+  (it "ignores the buffers its default value names"
+    (expect (projectile-ignored-buffer-p (get-buffer-create "*scratch*")) :to-be-truthy)
+    (expect (projectile-ignored-buffer-p (get-buffer-create "*lsp-log*")) :to-be-truthy)
+    (expect (projectile-ignored-buffer-p (get-buffer-create "scratch.el"))
+            :not :to-be-truthy))
+
+  (it "has a default value of valid regexps"
+    (dolist (re projectile-globally-ignored-buffers)
+      (expect (ignore-errors (string-match-p re "") t) :to-be-truthy))))
 
 (describe "projectile-process-current-project-buffers-current"
   (it "expects projectile-process-current-project-buffers and

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -298,7 +298,7 @@
     (let ((projectile-project-types projectile-project-types)
           (projectile-run-cmd-map (make-hash-table :test 'equal))
           (projectile-project-run-cmd nil)
-          (projectile-per-project-compilation-buffer nil)
+          (projectile-compilation-buffer-scope nil)
           (compilation-read-command nil))
       (defun projectile-test--dyn-run () "run-it")
       (projectile-register-project-type 'dyn-run-project '("dyn.marker")
@@ -316,7 +316,7 @@
   (it "re-runs CMake preset selection on every configure"
     (let ((projectile-configure-cmd-map (make-hash-table :test 'equal))
           (projectile-project-configure-cmd nil)
-          (projectile-per-project-compilation-buffer nil)
+          (projectile-compilation-buffer-scope nil)
           (compilation-read-command nil))
       (spy-on 'projectile-project-type :and-return-value 'cmake)
       (spy-on 'projectile--cmake-select-command
@@ -334,7 +334,7 @@
     (let ((projectile-project-types projectile-project-types)
           (projectile-compilation-cmd-map (make-hash-table :test 'equal))
           (projectile-project-compilation-cmd nil)
-          (projectile-per-project-compilation-buffer nil))
+          (projectile-compilation-buffer-scope nil))
       (defun projectile-test--dyn-compile () "cmake --build build")
       (projectile-register-project-type 'dyn-compile-project '("dyn.marker")
                                         :compile 'projectile-test--dyn-compile)
@@ -353,7 +353,7 @@
     (let ((projectile-project-types projectile-project-types)
           (projectile-compilation-cmd-map (make-hash-table :test 'equal))
           (projectile-project-compilation-cmd nil)
-          (projectile-per-project-compilation-buffer nil))
+          (projectile-compilation-buffer-scope nil))
       (defun projectile-test--dyn-compile2 () "cmake --build build")
       (projectile-register-project-type 'dyn-compile-project-2 '("dyn.marker")
                                         :compile 'projectile-test--dyn-compile2)
@@ -372,37 +372,46 @@
     (spy-on 'projectile-project-p :and-return-value t)
     (spy-on 'projectile-project-name :and-return-value "my-project"))
 
-  (it "is the plain compilation buffer when neither option is on"
-    (let ((projectile-per-project-compilation-buffer nil)
-          (projectile-per-command-compilation-buffer nil)
+  (it "is the plain compilation buffer when the scope is empty"
+    (let ((projectile-compilation-buffer-scope nil)
           (projectile--compilation-command-type 'test))
       (expect (projectile-compilation-buffer-name "compilation")
               :to-equal "*compilation*")))
 
-  (it "qualifies by project"
-    (let ((projectile-per-project-compilation-buffer t)
-          (projectile-per-command-compilation-buffer nil)
+  (it "still honors the obsolete per-project boolean"
+    (let ((projectile-compilation-buffer-scope nil)
+          (projectile-per-project-compilation-buffer t)
           (projectile--compilation-command-type 'test))
       (expect (projectile-compilation-buffer-name "compilation")
               :to-equal "*compilation*<my-project>")))
 
-  (it "qualifies by command type"
-    (let ((projectile-per-project-compilation-buffer nil)
+  (it "still honors the obsolete per-command boolean"
+    (let ((projectile-compilation-buffer-scope nil)
           (projectile-per-command-compilation-buffer t)
           (projectile--compilation-command-type 'test))
       (expect (projectile-compilation-buffer-name "compilation")
               :to-equal "*compilation*<test>")))
 
+  (it "qualifies by project"
+    (let ((projectile-compilation-buffer-scope '(project))
+          (projectile--compilation-command-type 'test))
+      (expect (projectile-compilation-buffer-name "compilation")
+              :to-equal "*compilation*<my-project>")))
+
+  (it "qualifies by command type"
+    (let ((projectile-compilation-buffer-scope '(command))
+          (projectile--compilation-command-type 'test))
+      (expect (projectile-compilation-buffer-name "compilation")
+              :to-equal "*compilation*<test>")))
+
   (it "qualifies by both, project first"
-    (let ((projectile-per-project-compilation-buffer t)
-          (projectile-per-command-compilation-buffer t)
+    (let ((projectile-compilation-buffer-scope '(project command))
           (projectile--compilation-command-type 'compile))
       (expect (projectile-compilation-buffer-name "compilation")
               :to-equal "*compilation*<my-project:compile>")))
 
   (it "omits the command type when there isn't one"
-    (let ((projectile-per-project-compilation-buffer nil)
-          (projectile-per-command-compilation-buffer t)
+    (let ((projectile-compilation-buffer-scope '(command))
           (projectile--compilation-command-type nil))
       (expect (projectile-compilation-buffer-name "compilation")
               :to-equal "*compilation*"))))
@@ -419,8 +428,7 @@
             (lambda (_arg default &rest _) default)))
 
   (it "sends compile and test output to different buffers"
-    (let ((projectile-per-command-compilation-buffer t)
-          (projectile-per-project-compilation-buffer nil)
+    (let ((projectile-compilation-buffer-scope '(command))
           names)
       (spy-on 'projectile-run-compilation :and-call-fake
               (lambda (&rest _)
@@ -431,8 +439,7 @@
               :to-equal '("*compilation*<compile>" "*compilation*<test>"))))
 
   (it "leaves them sharing a buffer when the option is off"
-    (let ((projectile-per-command-compilation-buffer nil)
-          (projectile-per-project-compilation-buffer t)
+    (let ((projectile-compilation-buffer-scope '(project))
           names)
       (spy-on 'projectile-run-compilation :and-call-fake
               (lambda (&rest _)
@@ -908,5 +915,32 @@
     (spy-on 'find-file)
     (projectile-find-changed-file t)
     (expect 'projectile-git-changed-files :to-have-been-called-with "/proj/" "main")))
+
+(describe "projectile-use-comint-mode-p"
+  (it "makes no command interactive when nil"
+    (let ((projectile-use-comint-mode nil))
+      (expect (projectile-use-comint-mode-p 'test) :to-be nil)
+      (expect (projectile-use-comint-mode-p 'compile) :to-be nil)))
+
+  (it "makes every command interactive when t"
+    (let ((projectile-use-comint-mode t))
+      (expect (projectile-use-comint-mode-p 'test) :to-be-truthy)
+      (expect (projectile-use-comint-mode-p 'run) :to-be-truthy)))
+
+  (it "makes only the listed commands interactive"
+    (let ((projectile-use-comint-mode '(test run)))
+      (expect (projectile-use-comint-mode-p 'test) :to-be-truthy)
+      (expect (projectile-use-comint-mode-p 'run) :to-be-truthy)
+      (expect (projectile-use-comint-mode-p 'compile) :to-be nil)))
+
+  (it "still honors the obsolete per-phase option"
+    (let ((projectile-use-comint-mode nil)
+          (projectile-test-use-comint-mode t))
+      (expect (projectile-use-comint-mode-p 'test) :to-be-truthy)
+      (expect (projectile-use-comint-mode-p 'compile) :to-be nil)))
+
+  (it "rejects a phase it doesn't know"
+    (let ((projectile-use-comint-mode nil))
+      (expect (projectile-use-comint-mode-p 'bogus) :to-throw))))
 
 ;;; projectile-commands-test.el ends here

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -202,10 +202,10 @@
       (projectile--run-project-cmd "make" command-map :command-type 'compile)
       (expect (hash-table-count command-map) :to-equal 1)))
 
-  (it "projectile-cmd-hist-ignoredups set to t"
+  (it "projectile-command-history-ignore-duplicates set to t"
 
     (let ((command-map (make-hash-table :test 'equal))
-          (projectile-cmd-hist-ignoredups t)
+          (projectile-command-history-ignore-duplicates t)
           ;; history is based on the project root, so we set it to a random
           ;; path to ensure there are no existing commands in history
           (projectile-project-root "/a/random/path"))
@@ -218,9 +218,9 @@
                (projectile--get-command-history projectile-project-root))
               :to-equal '("foo" "bar" "foo"))))
 
-  (it "projectile-cmd-hist-ignoredups set to erase"
+  (it "projectile-command-history-ignore-duplicates set to erase"
     (let ((command-map (make-hash-table :test 'equal))
-          (projectile-cmd-hist-ignoredups 'erase)
+          (projectile-command-history-ignore-duplicates 'erase)
           (projectile-project-root "/a/random/path"))
       (projectile--run-project-cmd "foo" command-map)
       (projectile--run-project-cmd "bar" command-map)
@@ -233,7 +233,7 @@
 
   (it "keeps a separate history per command type without bleeding"
     (let ((command-map (make-hash-table :test 'equal))
-          (projectile-cmd-hist-ignoredups t)
+          (projectile-command-history-ignore-duplicates t)
           (projectile-project-command-history (make-hash-table :test 'equal))
           (projectile-project-root "/a/random/path"))
       (projectile--run-project-cmd "make" command-map :command-type 'compile)
@@ -254,7 +254,7 @@
 
   (it "does not record a per-type history when command-type is nil"
     (let ((command-map (make-hash-table :test 'equal))
-          (projectile-cmd-hist-ignoredups t)
+          (projectile-command-history-ignore-duplicates t)
           (projectile-project-command-history (make-hash-table :test 'equal))
           (projectile-project-root "/a/random/path"))
       (projectile--run-project-cmd "foo" command-map)

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -392,6 +392,19 @@
       (expect (projectile-compilation-buffer-name "compilation")
               :to-equal "*compilation*<test>")))
 
+  (it "reads t as naming both aspects"
+    (let ((projectile-compilation-buffer-scope t)
+          (projectile--compilation-command-type 'compile))
+      (expect (projectile-compilation-buffer-name "compilation")
+              :to-equal "*compilation*<my-project:compile>")))
+
+  (it "does not repeat an aspect the obsolete boolean also asks for"
+    (let ((projectile-compilation-buffer-scope '(project))
+          (projectile-per-project-compilation-buffer t)
+          (projectile--compilation-command-type 'test))
+      (expect (projectile-compilation-buffer-name "compilation")
+              :to-equal "*compilation*<my-project>")))
+
   (it "qualifies by project"
     (let ((projectile-compilation-buffer-scope '(project))
           (projectile--compilation-command-type 'test))
@@ -937,10 +950,6 @@
     (let ((projectile-use-comint-mode nil)
           (projectile-test-use-comint-mode t))
       (expect (projectile-use-comint-mode-p 'test) :to-be-truthy)
-      (expect (projectile-use-comint-mode-p 'compile) :to-be nil)))
-
-  (it "rejects a phase it doesn't know"
-    (let ((projectile-use-comint-mode nil))
-      (expect (projectile-use-comint-mode-p 'bogus) :to-throw))))
+      (expect (projectile-use-comint-mode-p 'compile) :to-be nil))))
 
 ;;; projectile-commands-test.el ends here

--- a/test/projectile-core-test.el
+++ b/test/projectile-core-test.el
@@ -648,11 +648,6 @@
                     (projectile-replace-scan-chunk-size
                      . projectile-search-scan-chunk-size)))
       (expect (indirect-variable (car pair)) :to-be (cdr pair))
-      (expect (get (car pair) 'byte-obsolete-variable) :not :to-be nil)))
-
-  (it "routes a value set under the old name to the new option"
-    (let ((projectile-search-max-matches 5000))
-      (with-no-warnings (setq projectile-replace-max-matches 42))
-      (expect projectile-search-max-matches :to-equal 42))))
+      (expect (get (car pair) 'byte-obsolete-variable) :not :to-be nil))))
 
 ;;; projectile-core-test.el ends here

--- a/test/projectile-core-test.el
+++ b/test/projectile-core-test.el
@@ -632,4 +632,27 @@
       (expect (locate-user-emacs-file "projectile-bookmarks.eld")
               :to-equal "~/.emacs.d/projectile-bookmarks.eld"))))
 
+(describe "renamed configuration options"
+  ;; The old names are obsolete aliases, so a configuration written against
+  ;; them keeps working.  Setting one must reach the new option.
+  (it "keeps the old name working as an alias for the new one"
+    (dolist (pair '((projectile-auto-discover . projectile-auto-discover-projects)
+                    (projectile-global-ignore-file-patterns
+                     . projectile-globally-ignored-file-regexps)
+                    (projectile-related-files-fn-function
+                     . projectile-related-files-function)
+                    (projectile-cmd-hist-ignoredups
+                     . projectile-command-history-ignore-duplicates)
+                    (projectile-replace-max-matches . projectile-search-max-matches)
+                    (projectile-replace-async . projectile-search-async)
+                    (projectile-replace-scan-chunk-size
+                     . projectile-search-scan-chunk-size)))
+      (expect (indirect-variable (car pair)) :to-be (cdr pair))
+      (expect (get (car pair) 'byte-obsolete-variable) :not :to-be nil)))
+
+  (it "routes a value set under the old name to the new option"
+    (let ((projectile-search-max-matches 5000))
+      (with-no-warnings (setq projectile-replace-max-matches 42))
+      (expect projectile-search-max-matches :to-equal 42))))
+
 ;;; projectile-core-test.el ends here

--- a/test/projectile-ignore-test.el
+++ b/test/projectile-ignore-test.el
@@ -111,7 +111,7 @@
 
 (describe "projectile-globally-ignored-files"
   (it "includes TAGS file by default"
-    (expect (member projectile-tags-file-name projectile-globally-ignored-files) :to-be-truthy))
+    (expect (member "TAGS" projectile-globally-ignored-files) :to-be-truthy))
   (it "includes cache file by default"
     (expect (member projectile-cache-file projectile-globally-ignored-files) :to-be-truthy))
   (it "causes cache file to be ignored via projectile-ignored-file-p"

--- a/test/projectile-ignore-test.el
+++ b/test/projectile-ignore-test.el
@@ -62,8 +62,8 @@
   (it "lets an ensure pattern rescue an ignored file"
     (spy-on 'projectile--dirconfig-ensure :and-return-value '("TAGS"))
     (expect (projectile-ignored-file-p "/path/to/project/TAGS") :not :to-be-truthy))
-  (it "applies projectile-global-ignore-file-patterns to the absolute name"
-    (let ((projectile-global-ignore-file-patterns '("\\.min\\.js\\'")))
+  (it "applies projectile-globally-ignored-file-regexps to the absolute name"
+    (let ((projectile-globally-ignored-file-regexps '("\\.min\\.js\\'")))
       (expect (projectile-ignored-file-p "/path/to/project/a.min.js") :to-be-truthy)
       (expect (projectile-ignored-file-p "/path/to/project/a.js") :not :to-be-truthy))))
 
@@ -477,15 +477,15 @@
 (describe "projectile--global-ignore-regexp-p"
   (it "matches the regexps case-sensitively"
     ;; `string-match-p' folds case by default
-    (let ((projectile-global-ignore-file-patterns '("build")))
+    (let ((projectile-globally-ignored-file-regexps '("build")))
       (expect (projectile--global-ignore-regexp-p "/r/build/a.o") :to-be-truthy)
       (expect (projectile--global-ignore-regexp-p "/r/BUILD/a.o") :not :to-be-truthy)))
   (it "matches against the absolute file name"
-    (let ((projectile-global-ignore-file-patterns '("\\.min\\.js\\'")))
+    (let ((projectile-globally-ignored-file-regexps '("\\.min\\.js\\'")))
       (expect (projectile--global-ignore-regexp-p "/r/foo.min.js") :to-be-truthy)
       (expect (projectile--global-ignore-regexp-p "/r/foo.js") :not :to-be-truthy)))
   (it "returns nil when there are no patterns"
-    (let ((projectile-global-ignore-file-patterns nil))
+    (let ((projectile-globally-ignored-file-regexps nil))
       (expect (projectile--global-ignore-regexp-p "/r/foo.js") :not :to-be-truthy))))
 
 (describe "projectile--ignore-patterns"

--- a/test/projectile-indexing-test.el
+++ b/test/projectile-indexing-test.el
@@ -411,6 +411,19 @@
     (expect (projectile-get-ext-command 'none) :to-equal projectile-generic-command)
     (expect (projectile-get-ext-command nil) :to-equal projectile-generic-command)))
 
+(describe "projectile-svn-command"
+  ;; `svn list -R' lists directories too, with a trailing slash.  The
+  ;; filter meant to drop them read `grep -v '$/'', where the `$' is
+  ;; literal rather than an anchor, so it dropped nothing at all.
+  (it "drops the directory entries from an svn listing"
+    (let* ((filter (nth 1 (split-string projectile-svn-command "|" nil "[ \t]+")))
+           (out (with-temp-buffer
+                  (insert "src/\nsrc/main.c\ndoc/\nREADME\n")
+                  (shell-command-on-region (point-min) (point-max) filter
+                                           (current-buffer) t)
+                  (buffer-string))))
+      (expect (split-string out "\n" t) :to-equal '("src/main.c" "README")))))
+
 (describe "projectile-fd-executable-for"
   (it "returns the local fd executable for a local directory"
     (let ((projectile-fd-executable "fd"))

--- a/test/projectile-known-projects-test.el
+++ b/test/projectile-known-projects-test.el
@@ -238,7 +238,7 @@
 (describe "projectile-known-projects auto-discovery"
   (it "auto-discovers only once per session"
     (let ((projectile-known-projects '("/p/"))
-          (projectile-auto-discover t)
+          (projectile-auto-discover-projects t)
           (projectile-auto-cleanup-known-projects nil)
           (projectile-project-search-path '("/search/"))
           (projectile--search-path-discovered nil))
@@ -251,7 +251,7 @@
 
   (it "does not auto-discover without a search path"
     (let ((projectile-known-projects '("/p/"))
-          (projectile-auto-discover t)
+          (projectile-auto-discover-projects t)
           (projectile-auto-cleanup-known-projects nil)
           (projectile-project-search-path nil)
           (projectile--search-path-discovered nil))

--- a/test/projectile-scan-async-test.el
+++ b/test/projectile-scan-async-test.el
@@ -81,7 +81,7 @@
         (unwind-protect
             ;; a chunk larger than the candidate set finishes in one inline
             ;; pass (no timer), the simplest way to drive it to completion
-            (let ((projectile-replace-scan-chunk-size 10000))
+            (let ((projectile-search-scan-chunk-size 10000))
               (projectile-replace--gather-async candidates "foo" buf nil)
               (with-current-buffer buf
                 (expect projectile-replace--scanning :to-be nil)
@@ -103,7 +103,7 @@
              (sync (projectile-scan-async-test--sync-matches candidates))
              (buf (projectile-scan-async-test--seed root)))
         (unwind-protect
-            (let ((projectile-replace-scan-chunk-size 1))
+            (let ((projectile-search-scan-chunk-size 1))
               (projectile-replace--gather-async candidates "foo" buf nil)
               ;; the first chunk ran inline; more files remain, so a scan is
               ;; in flight with a pending timer and partial matches
@@ -140,7 +140,7 @@
         (unwind-protect
             ;; one file per chunk, so e.txt is scanned in a LATE chunk (from a
             ;; timer); the driver must re-establish case-fold there too
-            (let ((projectile-replace-scan-chunk-size 1))
+            (let ((projectile-search-scan-chunk-size 1))
               (projectile-replace--gather-async candidates "foo" buf nil)
               (projectile-scan-async-test--pump buf)
               (with-current-buffer buf
@@ -159,11 +159,11 @@
          ("d.txt" . "foo\n") ("e.txt" . "foo\n") ("f.txt" . "foo\n"))
       (let* ((root default-directory)
              (candidates (projectile-scan-async-test--candidates root))
-             (projectile-replace-max-matches 3)   ; budget ends at a chunk edge
+             (projectile-search-max-matches 3)   ; budget ends at a chunk edge
              (sync (projectile-scan-async-test--sync-matches candidates))
              (buf (projectile-scan-async-test--seed root)))
         (unwind-protect
-            (let ((projectile-replace-scan-chunk-size 3)) ; boundary at file 3
+            (let ((projectile-search-scan-chunk-size 3)) ; boundary at file 3
               (projectile-replace--gather-async candidates "foo" buf nil)
               (projectile-scan-async-test--pump buf)
               (with-current-buffer buf
@@ -184,7 +184,7 @@
              (buf (projectile-scan-async-test--seed root))
              (seen nil))
         (unwind-protect
-            (let ((projectile-replace-scan-chunk-size 1))
+            (let ((projectile-search-scan-chunk-size 1))
               (projectile-replace--gather-async
                candidates "foo" buf
                (lambda (b) (setq seen (list b (buffer-local-value
@@ -195,7 +195,7 @@
               (expect (cadr seen) :to-be nil))
           (kill-buffer buf)))))
 
-  (it "honors projectile-replace-max-matches and sets truncated"
+  (it "honors projectile-search-max-matches and sets truncated"
     (projectile-test-with-project
         (("a.txt" . "foo\nfoo\n")
          ("b.txt" . "foo\nfoo\n")
@@ -204,8 +204,8 @@
              (candidates (projectile-scan-async-test--candidates root))
              (buf (projectile-scan-async-test--seed root)))
         (unwind-protect
-            (let ((projectile-replace-max-matches 3)
-                  (projectile-replace-scan-chunk-size 1))
+            (let ((projectile-search-max-matches 3)
+                  (projectile-search-scan-chunk-size 1))
               (projectile-replace--gather-async candidates "foo" buf nil)
               (projectile-scan-async-test--pump buf)
               (with-current-buffer buf
@@ -268,7 +268,7 @@
              (candidates (projectile-scan-async-test--candidates root))
              (buf (projectile-scan-async-test--seed root)))
         (unwind-protect
-            (let ((projectile-replace-scan-chunk-size 1))
+            (let ((projectile-search-scan-chunk-size 1))
               (projectile-replace--gather-async candidates "foo" buf nil)
               (let ((old (buffer-local-value 'projectile-replace--scan-timer buf)))
                 (expect old :not :to-be nil)
@@ -290,7 +290,7 @@
       (let* ((root default-directory)
              (candidates (projectile-scan-async-test--candidates root))
              (buf (projectile-scan-async-test--seed root))
-             (projectile-replace-scan-chunk-size 1))
+             (projectile-search-scan-chunk-size 1))
         (projectile-replace--gather-async candidates "foo" buf nil)
         (let ((old (buffer-local-value 'projectile-replace--scan-timer buf)))
           (expect old :not :to-be nil)

--- a/test/projectile-search-review-test.el
+++ b/test/projectile-search-review-test.el
@@ -430,7 +430,7 @@ REGEXP-P selects `projectile-search-regexp-review'."
       (expect (member "--word-regexp" cmd) :to-be-truthy))))
 
 (describe "projectile-search--rg-ingest streaming and cap"
-  (it "honors projectile-replace-max-matches and marks the list truncated"
+  (it "honors projectile-search-max-matches and marks the list truncated"
     (projectile-test-with-project
         (("a.txt" . "foo\n"))
       (let ((buf (get-buffer-create projectile-search-buffer-name))
@@ -445,7 +445,7 @@ REGEXP-P selects `projectile-search-regexp-review'."
         (projectile-replace--seed buf #'projectile-search-mode
                                   default-directory "foo" "foo" nil t t)
         (with-current-buffer buf (setq projectile-replace--scanning t))
-        (let ((projectile-replace-max-matches 2))
+        (let ((projectile-search-max-matches 2))
           (let ((capped (projectile-search--rg-ingest
                          buf (list (funcall line 1)
                                    (funcall line 2)
@@ -585,13 +585,13 @@ REGEXP-P selects `projectile-search-regexp-review'."
                   :to-be-a-match-with '(:line 1 :column 5 :string "foo"
                                         :context "café foo bar"))))))
 
-  (it "honors projectile-replace-max-matches over a real ripgrep stream"
+  (it "honors projectile-search-max-matches over a real ripgrep stream"
     (assume (executable-find "rg") "ripgrep is not installed")
     (projectile-test-with-project
         (("a.txt" . "foo\nfoo\nfoo\n"))
       (let ((buf (get-buffer-create projectile-search-buffer-name))
             (root default-directory)
-            (projectile-replace-max-matches 1))
+            (projectile-search-max-matches 1))
         (projectile-replace--seed buf #'projectile-search-mode
                                   root "foo" "foo" nil t t)
         (projectile-search--gather-rg buf "foo" nil)

--- a/test/projectile-tasks-test.el
+++ b/test/projectile-tasks-test.el
@@ -485,12 +485,12 @@ main.o: main.c
       (spy-on 'projectile-completing-read :and-return-value "lint")
       (let ((projectile-project-command-history (make-hash-table :test 'equal))
             (projectile-last-task-map (make-hash-table :test 'equal))
-            (projectile-per-project-compilation-buffer nil)
+            (projectile-compilation-buffer-scope nil)
             (projectile-tasks '(("lint" . "make lint"))))
         (projectile-run-task nil)
         (expect buffer-name :to-equal "*projectile-task: lint*"))))
 
-  (it "appends the project name to the task buffer with per-project compilation buffers"
+  (it "appends the project name to the task buffer when the scope includes the project"
     (let ((buffer-name nil))
       (spy-on 'projectile-run-compilation :and-call-fake
               (lambda (&rest _)
@@ -499,7 +499,7 @@ main.o: main.c
       (spy-on 'projectile-completing-read :and-return-value "lint")
       (let ((projectile-project-command-history (make-hash-table :test 'equal))
             (projectile-last-task-map (make-hash-table :test 'equal))
-            (projectile-per-project-compilation-buffer t)
+            (projectile-compilation-buffer-scope '(project))
             (projectile-tasks '(("lint" . "make lint"))))
         (projectile-run-task nil)
         (expect buffer-name :to-equal "*projectile-task: lint*<myproj>")))))


### PR DESCRIPTION
A pass over all 128 defcustoms, looking for naming that broke its own scheme,
types that didn't match the values they accept, and options that could be one
instead of several.

Seven options document `nil` as meaningful but declared a `:type` that rejects
it, so Customize showed them as mismatched and refused to edit them at all. Two
families fold into one option each (the six `*-use-comint-mode` booleans, and
the two compilation-buffer ones), and seven options move onto the naming scheme
their siblings already used. Every old name stays as an obsolete alias or
variable, so existing configuration keeps working.

One real bug fell out of it: `projectile-svn-command` filters directories out of
`svn list -R` with `grep -v '$/'`, where the `$` is a literal rather than an
anchor, so it never dropped anything. That's been broken since 2014.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [docs](../blob/master/doc/modules/ROOT/pages) (when adding new project types, configuration options, commands, etc)