### PR TITLE
Share the command history across a repository's checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@
 
 ### Changes
 
+- [#2152](https://github.com/bbatsov/projectile/pull/2152): The per-command-type histories now belong to the repository rather than the directory, so pressing `M-p` at a compile or test prompt in a fresh git worktree - or in a second clone of the same upstream - offers the commands the project is actually built with instead of nothing ([#1786](https://github.com/bbatsov/projectile/issues/1786)).
+  - What a prompt is pre-filled with, and what `projectile-repeat-last-command` replays, stay local to the checkout you're in: both act without asking, and a remembered command can carry absolute paths back into the checkout it was typed in.
+  - Existing histories are adopted rather than dropped, and `projectile-command-history-scope` set to `project` restores a history per directory.
 - [#2146](https://github.com/bbatsov/projectile/pull/2146): The six `projectile-<cmd>-use-comint-mode` options fold into one `projectile-use-comint-mode`, taking `t` or a list of the phases to make interactive.
 - [#2146](https://github.com/bbatsov/projectile/pull/2146): `projectile-per-project-compilation-buffer` and `projectile-per-command-compilation-buffer` fold into `projectile-compilation-buffer-scope`, a list of `project` and/or `command` - which is what setting both booleans already meant.
 - [#2146](https://github.com/bbatsov/projectile/pull/2146): Rename the options that broke their own naming schemes: `projectile-global-ignore-file-patterns` to `projectile-globally-ignored-file-regexps`, `projectile-cmd-hist-ignoredups` to `projectile-command-history-ignore-duplicates`, `projectile-related-files-fn-function` to `projectile-related-files-function`, `projectile-auto-discover` to `projectile-auto-discover-projects`, and the three reviewable-search options named after replace (`projectile-replace-max-matches`, `-async` and `-scan-chunk-size`) to the `projectile-search-` prefix their siblings already used.

--- a/doc/modules/ROOT/pages/across_repositories.adoc
+++ b/doc/modules/ROOT/pages/across_repositories.adoc
@@ -169,6 +169,25 @@ signal goes quiet and you fall back to name matching. When a project you
 care about ends up with no siblings, that's what `projectile-project-groups`
 is for.
 
+== What else checkouts share
+
+Knowing that two roots are one repository is useful beyond switching between
+them: the *command history* you browse at a compile or test prompt is shared
+across checkouts, so a worktree made this morning already offers the commands
+the project is built with. See
+xref:tasks.adoc#history-scope[History across checkouts].
+
+The line elsewhere is drawn at anything that acts without asking, which stays
+local to the checkout you're in: the command a prompt is pre-filled with, what
+`projectile-repeat-last-command` replays, and the task
+`projectile-repeat-last-task` re-runs. A remembered command can carry absolute
+paths back into the checkout it was typed in, and being handed somebody else's
+build unasked is no fun.
+
+Per-project *sessions* aren't shared either, for a different reason: a window
+layout is a set of files in a particular directory, and the whole point of a
+second checkout is that its files differ.
+
 == How Projectile decides two projects are the same repository
 
 Both commands rest on `projectile-repo-identity`, which describes what

--- a/doc/modules/ROOT/pages/configuration_index.adoc
+++ b/doc/modules/ROOT/pages/configuration_index.adoc
@@ -53,6 +53,9 @@ and the other reference pages.
 | `projectile-command-history-ignore-duplicates`
 | Controls when inputs are added to projectile’s command history.
 
+| `projectile-command-history-scope`
+| How widely a project’s command history is shared.
+
 | `projectile-compilation-buffer-scope`
 | What a lifecycle command’s compilation buffer is named after.
 

--- a/doc/modules/ROOT/pages/tasks.adoc
+++ b/doc/modules/ROOT/pages/tasks.adoc
@@ -58,6 +58,34 @@ only cycle through previous *test* commands instead of a mix of every command
 you've run in the project. `projectile-repeat-last-command` still re-runs the
 most recent command of any type.
 
+[#history-scope]
+=== History across checkouts
+
+Those per-type histories belong to the *repository*, not to the directory. Press
+kbd:[M-p] at the test prompt in a git worktree you made this morning - or in a
+second clone of the same upstream - and you get the commands the project is
+actually tested with, instead of an empty history. They're the same project on
+another branch, after all, and you build them the same way.
+
+Set `projectile-command-history-scope` to `project` to go back to a history per
+directory. Either way a project whose repository Projectile can't identify (see
+xref:across_repositories.adoc[Working across repositories]) keeps its own.
+
+Two things deliberately stay local to the checkout you're in, because both act
+without asking and a remembered command can carry absolute paths back into the
+checkout it was typed in:
+
+* what a command prompt is *pre-filled* with, which is still whatever this
+  checkout last ran;
+* what `projectile-repeat-last-command` replays, so in a fresh worktree it still
+  says nothing has been run yet rather than rebuilding a sibling.
+
+One more thing worth knowing: the history is a ring of a fixed size, so several
+checkouts sharing one means their commands interleave in it. If you keep clones
+of a repository that are built in genuinely different ways - sparse checkouts of
+a monorepo, say - set the option to `project` for those, which works from a
+`.dir-locals.el` since the variable is marked safe.
+
 [#project-tasks]
 == Project tasks
 

--- a/projectile.el
+++ b/projectile.el
@@ -1656,6 +1656,35 @@ A value of nil means nothing is ignored."
                  (const :tag "Only keep last duplicate" erase))
   :package-version '(projectile . "2.9.0"))
 
+(defcustom projectile-command-history-scope 'repository
+  "How widely a project's command history is shared.
+
+- `repository' - every checkout of one repository shares a history.  Two
+  git worktrees, or two clones of the same upstream, are the same project
+  on two branches: the commands you build and test it with are the same
+  ones, so a worktree made this morning already knows them (issue #1786).
+
+- `project' - each project root keeps its own history, so checkouts of one
+  repository start empty and learn separately.
+
+This is a single choice, not a list of aspects like the other options
+whose names end in `-scope': one value replaces the other.
+
+What gets shared is the history you browse - the list behind \\[previous-history-element]
+at a command prompt.  Two things stay this checkout's own, because both
+act without asking and a remembered command can carry absolute paths back
+into the checkout it was typed in: what a prompt is pre-filled with, and
+what `projectile-repeat-last-command' replays.
+
+Sharing needs the repository to be identifiable (see
+`projectile-repo-identity'); a project Projectile can say nothing about
+keeps its own history whatever this is set to."
+  :group 'projectile
+  :type '(choice (const :tag "Share across checkouts of one repository" repository)
+                 (const :tag "Keep a history per project root" project))
+  :safe (lambda (value) (memq value '(repository project)))
+  :package-version '(projectile . "3.4.0"))
+
 (defvar projectile-project-test-suffix nil
   "Use this variable to override the current project's test-suffix property.
 It takes precedence over the test-suffix for the project type when set.
@@ -12122,7 +12151,36 @@ per-type command history."
 (defvar projectile-project-command-history (make-hash-table :test 'equal)
   "The history of last executed project commands, per project.
 
-Projects are indexed by their project-root value.")
+Indexed by whatever `projectile--command-history-key' makes of a project
+root, which is the repository the project is a checkout of when that can
+be established and the root itself otherwise.")
+
+(defun projectile--command-history-key (project-root)
+  "Return the key PROJECT-ROOT's command history is stored under.
+
+That's PROJECT-ROOT itself, unless `projectile-command-history-scope' asks
+for a repository-wide history and the repository can be identified - then
+it's a spelling of the repository, so that every checkout of it reaches the
+same history.
+
+The upstream is preferred over the repository directory because it is the
+broader of the two: worktrees of one repository agree on it, and so do
+separate clones, which is the same arrangement done by hand.  A repository
+with no upstream falls back to the directory its checkouts share, which
+still covers its worktrees.
+
+Two consequences worth knowing.  The key follows the remote, so pointing a
+repository at a new upstream moves it to a fresh history.  And this picks
+one of the two keys where `projectile-same-repo-p' accepts either, so
+checkouts that disagree about having a remote at all - an `hg share'
+working directory whose source configures a `default' path and which
+doesn't - are one repository for switching purposes but keep separate
+histories."
+  (or (and (eq projectile-command-history-scope 'repository)
+           (let ((identity (projectile-repo-identity project-root)))
+             (or (plist-get identity :remote)
+                 (plist-get identity :repo))))
+      project-root))
 
 (defun projectile--get-command-history (project-root &optional command-type)
   "Return the command history ring for PROJECT-ROOT.
@@ -12131,11 +12189,33 @@ With COMMAND-TYPE non-nil (one of the lifecycle command type
 symbols, e.g. `compile' or `test', or a (task . TASK-NAME) cons
 for named tasks) return the history specific to that command
 type, so histories of different types don't bleed into each
-other's prompts.  With COMMAND-TYPE nil return the combined
-per-project history, which is what `projectile-repeat-last-command'
-reads."
-  (let ((key (if command-type (cons project-root command-type) project-root)))
+other's prompts.  With COMMAND-TYPE nil return the combined history,
+which is what `projectile-repeat-last-command' reads.
+
+Which history that is depends on `projectile--command-history-key' - by
+default the repository's rather than this one checkout's."
+  (let* ((root-key (if command-type (cons project-root command-type) project-root))
+         (key (if command-type
+                  ;; The per-type histories are the ones you browse at a
+                  ;; prompt, so sharing them is all upside: pressing M-p in
+                  ;; a fresh worktree offers the commands this project is
+                  ;; actually built with.
+                  (cons (projectile--command-history-key project-root) command-type)
+                ;; The combined history stays this checkout's own.
+                ;; `projectile-repeat-last-command' replays its most recent
+                ;; entry without asking, and a command typed in another
+                ;; checkout can carry absolute paths back into it - being
+                ;; handed somebody else's build unasked is no fun.
+                project-root)))
     (or (gethash key projectile-project-command-history)
+        ;; The per-type histories used to be keyed by root, and they're
+        ;; persisted, so an upgrade would otherwise walk into a project you
+        ;; have been building for years with nothing in hand.  Adopt this
+        ;; root's history as the repository's instead.
+        (unless (equal key root-key)
+          (when-let* ((inherited (gethash root-key projectile-project-command-history)))
+            (remhash root-key projectile-project-command-history)
+            (puthash key inherited projectile-project-command-history)))
         (puthash key
                  (make-ring 16)
                  projectile-project-command-history))))

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -265,6 +265,117 @@
                (projectile--get-command-history projectile-project-root 'compile))
               :to-equal '()))))
 
+(describe "command history shared across checkouts (#1786)"
+  (defun projectile-history-test--record (root command)
+    "Put COMMAND into ROOT's `compile' command history."
+    (ring-insert (projectile--get-command-history root 'compile) command))
+
+  (defun projectile-history-test--commands (root)
+    "Return ROOT's `compile' command history as a list."
+    (ring-elements (projectile--get-command-history root 'compile)))
+
+  (it "gives the worktrees of one repository a single history"
+    ;; The point of the issue: pressing M-p in a worktree made this morning
+    ;; offers the commands the project is actually built with.
+    (projectile-test-with-sandbox
+     (let* ((repo (projectile-test-init-git-repo "repo"))
+            (worktree (projectile-test-add-git-worktree
+                       repo (expand-file-name "feature") "feature"))
+            (projectile-project-command-history (make-hash-table :test 'equal)))
+       (projectile-history-test--record repo "make test")
+       (expect (projectile-history-test--commands worktree)
+               :to-equal '("make test")))))
+
+  (it "gives two clones of one upstream a single history"
+    (projectile-test-with-sandbox
+     (let* ((remote "git@github.com:bbatsov/projectile.git")
+            (one (projectile-test-init-git-repo "one" remote))
+            (two (projectile-test-init-git-repo "two" remote))
+            (projectile-project-command-history (make-hash-table :test 'equal)))
+       (projectile-history-test--record one "make test")
+       (expect (projectile-history-test--commands two)
+               :to-equal '("make test")))))
+
+  (it "keeps unrelated projects apart"
+    (projectile-test-with-sandbox
+     (let* ((one (projectile-test-init-git-repo
+                  "one" "git@github.com:bbatsov/projectile.git"))
+            (other (projectile-test-init-git-repo
+                    "other" "git@github.com:bbatsov/crux.git"))
+            (projectile-project-command-history (make-hash-table :test 'equal)))
+       (projectile-history-test--record one "make test")
+       (expect (projectile-history-test--commands other) :to-equal nil))))
+
+  (it "does not share what projectile-repeat-last-command replays"
+    ;; The combined history is replayed without asking, so it stays this
+    ;; checkout's own however widely the browsable history is shared - a
+    ;; command typed elsewhere can carry absolute paths back into it.
+    (projectile-test-with-sandbox
+     (let* ((repo (projectile-test-init-git-repo "repo"))
+            (worktree (projectile-test-add-git-worktree
+                       repo (expand-file-name "feature") "feature"))
+            (projectile-project-command-history (make-hash-table :test 'equal)))
+       (ring-insert (projectile--get-command-history repo) "make -C /abs/path")
+       (expect (ring-elements (projectile--get-command-history worktree))
+               :to-equal nil))))
+
+  (it "keeps a history per root when the scope says so"
+    (projectile-test-with-sandbox
+     (let* ((repo (projectile-test-init-git-repo "repo"))
+            (worktree (projectile-test-add-git-worktree
+                       repo (expand-file-name "feature") "feature"))
+            (projectile-command-history-scope 'project)
+            (projectile-project-command-history (make-hash-table :test 'equal)))
+       (projectile-history-test--record repo "make test")
+       (expect (projectile-history-test--commands worktree) :to-equal nil))))
+
+  (it "still separates the per-type histories of a shared repository"
+    (projectile-test-with-sandbox
+     (let* ((repo (projectile-test-init-git-repo "repo"))
+            (worktree (projectile-test-add-git-worktree
+                       repo (expand-file-name "feature") "feature"))
+            (projectile-project-command-history (make-hash-table :test 'equal)))
+       (ring-insert (projectile--get-command-history repo 'compile) "make")
+       (ring-insert (projectile--get-command-history repo 'test) "make test")
+       (expect (ring-elements
+                (projectile--get-command-history worktree 'compile))
+               :to-equal '("make"))
+       (expect (ring-elements
+                (projectile--get-command-history worktree 'test))
+               :to-equal '("make test")))))
+
+  (it "adopts a history saved under the old per-root key"
+    ;; The per-type histories are persisted, so upgrading must not walk into
+    ;; a project you have been building for years with nothing in hand.
+    (projectile-test-with-sandbox
+     (let* ((repo (projectile-test-init-git-repo
+                   "repo" "git@github.com:bbatsov/projectile.git"))
+            (projectile-project-command-history (make-hash-table :test 'equal))
+            (saved (make-ring 16)))
+       (ring-insert saved "make from before the upgrade")
+       (puthash (cons repo 'compile) saved projectile-project-command-history)
+       (expect (projectile-history-test--commands repo)
+               :to-equal '("make from before the upgrade"))
+       ;; and it moved, rather than being left behind as a second copy
+       (expect (gethash (cons repo 'compile) projectile-project-command-history)
+               :to-be nil))))
+
+  (it "falls back to the project root when there's no repository to key on"
+    (spy-on 'projectile-repo-identity)
+    (expect (projectile--command-history-key "/src/plain/")
+            :to-equal "/src/plain/"))
+
+  (it "prefers the upstream, which relates clones as well as worktrees"
+    (spy-on 'projectile-repo-identity
+            :and-return-value '(:repo "/src/one/.git/" :remote "host/o/r"))
+    (expect (projectile--command-history-key "/src/one/") :to-equal "host/o/r"))
+
+  (it "falls back to the shared directory for a repository with no upstream"
+    (spy-on 'projectile-repo-identity
+            :and-return-value '(:repo "/src/one/.git/" :remote nil))
+    (expect (projectile--command-history-key "/src/one/")
+            :to-equal "/src/one/.git/")))
+
 (describe "projectile-default-generic-command"
   (it "returns a string command as-is"
     (let ((projectile-project-types '((test-type compile-command "make"))))


### PR DESCRIPTION
Fixes #1786.

Working on two branches means two directories, and you build and test the project the same way in both. Until now each checkout learned the commands separately, so a worktree made this morning greeted you with an empty history and you retyped everything.

The per-command-type histories - the ones behind `M-p` at a prompt - are now keyed by the repository rather than the directory, so a fresh worktree or a second clone offers the commands the project is actually built with. This is what the identity layer from #2147 was for.

Two things deliberately stay local to the checkout you're in: what a prompt is pre-filled with, and what `projectile-repeat-last-command` replays. My first draft shared the combined history too, and a review caught what that meant in practice - in a worktree the repeat binding rebuilt the *other* tree, unprompted, while you thought you were building the one you were sitting in. The browsable history is safe to share precisely because reaching for it is a deliberate act.

Same review caught that these histories are persisted through savehist, so keying them differently would have silently emptied every existing project's history on upgrade day - the exact opposite of the point. A history found under the old per-root key is adopted as the repository's.

`projectile-command-history-scope` set to `project` restores the old per-directory behaviour, and it's safe as a file-local so you can set it for the odd repo whose clones are genuinely built differently.