### PR TITLE
Correct the cross-repository docs against what the code does

### DIFF
--- a/doc/modules/ROOT/pages/across_repositories.adoc
+++ b/doc/modules/ROOT/pages/across_repositories.adoc
@@ -15,7 +15,7 @@ else" that come up constantly, and Projectile has a command for each:
 Both are narrowed versions of `projectile-switch-project` (kbd:[s-p p]).
 That command offers every project you've ever visited; these two offer
 the handful you're likely to actually want, which is the difference
-between typing a few characters and remembering which of your 90
+between typing a few characters and remembering which of a hundred
 directories is the right one.
 
 [cols="1,4"]
@@ -34,8 +34,8 @@ other switch commands.
 == Other checkouts of this project
 
 kbd:[s-p W] lists the other directories holding the same repository, each
-annotated with whatever tells it apart - the branch for git and
-Mercurial, the workspace name for Jujutsu:
+annotated with whatever tells it apart - the branch for git, the
+workspace name for Jujutsu:
 
 ....
 Switch to worktree:
@@ -88,8 +88,10 @@ and run `M-x projectile-discover-projects-in-search-path`.
 
 Where checkouts come from is controlled by `projectile-worktree-functions`,
 a list of functions each taking a project root and returning what it
-found. The default set covers git, Jujutsu and the known projects; add
-your own if you have another way of tracking checkouts.
+found. The default set covers git, Jujutsu and the known projects. To add
+another way of tracking checkouts, write a function returning a list of
+plists with `:path` (mandatory), `:label` and `:prunable` - see that
+option's docstring for the details.
 
 [#siblings]
 == Related projects
@@ -194,8 +196,8 @@ Both commands rest on `projectile-repo-identity`, which describes what
 repository a project root is a checkout of:
 
 `:repo`:: The directory the checkouts share - git's common dir, the store
-an `hg share` points at. Two roots with the same `:repo` are worktrees of
-each other.
+an `hg share` points at, the git directory a Jujutsu repository keeps its
+commits in. Two roots with the same `:repo` are worktrees of each other.
 `:remote`:: A canonical spelling of the upstream, so the scp-like and URL
 forms of one remote compare equal. Two roots with the same `:remote` are
 separate clones.
@@ -229,15 +231,19 @@ Worth knowing before you file a bug:
   the matching subdirectory of another worktree.
 * *Remote (TRAMP) projects are skipped.* Every probe would be a network
   round trip, so a remote project has no identity and no worktrees.
+* *Sibling clones must already be known projects.* Real git worktrees and
+  Jujutsu workspaces are found without that, since the version control
+  system registers them itself.
+* *Only git and Jujutsu checkouts carry a label.* A Mercurial share is
+  offered without one, since Projectile would have to run `hg` to learn
+  its branch and the whole point of the lookup is that it doesn't.
 
 When kbd:[s-p W] has nothing to offer it distinguishes the two reasons:
 having looked and found no other checkout, and not being able to look at
 all because the project isn't the top level of a git, Mercurial or
-Jujutsu repository. Only the first means "there aren't any". kbd:[s-p n] needs
-none of this, so it's the one to reach for when Projectile can't identify
-the repository.
-* *Sibling clones must already be known projects.* Real git worktrees are
-  found without that, since git registers them itself.
+Jujutsu repository. Only the first means "there aren't any". kbd:[s-p n]
+needs none of this, so it's the one to reach for when Projectile can't
+identify the repository.
 
 === Version control support
 
@@ -253,7 +259,8 @@ the repository.
 | A working directory created by `hg share` is matched against the other
   known projects via its `.hg/sharedpath`, and the `default` path in
   `.hg/hgrc` acts as the remote. Mercurial has no way to enumerate shares,
-  so one you've never visited won't be found.
+  so one you've never visited won't be found, and a share is listed
+  without a branch label.
 
 | Jujutsu
 | Workspaces come from `jj workspace list`, so one you've never visited is

--- a/doc/modules/ROOT/pages/configuration.adoc
+++ b/doc/modules/ROOT/pages/configuration.adoc
@@ -313,6 +313,13 @@ any other keymap:
 Project candidates keep their Marginalia annotations under the new category -
 they're directory paths, so Marginalia's file annotator handles them.
 
+`projectile-switch-worktree` (see
+xref:across_repositories.adoc[Working across repositories]) uses a category of
+its own, `projectile-worktree`, bound to the same action keymap - a worktree is
+a project directory too. It is deliberately *not* registered with Marginalia:
+those candidates carry their own annotation naming the branch or workspace each
+checkout has, and a registered annotator would take precedence over it.
+
 === Custom completion function
 
 You can also set `projectile-completion-system` to a function that accepts a

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -591,6 +591,8 @@ Toggle one (or more), then trigger a command:
 
 * kbd:[-i] *invalidate cache* - rebuild the file cache first (the find file/dir commands)
 * kbd:[-r] *regexp search* - treat the search term as a regexp (the `search`, `ripgrep` and `ag` commands)
+* kbd:[-c] *case-sensitive search* - seed the reviewable search and replace case-sensitive
+* kbd:[-w] *whole-word search* - match whole words only
 * kbd:[-n] *new process* - start a fresh process instead of reusing one (the shells / REPLs)
 * kbd:[-d] *display in* - cycle the display target through this window / other window / other frame (the file, buffer and project commands)
 


### PR DESCRIPTION
Went back over everything the worktree and sibling work landed to check the docs actually match the code. Three real problems, plus one bit of staleness next door.

A bullet in the Limitations list was falling out of it - a paragraph added later sat between the last two items, so the final one rendered as its own list. Six items showing where seven were written.

The page claimed a checkout is annotated with "the branch for git and Mercurial". Only git yields one: `projectile--checkout-branch` has no Mercurial arm, because learning an hg branch means running `hg` and the point of that lookup is that it reads files instead. Corrected, and stated in the limitations and the VCS table rather than left for someone to discover.

The `projectile-worktree` completion category was undocumented, including the deliberate choice to keep it out of the Marginalia registry so the branch annotation survives - precisely the kind of thing that otherwise arrives as a bug report.

Also: the plist a `projectile-worktree-functions` entry has to return, Jujutsu's backing store in the identity section, and the two dispatch modifiers (`-c`, `-w`) the menu has grown since that list was written.

Docs only, so CI skips it.