### PR TITLE
Document the sibling signal list as an extension point

### DIFF
--- a/doc/modules/ROOT/pages/across_repositories.adoc
+++ b/doc/modules/ROOT/pages/across_repositories.adoc
@@ -171,6 +171,37 @@ signal goes quiet and you fall back to name matching. When a project you
 care about ends up with no siblings, that's what `projectile-project-groups`
 is for.
 
+=== Signals of your own
+
+The three above are only the default value of
+`projectile-sibling-project-functions`, which is a plain list of functions.
+Each is called with a project root and should return a list of project
+directories related to it; the results are concatenated in the order the
+list gives, and a project found by more than one function is offered once,
+in the position the first one to report it put it.
+
+So you can add a signal of your own - reading a workspace manifest, asking
+a service, consulting whatever your organization uses to say which
+repositories belong together:
+
+[source,elisp]
+----
+(defun my-siblings-from-manifest (root)
+  "Return the projects listed beside ROOT in our workspace manifest."
+  ...)
+
+;; ahead of the built-ins, so it wins where it has an opinion
+(add-to-list 'projectile-sibling-project-functions #'my-siblings-from-manifest)
+----
+
+Put yours before the built-ins to have it take precedence, after them to
+act as a fallback, or replace the list outright to use nothing else.
+
+NOTE: The share cap applies inside the two inferred signals, not to the
+list as a whole, so a function of your own is never capped - it behaves
+like a configured group. That's usually what you want, but it does mean a
+function that accidentally matches everything will offer you everything.
+
 == What else checkouts share
 
 Knowing that two roots are one repository is useful beyond switching between

--- a/projectile.el
+++ b/projectile.el
@@ -9610,7 +9610,7 @@ and `:truncated' (non-nil when the cap was hit)."
 ;; batch runs and the tests drive.  The async driver below reuses the very same
 ;; per-file `projectile-replace--scan-file', so the structs it produces are
 ;; identical to what `--gather' would produce over the same candidate list and
-;; regexp -- only the DELIVERY changes: files are scanned in timer-yielded
+;; regexp - only the DELIVERY changes: files are scanned in timer-yielded
 ;; chunks, matches stream into the results buffer as they are found, and the
 ;; scan can be canceled.  The `case-fold-search' that `--scan-file' reads is
 ;; re-established from the buffer's `projectile-replace--case-fold' inside each
@@ -10813,7 +10813,7 @@ otherwise returns REGEXP unchanged."
 Cancels any in-flight scan in BUFFER first, then scans with the async
 chunked driver when `projectile-replace--async-p' holds and otherwise
 synchronously (always in batch), so the final match list is identical
-either way -- only delivery differs.  BUFFER is re-rendered when done and
+either way - only delivery differs.  BUFFER is re-rendered when done and
 ON-DONE (or nil) is called in it.
 
 As an optional accelerator, a read-only search-reviewer BUFFER doing a
@@ -10863,7 +10863,7 @@ plain regexp search always take the elisp path below."
 When scanning is asynchronous the buffer is shown immediately and matches
 stream in; when synchronous (always in batch) the scan completes first
 and, to preserve the pre-async behavior, no buffer is shown when nothing
-matched -- NO-MATCH-MSG is issued instead.  Returns the results buffer,
+matched - NO-MATCH-MSG is issued instead.  Returns the results buffer,
 or nil on the synchronous no-match path.  ROOT, TERM, REGEXP,
 REPLACEMENT, LITERAL, CASE-FOLD, WORD and RG-PATTERN seed the buffer
 state."
@@ -11153,8 +11153,8 @@ Emacs regexp.  There is no replacement prompt."
          (word projectile-search-whole-word)
          (candidates (projectile-replace--candidates term literal case-fold root)))
     ;; SEAM: everything above computes the candidate file list; the shared
-    ;; opener below seeds the buffer and scans -- synchronously in batch,
-    ;; asynchronously (streaming) when interactive -- then renders whatever
+    ;; opener below seeds the buffer and scans - synchronously in batch,
+    ;; asynchronously (streaming) when interactive - then renders whatever
     ;; matches come back.
     (projectile-replace--open
      #'projectile-search-mode projectile-search-buffer-name

--- a/projectile.el
+++ b/projectile.el
@@ -14428,7 +14428,13 @@ Each is called with a project root and should return a list of project
 directories related to it.  They're consulted in order and their results
 concatenated, so the most trustworthy signal should come first; a project
 found by more than one is offered once, in the position the first
-function to report it put it."
+function to report it put it.
+
+Adding your own is the intended way to teach Projectile a grouping it
+can't infer - a workspace manifest, say.  Note that
+`projectile-sibling-max-group-share' is applied inside the two built-in
+inferred signals rather than to this list, so a function you add is never
+capped: it is trusted the way a configured group is."
   :group 'projectile
   :type '(repeat function)
   :package-version '(projectile . "3.4.0"))


### PR DESCRIPTION
`projectile-sibling-project-functions` is a plain list of functions, and adding your own is the intended way to teach Projectile a grouping it can't infer - a workspace manifest, whatever your org uses to say which repos belong together. The manual mentioned the option exactly once, in passing, as the thing that fixes the order of the three built-ins. It never said the list is yours to extend, or what a function has to return.

The worktree equivalent, four sections down the same page, spells all of that out. So this was just an inconsistency between two extension points of the same shape.

Adds a section with the contract, a worked example, and where to put yours relative to the built-ins.

It also writes down something that was true but recorded nowhere: the share cap is applied inside the two inferred signals rather than to the list as a whole, so a function you add is never capped - it's trusted the way a configured group is. Anyone writing one would reasonably assume the cap protects them. That note is in the docstring as well, since that's where they'd look first.

No CHANGELOG entry, matching how the other docs-only PRs this cycle were handled.