### PR TITLE
Make the file's structure match what's in it

### DIFF
--- a/projectile.el
+++ b/projectile.el
@@ -4364,6 +4364,13 @@ this case unignored files will be absent from FILES."
   (seq-filter (lambda (b) (or (buffer-file-name b)
                                     (get-buffer-process b))) buffers))
 
+;;; Project buffers
+;;
+;; Which of Emacs's buffers belong to the project, and the filtering that
+;; decides it.  Consumed by the buffer-switching, killing and saving
+;; commands, and by the ibuffer integration.
+
+
 (defun projectile-project-buffers (&optional project)
   "Get a list of a project's buffers.
 If PROJECT is not specified the command acts on the current project."
@@ -6219,6 +6226,14 @@ for the kind, and repeated invocations cycle through them in table order."
   "Return a list of test files for the current project."
   (projectile-test-files (projectile-current-project-files)))
 
+;;; Project types
+;;
+;; What a project type is - a set of markers that recognise it plus the
+;; commands and conventions that follow - and the machinery for declaring
+;; one.  The types Projectile ships with are registered further down, in
+;; their own section.
+
+
 (defvar projectile-project-types nil
   "An alist holding all project types that are known to Projectile.
 The project types are symbols and they are linked to plists holding
@@ -6849,7 +6864,7 @@ a manual COMMAND-TYPE command is created with
 (defconst projectile--bun-lock-names '("bun.lock" "bun.lockb")
   "The lock file names Bun writes - the text one and the older binary one.")
 
-;;; Project type registration
+;;; The project types Projectile ships with
 ;;
 ;; Project type detection happens in a reverse order with respect to
 ;; project type registration (invocations of `projectile-register-project-type').
@@ -7633,6 +7648,130 @@ Results are cached in `projectile-project-vcs-cache' (cleared by
         (puthash project-root vcs projectile-project-vcs-cache)
         vcs))))
 
+
+;;; Git helpers
+;;
+;; Reading git for things other than the file listing: which files differ,
+;; which branch a checkout is on, where the repository's shared directory
+;; is.  These are consumed by the repository identity, the worktree lookup,
+;; the dashboard and `projectile-find-changed-file' alike, which is why they
+;; live next to the VCS detection rather than inside any one of them.
+
+(defun projectile--git (root &rest args)
+  "Run git with ARGS in ROOT and return its output, or nil when it fails.
+No shell is involved, and the call would go through TRAMP for a remote
+ROOT - which is why the callers make sure never to reach here with one.
+
+`--no-optional-locks' keeps a dashboard opened on project switch from
+taking the index lock and rewriting the index behind the user's back."
+  (let ((default-directory root))
+    (with-temp-buffer
+      (when (eql 0 (ignore-errors
+                     (apply #'process-file "git" nil '(t nil) nil
+                            "--no-optional-locks" args)))
+        (buffer-string)))))
+
+(defun projectile--git-toplevel (root)
+  "Return the toplevel of the git repository containing ROOT, or nil."
+  (when-let* ((top (projectile--git root "rev-parse" "--show-toplevel")))
+    (file-name-as-directory (file-truename (string-trim top)))))
+
+(defun projectile--git-relativize (paths root toplevel)
+  "Return PATHS, given relative to TOPLEVEL, relative to ROOT instead.
+Git reports porcelain and diff paths relative to the repository root
+regardless of where it was run, so a project sitting below that root
+needs them translated - and anything outside the project dropped."
+  (if (equal (file-truename root) toplevel)
+      paths
+    (delq nil
+          (mapcar (lambda (path)
+                    (let ((absolute (expand-file-name path toplevel))
+                          (root (file-truename root)))
+                      (when (string-prefix-p root absolute)
+                        (file-relative-name absolute root))))
+                  paths))))
+
+(defun projectile--git-status-changed-files (root)
+  "Return the paths git reports as changed in ROOT\\='s working tree.
+Covers staged, unstaged and untracked files, as repository-relative
+paths.  A rename occupies two NUL-separated fields - the new name and
+then the old one - so those are consumed in step rather than the old
+name being mistaken for another changed file."
+  (when-let* ((output (projectile--git root "status" "--porcelain" "-z"
+                                       "--untracked-files=all")))
+    (let ((records (split-string output "\0" t))
+          files)
+      (while records
+        (let ((record (pop records)))
+          ;; "XY PATH", with X and Y the index and worktree status codes.
+          (when (> (length record) 3)
+            (let ((status (substring record 0 2))
+                  (path (substring record 3)))
+              (push path files)
+              ;; A rename or copy carries the source path in the next field.
+              (when (string-match-p "[RC]" status)
+                (pop records))))))
+      (nreverse files))))
+
+(defun projectile-git-changed-files (root &optional base)
+  "Return the files changed in the project at ROOT, relative to it.
+
+Without BASE that is the working tree: everything staged, unstaged or
+untracked.  With BASE - a branch, tag or any other revision - it is
+everything that differs from it, plus the files not yet tracked at all,
+which is what \"show me what this branch changed\" usually means.
+
+Only git is supported; any other version control system returns nil."
+  (when (eq (projectile-project-vcs root) 'git)
+    (when-let* ((toplevel (projectile--git-toplevel root)))
+      (let ((paths
+             (if base
+                 (append
+                  (when-let* ((diff (projectile--git root "diff" "--name-only"
+                                                     "-z" base)))
+                    (split-string diff "\0" t))
+                  (when-let* ((new (projectile--git root "ls-files" "-z"
+                                                    "--others" "--exclude-standard")))
+                    (split-string new "\0" t)))
+               (projectile--git-status-changed-files root))))
+        (seq-uniq (projectile--git-relativize paths root toplevel))))))
+
+(defun projectile--read-git-ref (root)
+  "Read a git revision to compare against, completing over ROOT\\='s branches."
+  (let ((branches (when-let* ((output (projectile--git
+                                       root "for-each-ref" "--format=%(refname:short)"
+                                       "refs/heads" "refs/remotes")))
+                    (split-string output "\n" t))))
+    (completing-read "Compare against: " branches nil nil nil nil
+                     (car (member "main" branches)))))
+
+;;;###autoload
+(defun projectile-find-changed-file (&optional arg)
+  "Jump to a file changed in the current project.
+
+That is everything git reports as staged, unstaged or untracked.  With a
+prefix ARG you are asked for a revision to compare against instead - a
+branch, say - and the candidates become everything that differs from it,
+which is the \"what did this branch touch\" list.
+
+Only git projects are supported."
+  (interactive "P")
+  (let* ((root (projectile-acquire-root))
+         (base (when arg (projectile--read-git-ref root))))
+    (unless (eq (projectile-project-vcs root) 'git)
+      (user-error "`projectile-find-changed-file' needs a git project"))
+    (let ((files (projectile-git-changed-files root base)))
+      (unless files
+        (user-error "No changed files in %s%s" root
+                    (if base (format " compared to %s" base) "")))
+      (find-file (expand-file-name
+                  (projectile-completing-read
+                   (if base (format "Changed vs %s: " base) "Changed file: ")
+                   files :caller 'projectile-find-changed-file)
+                  root))
+      (run-hooks 'projectile-find-file-hook))))
+
+
 (defun projectile--test-name-for-impl-name (impl-file-path)
   "Determine the name of the test file for IMPL-FILE-PATH.
 
@@ -8140,6 +8279,12 @@ is appended and faced as `(default VALUE)'."
                                   (propertize default-value
                                               'face 'projectile-search-prompt-default)))))
     (read-string (format "%s%s: " prompt-label default-label) nil nil default-value)))
+
+;;; Grep command construction
+;;
+;; Turning Projectile's ignore rules into the arguments `rgrep' and friends
+;; expect, which is fiddly enough to be worth keeping in one place.
+
 
 (defvar projectile-grep-find-ignored-paths)
 (defvar projectile-grep-find-unignored-paths)
@@ -11901,6 +12046,12 @@ supplied via .dir-locals.el and finally the default configure command
 for a project of that type."
   (projectile--phase-command 'configure compile-dir))
 
+;;; Compilation buffers, and resolving a command
+;;
+;; Where a lifecycle command's output goes and what it's called, plus the
+;; per-phase readers that resolve which command to run.
+
+
 (defvar projectile--compilation-command-type nil
   "Lifecycle command type of the compilation being started, or nil.
 Bound by `projectile--run-project-cmd' for the duration of the call, so
@@ -12117,6 +12268,16 @@ that part of the repository."
                                              :caller 'projectile-read-file)))
       (find-file (expand-file-name file project-root))
       (run-hooks 'projectile-find-file-hook))))
+
+;;; Lifecycle commands
+;;
+;; Configure, compile, test, install, package and run: the six phases a
+;; project is driven through from Projectile.  Each resolves its command
+;; the same way (cache, then .dir-locals.el, then the project type's
+;; default), remembers what you ran, and hands it to `compile'.  The
+;; subproject variants at the end of the section are the same six, scoped
+;; to the part of a monorepo you're in.
+
 
 (defun projectile-compilation-dir (&optional base)
   "Retrieve the compilation directory for this project.
@@ -12467,6 +12628,36 @@ with a prefix ARG."
   (interactive "P")
   (projectile--run-lifecycle-phase 'test arg))
 
+;;;###autoload
+(defun projectile-install-project (arg)
+  "Run project install command.
+
+Normally you'll be prompted for a compilation command, unless
+variable `compilation-read-command'.  You can force the prompt
+with a prefix ARG."
+  (interactive "P")
+  (projectile--run-lifecycle-phase 'install arg))
+
+;;;###autoload
+(defun projectile-package-project (arg)
+  "Run project package command.
+
+Normally you'll be prompted for a compilation command, unless
+variable `compilation-read-command'.  You can force the prompt
+with a prefix ARG."
+  (interactive "P")
+  (projectile--run-lifecycle-phase 'package arg))
+
+;;;###autoload
+(defun projectile-run-project (arg)
+  "Run project run command.
+
+Normally you'll be prompted for a compilation command, unless
+variable `compilation-read-command'.  You can force the prompt
+with a prefix ARG."
+  (interactive "P")
+  (projectile--run-lifecycle-phase 'run arg))
+
 (defun projectile--run-subproject-phase (phase show-prompt)
   "Run lifecycle PHASE in the nearest subproject of the current file.
 SHOW-PROMPT is as in `projectile--run-lifecycle-phase', which does the
@@ -12506,6 +12697,14 @@ Normally you will be prompted for the command, unless variable
 ;;;###autoload (autoload 'projectile-package-subproject "projectile" nil t)
 ;;;###autoload (autoload 'projectile-run-subproject "projectile" nil t)
 (projectile--define-subproject-commands configure compile test install package run)
+
+;;; Running the test at point
+;;
+;; Run just the test the cursor is in, rather than the whole suite.  A rule
+;; per major mode says how to recognise a test in that language's syntax
+;; tree and how to name it on the command line; `projectile-test-at-point-rules'
+;; ties them together and is where a language gets added.
+
 
 (defun projectile-test-at-point-python-name (node)
   "Return the test name for the Python `function_definition' NODE.
@@ -12896,35 +13095,13 @@ a prefix ARG you can edit the command before it's run."
                                      :save-buffers t
                                      :use-comint-mode (projectile-use-comint-mode-p 'test))))))
 
-;;;###autoload
-(defun projectile-install-project (arg)
-  "Run project install command.
+;;; Tasks, and repeating what you ran last
+;;
+;; Tasks are the commands a project's own tooling defines - npm scripts,
+;; rake tasks, a Makefile's targets - discovered rather than configured.
+;; `projectile-repeat-last-command' sits here too: it re-runs the last
+;; command of any kind, lifecycle phase or task alike.
 
-Normally you'll be prompted for a compilation command, unless
-variable `compilation-read-command'.  You can force the prompt
-with a prefix ARG."
-  (interactive "P")
-  (projectile--run-lifecycle-phase 'install arg))
-
-;;;###autoload
-(defun projectile-package-project (arg)
-  "Run project package command.
-
-Normally you'll be prompted for a compilation command, unless
-variable `compilation-read-command'.  You can force the prompt
-with a prefix ARG."
-  (interactive "P")
-  (projectile--run-lifecycle-phase 'package arg))
-
-;;;###autoload
-(defun projectile-run-project (arg)
-  "Run project run command.
-
-Normally you'll be prompted for a compilation command, unless
-variable `compilation-read-command'.  You can force the prompt
-with a prefix ARG."
-  (interactive "P")
-  (projectile--run-lifecycle-phase 'run arg))
 
 ;;;###autoload
 (defun projectile-repeat-last-command (show-prompt)
@@ -13092,6 +13269,13 @@ directories."
                   dirs)
               compilation-search-path)))
       (apply orig-fun `(,marker ,filename ,directory ,@formats)))))
+
+;;; Known projects, and switching between them
+;;
+;; The list of projects Projectile has seen, how it's kept (loaded, merged
+;; between Emacsen, pruned of directories that have gone away) and the
+;; commands that move you from one to another.
+
 
 (defun projectile-open-projects ()
   "Return a list of all open projects.
@@ -15540,122 +15724,7 @@ Used by the buffer's `revert-buffer' to regenerate it.")
   "Return non-nil when SECTION is enabled in `projectile-dashboard-sections'."
   (memq section projectile-dashboard-sections))
 
-
 ;;;; Dashboard data collection
-
-(defun projectile--git (root &rest args)
-  "Run git with ARGS in ROOT and return its output, or nil when it fails.
-No shell is involved, and the call would go through TRAMP for a remote
-ROOT - which is why the callers make sure never to reach here with one.
-
-`--no-optional-locks' keeps a dashboard opened on project switch from
-taking the index lock and rewriting the index behind the user's back."
-  (let ((default-directory root))
-    (with-temp-buffer
-      (when (eql 0 (ignore-errors
-                     (apply #'process-file "git" nil '(t nil) nil
-                            "--no-optional-locks" args)))
-        (buffer-string)))))
-
-(defun projectile--git-toplevel (root)
-  "Return the toplevel of the git repository containing ROOT, or nil."
-  (when-let* ((top (projectile--git root "rev-parse" "--show-toplevel")))
-    (file-name-as-directory (file-truename (string-trim top)))))
-
-(defun projectile--git-relativize (paths root toplevel)
-  "Return PATHS, given relative to TOPLEVEL, relative to ROOT instead.
-Git reports porcelain and diff paths relative to the repository root
-regardless of where it was run, so a project sitting below that root
-needs them translated - and anything outside the project dropped."
-  (if (equal (file-truename root) toplevel)
-      paths
-    (delq nil
-          (mapcar (lambda (path)
-                    (let ((absolute (expand-file-name path toplevel))
-                          (root (file-truename root)))
-                      (when (string-prefix-p root absolute)
-                        (file-relative-name absolute root))))
-                  paths))))
-
-(defun projectile--git-status-changed-files (root)
-  "Return the paths git reports as changed in ROOT\\='s working tree.
-Covers staged, unstaged and untracked files, as repository-relative
-paths.  A rename occupies two NUL-separated fields - the new name and
-then the old one - so those are consumed in step rather than the old
-name being mistaken for another changed file."
-  (when-let* ((output (projectile--git root "status" "--porcelain" "-z"
-                                       "--untracked-files=all")))
-    (let ((records (split-string output "\0" t))
-          files)
-      (while records
-        (let ((record (pop records)))
-          ;; "XY PATH", with X and Y the index and worktree status codes.
-          (when (> (length record) 3)
-            (let ((status (substring record 0 2))
-                  (path (substring record 3)))
-              (push path files)
-              ;; A rename or copy carries the source path in the next field.
-              (when (string-match-p "[RC]" status)
-                (pop records))))))
-      (nreverse files))))
-
-(defun projectile-git-changed-files (root &optional base)
-  "Return the files changed in the project at ROOT, relative to it.
-
-Without BASE that is the working tree: everything staged, unstaged or
-untracked.  With BASE - a branch, tag or any other revision - it is
-everything that differs from it, plus the files not yet tracked at all,
-which is what \"show me what this branch changed\" usually means.
-
-Only git is supported; any other version control system returns nil."
-  (when (eq (projectile-project-vcs root) 'git)
-    (when-let* ((toplevel (projectile--git-toplevel root)))
-      (let ((paths
-             (if base
-                 (append
-                  (when-let* ((diff (projectile--git root "diff" "--name-only"
-                                                     "-z" base)))
-                    (split-string diff "\0" t))
-                  (when-let* ((new (projectile--git root "ls-files" "-z"
-                                                    "--others" "--exclude-standard")))
-                    (split-string new "\0" t)))
-               (projectile--git-status-changed-files root))))
-        (seq-uniq (projectile--git-relativize paths root toplevel))))))
-
-(defun projectile--read-git-ref (root)
-  "Read a git revision to compare against, completing over ROOT\\='s branches."
-  (let ((branches (when-let* ((output (projectile--git
-                                       root "for-each-ref" "--format=%(refname:short)"
-                                       "refs/heads" "refs/remotes")))
-                    (split-string output "\n" t))))
-    (completing-read "Compare against: " branches nil nil nil nil
-                     (car (member "main" branches)))))
-
-;;;###autoload
-(defun projectile-find-changed-file (&optional arg)
-  "Jump to a file changed in the current project.
-
-That is everything git reports as staged, unstaged or untracked.  With a
-prefix ARG you are asked for a revision to compare against instead - a
-branch, say - and the candidates become everything that differs from it,
-which is the \"what did this branch touch\" list.
-
-Only git projects are supported."
-  (interactive "P")
-  (let* ((root (projectile-acquire-root))
-         (base (when arg (projectile--read-git-ref root))))
-    (unless (eq (projectile-project-vcs root) 'git)
-      (user-error "`projectile-find-changed-file' needs a git project"))
-    (let ((files (projectile-git-changed-files root base)))
-      (unless files
-        (user-error "No changed files in %s%s" root
-                    (if base (format " compared to %s" base) "")))
-      (find-file (expand-file-name
-                  (projectile-completing-read
-                   (if base (format "Changed vs %s: " base) "Changed file: ")
-                   files :caller 'projectile-find-changed-file)
-                  root))
-      (run-hooks 'projectile-find-file-hook))))
 
 (defun projectile-dashboard--git-status (root)
   "Return the git branch and working tree counts for ROOT as a plist.

--- a/projectile.el
+++ b/projectile.el
@@ -6279,55 +6279,14 @@ Returns nil for a predicate marker, which has no file names to give."
 
 (cl-defun projectile--build-project-plist
     (marker-files &key project-file compilation-dir configure compile install package test run test-suffix test-prefix src-dir test-dir src-extension test-extension related-files-fn file-kinds tasks)
-  "Return a project type plist with the provided arguments.
+  "Return a project type plist built from MARKER-FILES and the keyword arguments.
 
-A project type is defined by PROJECT-TYPE, a set of MARKER-FILES,
-and optional keyword arguments.
-
-MARKER-FILES is either a list of files or a predicate function.  When it
-is a list, ALL of the listed files must be present in the project root for
-the type to match (logical AND) - so a single-file marker like `(\"Foo\")'
-is the common case.  A list element may itself be an alternatives clause
-of the form (:any FILE...), which is satisfied when any one of its FILEs
-is present, so `((:any \"build.gradle\" \"build.gradle.kts\"))' matches a
-project with either of them.  For anything more involved, don't pass a
-list; use a predicate function instead.  The predicate is called with the
-project root as its single argument and should return non-nil when the
-project is of this type.
-
-The optional keyword arguments are:
-PROJECT-FILE the main project file in the root project directory.  It may be a
-             single file or a list of possible files.  When omitted it
-             defaults to the first marker file.  Pass the symbol `none'
-             to opt out, so the type is detected but contributes no
-             project-root marker (e.g. when its marker also appears
-             outside real projects).
-COMPILATION-DIR the directory to run the tests- and compilations in,
-CONFIGURE which specifies a command that configures the project
-          `%s' in the command will be substituted with (projectile-project-root)
-          before the command is run,
-COMPILE which specifies a command that builds the project,
-INSTALL which specifies a command to install the project.
-PACKAGE which specifies a command to package the project.
-TEST which specifies a command that tests the project,
-RUN which specifies a command that runs the project,
-TEST-SUFFIX which specifies test file suffix, and
-TEST-PREFIX which specifies test file prefix.
-SRC-DIR which specifies the path to the source relative to the project root.
-TEST-DIR which specifies the path to the tests relative to the project root.
-SRC-EXTENSION which specifies the file extension implementation files use,
-    when it differs from the one their tests use.
-TEST-EXTENSION which specifies the file extension test files use, when it
-    differs from the implementation's (Elixir tests are scripts: `foo.ex\\='
-    is tested by `foo_test.exs\\=').
-RELATED-FILES-FN which specifies a custom function to find the related
-files such as test/impl/other files as below:
-    CUSTOM-FUNCTION accepts FILE as relative path from the project root and
-    returns a plist containing :test, :impl or :other as key and the
-    relative path/paths or predicate as value.  PREDICATE accepts a
-    relative path as the input.
-TASKS an alist of named tasks of the form (TASK-NAME . COMMAND); see
-    `projectile-tasks' for the exact shape."
+This is the shape a registered project type takes; the arguments, and what
+each of them means, are documented on `projectile-register-project-type',
+which is the entry point users call and where the description belongs.
+Both take the same keywords, so keeping a second copy here only bought two
+descriptions that could disagree - and by the time this was written, they
+already did."
   ;; When PROJECT-FILE isn't given explicitly, derive it from the first
   ;; marker file - that's the project's primary manifest in every
   ;; file-based registration, so callers needn't repeat it.  Function

--- a/test/projectile-core-test.el
+++ b/test/projectile-core-test.el
@@ -589,7 +589,6 @@
          (let* ((root (projectile-test-project-root))
                 (projectile-indexing-method 'native)
                 (projectile-enable-caching t)
-                (projectile-projects-cache (make-hash-table :test 'equal))
                 (projectile-projects-cache-time (make-hash-table :test 'equal))
                 seen)
            (spy-on 'projectile-project-root :and-return-value root)

--- a/test/projectile-indexing-test.el
+++ b/test/projectile-indexing-test.el
@@ -513,6 +513,9 @@
          (let ((projectile-vcs-markers
                 (cons '(".jj" . jj)
                       (assoc-delete-all ".jj" (copy-alist projectile-vcs-markers))))
+               ;; Not redundant with the sandbox's fresh caches: the same
+               ;; directory was asked about above, so the answer has to be
+               ;; forgotten before asking again under different markers.
                (projectile-project-vcs-cache (make-hash-table :test 'equal)))
            (expect (projectile-project-vcs dir) :to-equal 'jj))))))
 
@@ -785,10 +788,7 @@
              (root-b (file-truename (expand-file-name "projectB/")))
              (roots (list root-a root-b))
              (projectile-enable-caching 'transient)
-             (projectile-projects-cache (make-hash-table :test 'equal))
              (projectile-projects-cache-time (make-hash-table :test 'equal))
-             (projectile-project-type-cache (make-hash-table :test 'equal))
-             (projectile--dirconfig-cache (make-hash-table :test 'equal))
              (projectile-file-exists-cache (make-hash-table :test 'equal)))
         (spy-on 'projectile-known-projects :and-return-value roots)
         (spy-on 'recentf-cleanup)
@@ -822,7 +822,6 @@
       (let* ((root-a (file-truename (expand-file-name "projectA/")))
              (root-b (file-truename (expand-file-name "projectB/")))
              (projectile-enable-caching 'persistent)
-             (projectile-projects-cache (make-hash-table :test 'equal))
              (projectile-projects-cache-time (make-hash-table :test 'equal))
              (cache-a (projectile-project-cache-file root-a))
              (cache-b (projectile-project-cache-file root-b)))
@@ -1225,7 +1224,6 @@
              (default-directory root)
              (projectile-indexing-method 'alien)
              (projectile-enable-caching t)
-             (projectile-projects-cache (make-hash-table :test 'equal))
              (projectile-projects-cache-time (make-hash-table :test 'equal)))
         (write-region "build/\n" nil ".gitignore")
         (call-process "git" nil nil nil "init")
@@ -1246,7 +1244,6 @@
              (default-directory root)
              (projectile-indexing-method 'alien)
              (projectile-enable-caching t)
-             (projectile-projects-cache (make-hash-table :test 'equal))
              (projectile-projects-cache-time (make-hash-table :test 'equal)))
         (write-region "build/\n" nil ".gitignore")
         (call-process "git" nil nil nil "init")
@@ -1267,8 +1264,7 @@
       ("project/" "project/.projectile" "project/build/" "project/build/main.o")
       (let* ((root (projectile-test-project-root))
              (projectile-indexing-method 'native)
-             (projectile-enable-caching t)
-             (projectile-projects-cache (make-hash-table :test 'equal)))
+             (projectile-enable-caching t))
         (spy-on 'projectile-project-root :and-return-value root)
         (puthash root '("main.c") projectile-projects-cache)
         (with-temp-buffer

--- a/test/projectile-known-projects-test.el
+++ b/test/projectile-known-projects-test.el
@@ -351,7 +351,6 @@
       (projectile-test-with-files
        ("project/")
        (let ((cache-file (expand-file-name "project/.projectile-cache.eld"))
-             (projectile-projects-cache (make-hash-table :test 'equal))
              (projectile-projects-cache-time (make-hash-table :test 'equal)))
          (with-temp-file cache-file
            (insert (prin1-to-string '("file1.el" "file2.el"))))

--- a/test/projectile-project-type-test.el
+++ b/test/projectile-project-type-test.el
@@ -241,30 +241,23 @@
 (describe "JavaScript project types"
   (it "falls back to node for a package.json with no lock file"
     (projectile-test-with-stub-root "project" ("package.json")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'node))))
+      (expect (projectile-detect-project-type) :to-equal 'node)))
   (it "prefers the package manager that owns the lock file"
     (projectile-test-with-stub-root "project" ("package.json" "pnpm-lock.yaml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'pnpm))))
+      (expect (projectile-detect-project-type) :to-equal 'pnpm)))
   (it "detects a bun project by either spelling of its lock file"
     (projectile-test-with-stub-root "project" ("package.json" "bun.lock")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'bun)))
+      (expect (projectile-detect-project-type) :to-equal 'bun))
     (projectile-test-with-stub-root "project" ("package.json" "bun.lockb")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'bun))))
+      (expect (projectile-detect-project-type) :to-equal 'bun)))
   (it "detects a deno project"
     (projectile-test-with-stub-root "project" ("deno.jsonc")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'deno))))
+      (expect (projectile-detect-project-type) :to-equal 'deno)))
   (it "prefers the monorepo tool over the package manager underneath it"
     (projectile-test-with-stub-root "project" ("package.json" "package-lock.json" "turbo.json")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'turborepo)))
+      (expect (projectile-detect-project-type) :to-equal 'turborepo))
     (projectile-test-with-stub-root "project" ("package.json" "pnpm-lock.yaml" "nx.json")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'nx)))))
+      (expect (projectile-detect-project-type) :to-equal 'nx))))
 
 (describe "single-language project types"
   (it "detects each language by its manifest"
@@ -279,8 +272,7 @@
                     ("platformio.ini" . platformio)))
       (projectile-test-with-sandbox
         (projectile-test-with-files ("project/")
-          (let ((projectile-project-type-cache (make-hash-table :test 'equal))
-                (root (file-truename (expand-file-name "project/"))))
+          (let ((root (file-truename (expand-file-name "project/"))))
             (write-region "" nil (expand-file-name (car case) root))
             (spy-on 'projectile-project-root :and-return-value root)
             (expect (projectile-detect-project-type) :to-equal (cdr case))))))))
@@ -288,111 +280,85 @@
 (describe "static site project types"
   (it "detects a Hugo site by any of its config file spellings"
     (projectile-test-with-stub-root "project" ("hugo.toml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'hugo)))
+      (expect (projectile-detect-project-type) :to-equal 'hugo))
     (projectile-test-with-stub-root "project" ("hugo.yaml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'hugo))))
+      (expect (projectile-detect-project-type) :to-equal 'hugo)))
   (it "detects Jekyll, MkDocs and Quarto"
     (projectile-test-with-stub-root "project" ("_config.yml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'jekyll)))
+      (expect (projectile-detect-project-type) :to-equal 'jekyll))
     (projectile-test-with-stub-root "project" ("mkdocs.yml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'mkdocs)))
+      (expect (projectile-detect-project-type) :to-equal 'mkdocs))
     (projectile-test-with-stub-root "project" ("_quarto.yml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'quarto))))
+      (expect (projectile-detect-project-type) :to-equal 'quarto)))
   (it "detects a Zola site without letting config.toml anchor a root"
     (projectile-test-with-stub-root "project" ("config.toml" "content/")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'zola)))
+      (expect (projectile-detect-project-type) :to-equal 'zola))
     (expect (member "config.toml" projectile-project-root-files) :to-be nil))
   (it "prefers the site generator over the package.json of its asset pipeline"
     (projectile-test-with-stub-root "project" ("hugo.toml" "package.json")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'hugo)))))
+      (expect (projectile-detect-project-type) :to-equal 'hugo))))
 
 (describe "task runner project types"
   (it "detects a just project by any spelling of the justfile"
     (projectile-test-with-stub-root "project" ("justfile")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'just)))
+      (expect (projectile-detect-project-type) :to-equal 'just))
     (projectile-test-with-stub-root "project" (".justfile")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'just))))
+      (expect (projectile-detect-project-type) :to-equal 'just)))
   (it "detects a mise project"
     (projectile-test-with-stub-root "project" ("mise.toml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'mise))))
+      (expect (projectile-detect-project-type) :to-equal 'mise)))
   (it "yields to the project's own build tool"
     (projectile-test-with-stub-root "project" ("justfile" "Cargo.toml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'rust-cargo))))
+      (expect (projectile-detect-project-type) :to-equal 'rust-cargo)))
   (it "detects buck2 and pants projects"
     (projectile-test-with-stub-root "project" (".buckconfig")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'buck2)))
+      (expect (projectile-detect-project-type) :to-equal 'buck2))
     (projectile-test-with-stub-root "project" ("pants.toml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'pants)))))
+      (expect (projectile-detect-project-type) :to-equal 'pants))))
 
 (describe "infrastructure project types"
   (it "detects a Terraform project"
     (projectile-test-with-stub-root "project" ("main.tf")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'terraform))))
+      (expect (projectile-detect-project-type) :to-equal 'terraform)))
   (it "detects a Helm chart"
     (projectile-test-with-stub-root "project" ("Chart.yaml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'helm))))
+      (expect (projectile-detect-project-type) :to-equal 'helm)))
   (it "detects a Pulumi project"
     (projectile-test-with-stub-root "project" ("Pulumi.yaml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'pulumi))))
+      (expect (projectile-detect-project-type) :to-equal 'pulumi)))
   (it "detects a Compose project by any of the file's four spellings"
     (projectile-test-with-stub-root "project" ("compose.yaml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'docker-compose)))
+      (expect (projectile-detect-project-type) :to-equal 'docker-compose))
     (projectile-test-with-stub-root "project" ("docker-compose.yml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'docker-compose))))
+      (expect (projectile-detect-project-type) :to-equal 'docker-compose)))
   (it "yields to the project's own build tool when it merely ships a Compose file"
     (projectile-test-with-stub-root "project" ("compose.yaml" "Cargo.toml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'rust-cargo)))))
+      (expect (projectile-detect-project-type) :to-equal 'rust-cargo))))
 
 (describe "python project types"
   ;; Nearly every Python project has a pyproject.toml, so the more
   ;; specific types have to win over it.
   (it "prefers django over the packaging manifests"
     (projectile-test-with-stub-root "project" ("manage.py" "pyproject.toml" "requirements.txt")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'django))))
+      (expect (projectile-detect-project-type) :to-equal 'django)))
   (it "prefers poetry over the bare pyproject.toml"
     (projectile-test-with-stub-root "project" ("poetry.lock" "pyproject.toml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'python-poetry))))
+      (expect (projectile-detect-project-type) :to-equal 'python-poetry)))
   (it "prefers pipenv over the bare pyproject.toml"
     (projectile-test-with-stub-root "project" ("Pipfile" "pyproject.toml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'python-pipenv))))
+      (expect (projectile-detect-project-type) :to-equal 'python-pipenv)))
   (it "prefers tox over the bare pyproject.toml"
     (projectile-test-with-stub-root "project" ("tox.ini" "pyproject.toml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'python-tox))))
+      (expect (projectile-detect-project-type) :to-equal 'python-tox)))
   (it "detects a uv project"
     (projectile-test-with-stub-root "project" ("uv.lock" "pyproject.toml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'python-uv))))
+      (expect (projectile-detect-project-type) :to-equal 'python-uv)))
   (it "detects a pdm project"
     (projectile-test-with-stub-root "project" ("pdm.lock" "pyproject.toml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'python-pdm))))
+      (expect (projectile-detect-project-type) :to-equal 'python-pdm)))
   (it "prefers pyproject.toml over setup.py and requirements.txt"
     (projectile-test-with-stub-root "project" ("pyproject.toml" "setup.py" "requirements.txt")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'python-toml))))
+      (expect (projectile-detect-project-type) :to-equal 'python-toml)))
   (it "runs the django server as the run command, not as the compile command"
     (expect (projectile-default-run-command 'django)
             :to-equal "python manage.py runserver")))
@@ -401,27 +367,22 @@
   (it "detects a modern Symfony layout, which has no app directory"
     (projectile-test-with-stub-root "project"
         ("composer.json" "src/" "bin/" "bin/console")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'php-symfony))))
+      (expect (projectile-detect-project-type) :to-equal 'php-symfony)))
   (it "still detects the legacy app/console layout"
     (projectile-test-with-stub-root "project"
         ("composer.json" "src/" "app/" "app/console")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'php-symfony))))
+      (expect (projectile-detect-project-type) :to-equal 'php-symfony)))
   (it "detects a Laravel project"
     (projectile-test-with-stub-root "project" ("composer.json" "artisan")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'php-laravel))))
+      (expect (projectile-detect-project-type) :to-equal 'php-laravel)))
   (it "falls back to plain composer for any other PHP project"
     (projectile-test-with-stub-root "project" ("composer.json")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'php-composer))))
+      (expect (projectile-detect-project-type) :to-equal 'php-composer)))
   (it "is not mistaken for a Node project because of its front-end assets"
     ;; A PHP application ships a package.json for its asset pipeline.
     (projectile-test-with-stub-root "project"
         ("composer.json" "artisan" "package.json" "package-lock.json")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'php-laravel)))))
+      (expect (projectile-detect-project-type) :to-equal 'php-laravel))))
 
 (describe "projectile-project-type"
   :var ((dir default-directory))
@@ -431,8 +392,7 @@
     (expect (gethash (projectile-project-root) projectile-project-type-cache) :to-equal 'emacs-eldev))
   (it "detects the type of Projectile's project when it is passed as args"
     (projectile-test-with-sandbox
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-project-type dir) :to-equal 'emacs-eldev))))
+      (expect (projectile-project-type dir) :to-equal 'emacs-eldev)))
   (describe "override by projectile-project-type"
     (it "is respected when no DIR is passed"
       (let ((projectile-project-type 'python-poetry))
@@ -443,11 +403,10 @@
           (expect (projectile-project-type dir) :to-equal 'emacs-eldev)))))
   (it "passes project-root to detect-project-type to avoid redundant resolution"
     (projectile-test-with-sandbox
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (spy-on 'projectile-detect-project-type :and-call-through)
-        (projectile-project-type dir)
-        (expect 'projectile-detect-project-type
-                :to-have-been-called-with dir (projectile-project-root dir))))))
+      (spy-on 'projectile-detect-project-type :and-call-through)
+      (projectile-project-type dir)
+      (expect 'projectile-detect-project-type
+              :to-have-been-called-with dir (projectile-project-root dir)))))
 
 (describe "projectile-detect-project-type"
   (it "detects project-type for rails-like npm tests"
@@ -509,36 +468,29 @@
         (expect (projectile-detect-project-type) :to-equal 'zig)))))
   (it "detects a Zig project that has only a build.zig"
     (projectile-test-with-stub-root "project" ("build.zig")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'zig))))
+      (expect (projectile-detect-project-type) :to-equal 'zig)))
   (it "detects a bzlmod Bazel project (MODULE.bazel)"
     (projectile-test-with-stub-root "project" ("MODULE.bazel")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'bazel))))
+      (expect (projectile-detect-project-type) :to-equal 'bazel)))
   (it "detects a legacy WORKSPACE Bazel project"
     (projectile-test-with-stub-root "project" ("WORKSPACE")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'bazel))))
+      (expect (projectile-detect-project-type) :to-equal 'bazel)))
   (it "detects a Gradle project using the Kotlin DSL"
     (projectile-test-with-stub-root "project" ("build.gradle.kts")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'gradle))))
+      (expect (projectile-detect-project-type) :to-equal 'gradle)))
   (it "detects an Angular project (its two markers are alternatives, not both)"
     (projectile-test-with-stub-root "project" ("angular.json" "package.json")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'angular))))
+      (expect (projectile-detect-project-type) :to-equal 'angular)))
   (it "detects a Taskfile.yaml go-task project"
     (projectile-test-with-stub-root "project" ("Taskfile.yaml")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (expect (projectile-detect-project-type) :to-equal 'go-task))))
+      (expect (projectile-detect-project-type) :to-equal 'go-task)))
   (it "does not match a project type whose marker-files are empty"
     (projectile-test-with-sandbox
      (projectile-test-with-files
       ("project/"
        "project/foo")
       (let ((projectile-project-types '((empty marker-files nil)
-                                        (real marker-files ("foo"))))
-            (projectile-project-type-cache (make-hash-table :test 'equal)))
+                                        (real marker-files ("foo")))))
         (spy-on 'projectile-project-root :and-return-value (projectile-test-project-root))
         (expect (projectile-detect-project-type) :to-equal 'real)))))
   (it "falls back to generic when the only type has empty marker-files"
@@ -546,8 +498,7 @@
      (projectile-test-with-files
       ("project/"
        "project/foo")
-      (let ((projectile-project-types '((empty marker-files nil)))
-            (projectile-project-type-cache (make-hash-table :test 'equal)))
+      (let ((projectile-project-types '((empty marker-files nil))))
         (spy-on 'projectile-project-root :and-return-value (projectile-test-project-root))
         (expect (projectile-detect-project-type) :to-equal 'generic)))))
   (it "detects a marker that sits in a subdirectory of the root"
@@ -559,25 +510,22 @@
       ("project/"
        "project/debian/"
        "project/debian/control")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (spy-on 'projectile-project-root :and-return-value (projectile-test-project-root))
-        (expect (projectile-detect-project-type) :to-equal 'debian)))))
+      (spy-on 'projectile-project-root :and-return-value (projectile-test-project-root))
+      (expect (projectile-detect-project-type) :to-equal 'debian))))
   (it "detects project-type for lowercase makefile projects"
     (projectile-test-with-sandbox
      (projectile-test-with-files
       ("project/"
        "project/makefile")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (spy-on 'projectile-project-root :and-return-value (projectile-test-project-root))
-        (expect (projectile-detect-project-type) :to-equal 'make)))))
+      (spy-on 'projectile-project-root :and-return-value (projectile-test-project-root))
+      (expect (projectile-detect-project-type) :to-equal 'make))))
   (it "detects project-type for GNUmakefile projects"
     (projectile-test-with-sandbox
      (projectile-test-with-files
       ("project/"
        "project/GNUmakefile")
-      (let ((projectile-project-type-cache (make-hash-table :test 'equal)))
-        (spy-on 'projectile-project-root :and-return-value (projectile-test-project-root))
-        (expect (projectile-detect-project-type) :to-equal 'gnumake)))))
+      (spy-on 'projectile-project-root :and-return-value (projectile-test-project-root))
+      (expect (projectile-detect-project-type) :to-equal 'gnumake))))
   (it "passes the project root to a function marker (#1909)"
     (let ((projectile-project-types
            (list (list 'custom 'marker-files


### PR DESCRIPTION
Three cleanups out of a look at where the maintenance cost actually sits. The code itself is in good shape - 818 functions averaging 14 lines, only two dead ones, no deprecation backlog - so none of this is about the code being bad.

**The section headers had stopped being true.** `;;; Subprojects` covered 1641 lines and 95 definitions, about five of which were subprojects; the rest was lifecycle commands, command history, test-at-point rules, tasks, and all of known-projects management and switching. Half the other big sections drifted the same way - `Alien Project Indexing` into project buffers, `File kinds` into the project type machinery, `Project type registration` into grep. In a file this size those headers are the map that imenu and outline-minor-mode read, so a wrong one is worse than none. Largest section is now 989 lines.

Two things were genuinely in the wrong place and moved: the git helpers, which sat under `;;;; Dashboard data collection` while the worktree lookup depended on them, and the six lifecycle commands, which were split in half by 390 lines of test-at-point rules. I checked the change by diffing the inventory of top-level forms before and after rather than by reading it - identical.

**Tests were re-emptying caches the sandbox had already emptied.** `projectile-test-with-sandbox` rebinds every registered per-project cache; 60 specs inside it rebound those same caches again, usually as a `let` whose only binding that was. One that looks identical stays, with a comment: the colocated-marker spec asks about the same directory twice under different `projectile-vcs-markers`, so that table is forgetting an answer mid-spec, not isolating the spec. I removed it with the rest and the suite caught it.

**The project type keywords were described twice and had drifted.** `register-project-type` and `--build-project-plist` take the same seventeen keywords with 61- and 49-line descriptions; they disagreed about what PROJECT-FILE falls back to. The code agrees with the public one, so that copy stays and the private builder points at it.