### PR TITLE
Work across a group of projects, not just the one you're in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /project
 /.projectile-cache.eld
 .claude/
+AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@
 
 ### New features
 
-- [#2160](https://github.com/bbatsov/projectile/pull/2160): Add `projectile-find-file-in-sibling-projects` (`s-p N`) and `projectile-search-in-sibling-projects` (`s-p s n`), which work across the family of related projects rather than just the one you're in.
+- [#2160](https://github.com/bbatsov/projectile/pull/2160): Add `projectile-find-file-in-sibling-projects` (`s-p n f`) and `projectile-search-in-sibling-projects` (`s-p n s`), which work across the family of related projects rather than just the one you're in.
   - Both are built on `projectile-find-file-in-projects` and `projectile-search-in-projects`, which take any list of projects, so a command for a group of your own is a two-line wrapper.
   - A group search puts every match in one `*projectile-search*` buffer, named relative to the directory containing the group, so each one is labelled with the project it came from.
+
+### Changes
+
+- [#2160](https://github.com/bbatsov/projectile/pull/2160): `projectile-switch-sibling-project` moved from `s-p n` to `s-p n p`. `s-p n` is now the prefix for every command that works across related projects, with each key mirroring the project-wide one a level down, the way `c m` does for subprojects.
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ## master (unreleased)
 
+### New features
+
+- [#2160](https://github.com/bbatsov/projectile/pull/2160): Add `projectile-find-file-in-sibling-projects` (`s-p N`) and `projectile-search-in-sibling-projects` (`s-p s n`), which work across the family of related projects rather than just the one you're in.
+  - Both are built on `projectile-find-file-in-projects` and `projectile-search-in-projects`, which take any list of projects, so a command for a group of your own is a two-line wrapper.
+  - A group search puts every match in one `*projectile-search*` buffer, named relative to the directory containing the group, so each one is labelled with the project it came from.
+
 ### Bugs fixed
 
 - [#2157](https://github.com/bbatsov/projectile/pull/2157): `projectile-use-comint-mode` now covers the named tasks run by `projectile-run-task`, which were always given a read-only compilation buffer however it was set - so a task that needs to ask for a sudo password had nowhere to type one ([#2156](https://github.com/bbatsov/projectile/issues/2156)). Name `task` in the list, or set the option to `t`.

--- a/doc/modules/ROOT/pages/across_repositories.adoc
+++ b/doc/modules/ROOT/pages/across_repositories.adoc
@@ -24,11 +24,16 @@ directories is the right one.
 
 | kbd:[s-p W] | `projectile-switch-worktree`
 | kbd:[s-p n] | `projectile-switch-sibling-project`
+| kbd:[s-p N] | `projectile-find-file-in-sibling-projects`
+| kbd:[s-p s n] | `projectile-search-in-sibling-projects`
 |===
 
-Both honour `projectile-switch-project-action` on switch, and both take a
-prefix argument to run `projectile-dispatch` instead, exactly like the
+The two switch commands honour `projectile-switch-project-action`, and both
+take a prefix argument to run `projectile-dispatch` instead, exactly like the
 other switch commands.
+
+The other two don't switch anywhere - see <<working-across,Working across a
+group>> below.
 
 [#worktrees]
 == Other checkouts of this project
@@ -201,6 +206,58 @@ NOTE: The share cap applies inside the two inferred signals, not to the
 list as a whole, so a function of your own is never capped - it behaves
 like a configured group. That's usually what you want, but it does mean a
 function that accidentally matches everything will offer you everything.
+
+[#working-across]
+== Working across a group
+
+Switching isn't the only thing you want a family of projects for. Two
+commands work on the whole group at once, the current project included:
+
+* kbd:[s-p N] (`projectile-find-file-in-sibling-projects`) completes over
+  the files of every related project. It's kbd:[s-p F] narrowed from "every
+  project I have ever visited" to "the handful this one belongs with",
+  which is the difference between a useful completion list and a hopeless
+  one.
+* kbd:[s-p s n] (`projectile-search-in-sibling-projects`) searches them all
+  and collects the matches in one `*projectile-search*` buffer. A prefix
+  argument makes the term an Emacs regexp.
+
+The search results are named relative to the innermost directory holding
+the group, so each match says which project it came from:
+
+....
+Search "defcustom"
+1261 matches in 191 files  [literal] [ignore-case]
+
+cider/lisp/cider-eval.el (4)
+orchard/src/orchard/info.clj (2)
+....
+
+Everything the buffer does then covers the whole group - filtering,
+re-search, exporting to `grep-mode`, and kbd:[r] to turn it into a
+reviewable replacement across all of them. See
+xref:usage.adoc[the search and replace reviewers].
+
+Both commands take a plain list of projects underneath, so a command for
+a group of your own is a two-line wrapper:
+
+[source,elisp]
+----
+(defun my-find-file-in-infra-projects ()
+  (interactive)
+  (projectile-find-file-in-projects
+   (cdr (assoc "infra" projectile-project-groups))
+   "Find file in infra: "))
+----
+
+`projectile-search-in-projects` is the same shape for searching.
+
+NOTE: A group search skips the ripgrep fast-path, which runs one `rg` over
+one directory tree, so it's slower than searching a single project. And a
+project's own `.projectile` ignore rules only apply while you're inside it,
+so the other members of a group are filtered by the global ignore rules
+alone - long-standing behaviour that
+`projectile-find-file-in-known-projects` shares.
 
 == What else checkouts share
 

--- a/doc/modules/ROOT/pages/across_repositories.adoc
+++ b/doc/modules/ROOT/pages/across_repositories.adoc
@@ -10,7 +10,7 @@ else" that come up constantly, and Projectile has a command for each:
 * *Different projects that belong together* - a library and the app using
   it, a tool and its documentation site.
   <<siblings,`projectile-switch-sibling-project`>>
-  (kbd:[s-p n]).
+  (kbd:[s-p n p]).
 
 Both are narrowed versions of `projectile-switch-project` (kbd:[s-p p]).
 That command offers every project you've ever visited; these two offer
@@ -23,9 +23,9 @@ directories is the right one.
 | Keybinding | Command
 
 | kbd:[s-p W] | `projectile-switch-worktree`
-| kbd:[s-p n] | `projectile-switch-sibling-project`
-| kbd:[s-p N] | `projectile-find-file-in-sibling-projects`
-| kbd:[s-p s n] | `projectile-search-in-sibling-projects`
+| kbd:[s-p n p] | `projectile-switch-sibling-project`
+| kbd:[s-p n f] | `projectile-find-file-in-sibling-projects`
+| kbd:[s-p n s] | `projectile-search-in-sibling-projects`
 |===
 
 The two switch commands honour `projectile-switch-project-action`, and both
@@ -101,7 +101,7 @@ option's docstring for the details.
 [#siblings]
 == Related projects
 
-kbd:[s-p n] offers the projects related to the one you're in. Three
+kbd:[s-p n p] offers the projects related to the one you're in. Three
 signals decide what "related" means, consulted in the order listed by
 `projectile-sibling-project-functions` - from the one you can trust
 completely to the one that's a guess.
@@ -213,12 +213,12 @@ function that accidentally matches everything will offer you everything.
 Switching isn't the only thing you want a family of projects for. Two
 commands work on the whole group at once, the current project included:
 
-* kbd:[s-p N] (`projectile-find-file-in-sibling-projects`) completes over
+* kbd:[s-p n f] (`projectile-find-file-in-sibling-projects`) completes over
   the files of every related project. It's kbd:[s-p F] narrowed from "every
   project I have ever visited" to "the handful this one belongs with",
   which is the difference between a useful completion list and a hopeless
   one.
-* kbd:[s-p s n] (`projectile-search-in-sibling-projects`) searches them all
+* kbd:[s-p n s] (`projectile-search-in-sibling-projects`) searches them all
   and collects the matches in one `*projectile-search*` buffer. A prefix
   argument makes the term an Emacs regexp.
 
@@ -329,7 +329,7 @@ Worth knowing before you file a bug:
 When kbd:[s-p W] has nothing to offer it distinguishes the two reasons:
 having looked and found no other checkout, and not being able to look at
 all because the project isn't the top level of a git, Mercurial or
-Jujutsu repository. Only the first means "there aren't any". kbd:[s-p n]
+Jujutsu repository. Only the first means "there aren't any". kbd:[s-p n p]
 needs none of this, so it's the one to reach for when Projectile can't
 identify the repository.
 

--- a/doc/modules/ROOT/pages/cheatsheet.adoc
+++ b/doc/modules/ROOT/pages/cheatsheet.adoc
@@ -16,6 +16,9 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p F]
 | Display a list of all files in all known projects.
 
+| kbd:[s-p N]
+| Display a list of all files in the projects related to this one - kbd:[s-p F] narrowed to the family the current project belongs to (see xref:across_repositories.adoc[Working across repositories]).
+
 | kbd:[s-p g]
 | Display a list of all files at point in the project. With a prefix argument it will clear the cache first.
 
@@ -81,6 +84,9 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 
 | kbd:[s-p s t]
 | Collect the project's `TODO`/`FIXME`-style annotations into the reviewable search buffer. With a prefix argument it prompts for which keywords to search for.
+
+| kbd:[s-p s n]
+| Search the current project and the ones related to it, collecting every match in one reviewable buffer. With a prefix argument the term is an Emacs regexp (see xref:across_repositories.adoc[Working across repositories]).
 
 | kbd:[s-p v]
 | Run `vc-dir` on the root directory of the project.

--- a/doc/modules/ROOT/pages/cheatsheet.adoc
+++ b/doc/modules/ROOT/pages/cheatsheet.adoc
@@ -16,7 +16,7 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p F]
 | Display a list of all files in all known projects.
 
-| kbd:[s-p N]
+| kbd:[s-p n f]
 | Display a list of all files in the projects related to this one - kbd:[s-p F] narrowed to the family the current project belongs to (see xref:across_repositories.adoc[Working across repositories]).
 
 | kbd:[s-p g]
@@ -85,7 +85,7 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p s t]
 | Collect the project's `TODO`/`FIXME`-style annotations into the reviewable search buffer. With a prefix argument it prompts for which keywords to search for.
 
-| kbd:[s-p s n]
+| kbd:[s-p n s]
 | Search the current project and the ones related to it, collecting every match in one reviewable buffer. With a prefix argument the term is an Emacs regexp (see xref:across_repositories.adoc[Working across repositories]).
 
 | kbd:[s-p v]
@@ -244,7 +244,7 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p W]
 | Switch to another checkout of the current project's repository - a git worktree, a Jujutsu workspace, or another clone of the same upstream - showing what tells each apart (see xref:across_repositories.adoc[Working across repositories]).
 
-| kbd:[s-p n]
+| kbd:[s-p n p]
 | Switch to a project related to the current one, rather than to any known project (see xref:across_repositories.adoc[Working across repositories]).
 
 | kbd:[s-p S]

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -630,7 +630,7 @@ where you're headed. Two commands narrow it down:
   current project's repository - its git worktrees, its Jujutsu workspaces, or
   another clone of the same upstream - each labelled with whatever tells it
   apart: the branch, or the workspace name.
-* `projectile-switch-sibling-project` (kbd:[s-p n]) offers the projects related
+* `projectile-switch-sibling-project` (kbd:[s-p n p]) offers the projects related
   to this one: grouped with it in your configuration, sharing the owner of its
   remote, or named after the same thing.
 

--- a/projectile.el
+++ b/projectile.el
@@ -16480,9 +16480,11 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "k") #'projectile-kill-buffers)
     (define-key map (kbd "l") #'projectile-find-file-in-directory)
     (define-key map (kbd "m") #'projectile-dispatch)
-    ;; projects related to this one, in other repositories
-    (define-key map (kbd "n") #'projectile-switch-sibling-project)
-    (define-key map (kbd "N") #'projectile-find-file-in-sibling-projects)
+    ;; projects related to this one, in other repositories - the keys
+    ;; mirror the project-wide ones a level down, as `c m' does
+    (define-key map (kbd "n p") #'projectile-switch-sibling-project)
+    (define-key map (kbd "n f") #'projectile-find-file-in-sibling-projects)
+    (define-key map (kbd "n s") #'projectile-search-in-sibling-projects)
     (define-key map (kbd "o") #'projectile-multi-occur)
     (define-key map (kbd "p") #'projectile-switch-project)
     (define-key map (kbd "q") #'projectile-switch-open-project)
@@ -16496,7 +16498,6 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "s x") #'projectile-find-references)
     (define-key map (kbd "s R") #'projectile-search-review)
     (define-key map (kbd "s X") #'projectile-search-regexp-review)
-    (define-key map (kbd "s n") #'projectile-search-in-sibling-projects)
     (define-key map (kbd "s t") #'projectile-todos)
     (define-key map (kbd "S") #'projectile-save-project-buffers)
     (define-key map (kbd "t") #'projectile-toggle-between-implementation-and-test)
@@ -16817,7 +16818,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("l" "file in dir" projectile-find-file-in-directory)
       ("C" "changed file" projectile-find-changed-file)
       ("F" "file in known projects" projectile-find-file-in-known-projects)
-      ("N" "file in sibling projects" projectile-find-file-in-sibling-projects)
+      ("nf" "file in sibling projects" projectile-find-file-in-sibling-projects)
       ("d" "dir" projectile-dispatch-find-dir)
       ("D" "dired" projectile-dispatch-dired)
       ("e" "recentf" projectile-recentf)
@@ -16843,7 +16844,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("sa" "ag" projectile-dispatch-ag)
       ("sx" "references" projectile-find-references)
       ("sR" "search (review)" projectile-dispatch-search-review)
-      ("sn" "search siblings" projectile-dispatch-search-siblings)
+      ("ns" "search siblings" projectile-dispatch-search-siblings)
       ("st" "todos" projectile-todos)
       ("o" "multi-occur" projectile-multi-occur)
       ("r" "replace" projectile-replace)
@@ -16853,7 +16854,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("p" "switch project" projectile-dispatch-switch-project)
       ("q" "switch open project" projectile-switch-open-project)
       ("W" "switch worktree" projectile-switch-worktree)
-      ("n" "switch sibling project" projectile-switch-sibling-project)
+      ("np" "switch sibling project" projectile-switch-sibling-project)
       ("A" "add known project" projectile-add-known-project)
       ("v" "vc" projectile-vc)
       ("P" "dashboard" projectile-dashboard)
@@ -16960,6 +16961,8 @@ search/replace case-sensitive, `--word' makes it match whole words,
          "--"
          ["Switch to project" projectile-switch-project]
          ["Switch to open project" projectile-switch-open-project]
+         ["Switch to sibling project" projectile-switch-sibling-project]
+         ["Switch to worktree" projectile-switch-worktree]
          "--"
          ["Discover projects in directory" projectile-discover-projects-in-directory]
          ["Discover projects in search path" projectile-discover-projects-in-search-path]

--- a/projectile.el
+++ b/projectile.el
@@ -16735,6 +16735,19 @@ buffer."
                               #'projectile-search-regexp-review
                             #'projectile-search-review)))))
 
+(defun projectile-dispatch-search-siblings ()
+  "Sibling-project search honouring the search switches.
+`--regexp' reads the term as an Emacs regexp, `--case-sensitive' seeds
+the search case-sensitive and `--word' matches whole words; all can still
+be flipped (`x'/`c'/`w') in the results buffer."
+  (interactive)
+  (let* ((switches (projectile-dispatch--args))
+         (case-fold-search (if (member "--case-sensitive" switches)
+                               nil case-fold-search))
+         (projectile-search-whole-word
+          (if (member "--word" switches) t projectile-search-whole-word)))
+    (projectile-search-in-sibling-projects (and (member "--regexp" switches) t))))
+
 (defun projectile-dispatch-replace-review ()
   "Reviewable replace honouring the `--regexp' and `--case-sensitive' switches.
 Like `projectile-dispatch-search-review', but for the replace reviewer."
@@ -16804,6 +16817,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("l" "file in dir" projectile-find-file-in-directory)
       ("C" "changed file" projectile-find-changed-file)
       ("F" "file in known projects" projectile-find-file-in-known-projects)
+      ("N" "file in sibling projects" projectile-find-file-in-sibling-projects)
       ("d" "dir" projectile-dispatch-find-dir)
       ("D" "dired" projectile-dispatch-dired)
       ("e" "recentf" projectile-recentf)
@@ -16829,7 +16843,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("sa" "ag" projectile-dispatch-ag)
       ("sx" "references" projectile-find-references)
       ("sR" "search (review)" projectile-dispatch-search-review)
-      ("sn" "search siblings" projectile-search-in-sibling-projects)
+      ("sn" "search siblings" projectile-dispatch-search-siblings)
       ("st" "todos" projectile-todos)
       ("o" "multi-occur" projectile-multi-occur)
       ("r" "replace" projectile-replace)
@@ -16840,7 +16854,6 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("q" "switch open project" projectile-switch-open-project)
       ("W" "switch worktree" projectile-switch-worktree)
       ("n" "switch sibling project" projectile-switch-sibling-project)
-      ("N" "file in sibling projects" projectile-find-file-in-sibling-projects)
       ("A" "add known project" projectile-add-known-project)
       ("v" "vc" projectile-vc)
       ("P" "dashboard" projectile-dashboard)

--- a/projectile.el
+++ b/projectile.el
@@ -9145,7 +9145,9 @@ files in the project."
                         ((executable-find "ack")
                          (projectile--ack-construct-command search-term file-ext))
                         ((and (executable-find "git")
-                              (eq (projectile-project-vcs) 'git))
+                              ;; DIRECTORY's VCS, not the current project's -
+                              ;; a group search asks about each member in turn
+                              (eq (projectile-project-vcs directory) 'git))
                          (projectile--git-grep-construct-command search-term file-ext))
                         (t
                          (projectile--grep-construct-command search-term file-ext)))))
@@ -9414,7 +9416,15 @@ often; smaller values keep Emacs more responsive."
 
 ;; Buffer-local state of a `*projectile-replace*' buffer.
 (defvar-local projectile-replace--root nil
-  "Project root the current results buffer was gathered from.")
+  "Directory the current results buffer's file names are shown relative to.
+For an ordinary search that is the project root; for a search over a
+group of projects it is the innermost directory containing all of them,
+so each match is labelled with the project it came from.")
+(defvar-local projectile-replace--projects nil
+  "Project roots the current results buffer was gathered from.
+Always a list - a one-element one for an ordinary single-project search.
+This, not `projectile-replace--root', is what a re-scan re-reads, so
+re-searching a group of projects covers the same group again.")
 (defvar-local projectile-replace--term nil
   "Raw search term the current results buffer was gathered with.")
 (defvar-local projectile-replace--search nil
@@ -9732,8 +9742,14 @@ The write-back and export must never run against a partial match set."
   (when projectile-replace--scanning
     (user-error "Still searching; wait for the scan to finish")))
 
-(defun projectile-replace--candidates (term literal case-fold directory)
-  "Return the files under DIRECTORY worth scanning for TERM.
+(defun projectile-replace--candidates (term literal case-fold directories)
+  "Return the files under DIRECTORIES worth scanning for TERM.
+DIRECTORIES is a project root, or a list of them for a search spanning a
+group of projects, in which case each contributes its own file list and
+the result is de-duplicated - two members of a group can nest (a
+monorepo and a project inside it), and a file scanned twice would be
+replaced twice, corrupting it.
+
 For a case-sensitive LITERAL search this narrows to files that contain
 TERM, via `projectile-files-with-string' - which matches
 case-insensitively, so the narrowed set is a safe superset that the scan
@@ -9741,13 +9757,18 @@ then filters exactly - intersected with the project's ignore-aware file
 list.  For a regexp search, or a case-insensitive literal search, it
 returns the whole ignore-aware file list, since those can't be narrowed
 by an external grep this way."
-  (let ((project-files (mapcar (lambda (f) (expand-file-name f directory))
-                               (projectile-dir-files directory))))
-    (if (and literal (not case-fold))
-        (seq-filter (lambda (f) (member f project-files))
-                    (projectile-files-with-string term directory))
-      (seq-remove (lambda (f) (or (file-directory-p f) (not (file-exists-p f))))
-                  project-files))))
+  (delete-dups
+   (mapcan
+    (lambda (directory)
+      (let ((project-files (mapcar (lambda (f) (expand-file-name f directory))
+                                   (projectile-dir-files directory))))
+        (if (and literal (not case-fold))
+            (seq-filter (lambda (f) (member f project-files))
+                        (projectile-files-with-string term directory))
+          (seq-remove (lambda (f) (or (file-directory-p f) (not (file-exists-p f))))
+                      project-files))))
+    ;; a recorded group can name a directory that has since been moved away
+    (seq-filter #'projectile--directory-p (ensure-list directories)))))
 
 ;;; Results buffer rendering
 
@@ -10002,7 +10023,7 @@ state.  The re-render happens from the (streaming) scan, so callers need
 not render again."
   (let ((candidates (projectile-replace--candidates
                      projectile-replace--term projectile-replace--literal
-                     projectile-replace--case-fold projectile-replace--root)))
+                     projectile-replace--case-fold projectile-replace--projects)))
     (setq projectile-replace--filtered nil)
     (projectile-replace--start (current-buffer) candidates
                                projectile-replace--search nil)))
@@ -10549,14 +10570,16 @@ write back to the files.
 
 (defun projectile-replace--seed (buf mode root term regexp replacement
                                      literal case-fold &optional word
-                                     rg-pattern)
+                                     rg-pattern projects)
   "Put BUF in MODE and seed its results-buffer state, with no matches yet.
 ROOT, TERM, REGEXP, REPLACEMENT, LITERAL, CASE-FOLD, WORD and RG-PATTERN
 seed the search parameters; the match list starts empty, ready for a
-\(sync or async) scan to fill it."
+\(sync or async) scan to fill it.  PROJECTS is the list of project roots
+searched, defaulting to just ROOT."
   (with-current-buffer buf
     (funcall mode)
-    (setq projectile-replace--root root
+    (setq projectile-replace--projects (or projects (list root))
+          projectile-replace--root root
           projectile-replace--term term
           projectile-replace--search regexp
           projectile-replace--replacement replacement
@@ -10820,12 +10843,15 @@ As an optional accelerator, a read-only search-reviewer BUFFER doing a
 literal search (or one carrying a `projectile-replace--rg-pattern') takes
 the ripgrep fast-path (`projectile-search--gather-rg') when
 `projectile-search--rg-fastpath-p' holds; the replace reviewer and the
-plain regexp search always take the elisp path below."
+plain regexp search always take the elisp path below.  So does a search
+spanning several projects: the fast-path runs one `rg' over one directory
+tree, and a group of projects is not one tree."
   (with-current-buffer buffer
     (projectile-replace--cancel-scan))
   (cond
    ((with-current-buffer buffer
       (and (derived-mode-p 'projectile-search-mode)
+           (null (cdr projectile-replace--projects))
            (projectile-search--rg-fastpath-p projectile-replace--literal
                                              projectile-replace--rg-pattern)))
     (projectile-search--gather-rg
@@ -10858,15 +10884,15 @@ plain regexp search always take the elisp path below."
 
 (defun projectile-replace--open (mode buf-name root term regexp replacement
                                       literal case-fold candidates no-match-msg
-                                      &optional word rg-pattern)
+                                      &optional word rg-pattern projects)
   "Open BUF-NAME in MODE and scan CANDIDATES for REGEXP into it.
 When scanning is asynchronous the buffer is shown immediately and matches
 stream in; when synchronous (always in batch) the scan completes first
 and, to preserve the pre-async behavior, no buffer is shown when nothing
 matched - NO-MATCH-MSG is issued instead.  Returns the results buffer,
 or nil on the synchronous no-match path.  ROOT, TERM, REGEXP,
-REPLACEMENT, LITERAL, CASE-FOLD, WORD and RG-PATTERN seed the buffer
-state."
+REPLACEMENT, LITERAL, CASE-FOLD, WORD, RG-PATTERN and PROJECTS seed the
+buffer state."
   ;; re-running the command must not orphan a scan still filling an earlier
   ;; instance of the buffer (re-seeding resets its buffer-locals)
   (when-let* ((existing (get-buffer buf-name)))
@@ -10877,10 +10903,11 @@ state."
           ;; engine is off (`projectile-search-async' nil); `--start' then
           ;; dispatches it to ripgrep
           (and (eq mode #'projectile-search-mode)
+               (null (cdr projects))
                (projectile-search--rg-fastpath-p literal rg-pattern)))
       (let ((buf (get-buffer-create buf-name)))
         (projectile-replace--seed buf mode root term regexp replacement
-                                  literal case-fold word rg-pattern)
+                                  literal case-fold word rg-pattern projects)
         (with-current-buffer buf
           (setq projectile-replace--scanning t)
           (funcall projectile-replace--render-function))
@@ -10899,7 +10926,7 @@ state."
           (progn (when no-match-msg (message "%s" no-match-msg)) nil)
         (let ((buf (get-buffer-create buf-name)))
           (projectile-replace--seed buf mode root term regexp replacement
-                                    literal case-fold word rg-pattern)
+                                    literal case-fold word rg-pattern projects)
           (with-current-buffer buf
             (setq projectile-replace--matches matches
                   projectile-replace--truncated truncated)
@@ -11076,6 +11103,7 @@ any filtering is undone and every match comes back enabled), mirroring
 `projectile-replace-review'."
   (interactive)
   (let* ((root projectile-replace--root)
+         (projects projectile-replace--projects)
          (term projectile-replace--term)
          (literal projectile-replace--literal)
          (case-fold projectile-replace--case-fold)
@@ -11084,12 +11112,12 @@ any filtering is undone and every match comes back enabled), mirroring
          (replacement (read-string
                        (projectile-prepend-project-name
                         (format "Replace %s with: " term))))
-         (candidates (projectile-replace--candidates term literal case-fold root)))
+         (candidates (projectile-replace--candidates term literal case-fold projects)))
     (projectile-replace--open
      #'projectile-replace-mode projectile-replace-buffer-name
      root term regexp replacement literal case-fold candidates
      (projectile-prepend-project-name (format "No matches for %s" term))
-     word)))
+     word nil projects)))
 
 (defvar projectile-search-mode-map
   (let ((map (make-sparse-keymap)))
@@ -11140,27 +11168,18 @@ matches to a `grep-mode' buffer for wgrep or Emacs 31's `grep-edit-mode'.
 (defun projectile-search--review (literal)
   "Gather matches for a project-wide search and pop the read-only results buffer.
 LITERAL non-nil searches for a literal string; otherwise the term is an
-Emacs regexp.  There is no replacement prompt."
-  (let* ((root (projectile-acquire-root))
-         (term (projectile--read-search-string-with-default
-                (format "Search %s%s for"
-                        (projectile--search-tool-tag
-                         (if (and literal (projectile-search--rg-fastpath-p t))
-                             "ripgrep" "elisp"))
-                        (if literal "" " regexp"))))
-         (regexp (if literal (regexp-quote term) term))
-         (case-fold case-fold-search)
-         (word projectile-search-whole-word)
-         (candidates (projectile-replace--candidates term literal case-fold root)))
-    ;; SEAM: everything above computes the candidate file list; the shared
-    ;; opener below seeds the buffer and scans - synchronously in batch,
-    ;; asynchronously (streaming) when interactive - then renders whatever
-    ;; matches come back.
-    (projectile-replace--open
-     #'projectile-search-mode projectile-search-buffer-name
-     root term regexp nil literal case-fold candidates
-     (projectile-prepend-project-name (format "No matches for %s" term))
-     word)))
+Emacs regexp.  There is no replacement prompt.
+
+This is `projectile-search-in-projects' over the one project you are in;
+the prompt is built here because only the single-project case can name
+the tool that will do the scanning."
+  (projectile-search-in-projects
+   (list (projectile-acquire-root)) literal
+   (format "Search %s%s for"
+           (projectile--search-tool-tag
+            (if (and literal (projectile-search--rg-fastpath-p t))
+                "ripgrep" "elisp"))
+           (if literal "" " regexp"))))
 
 ;;;###autoload
 (defun projectile-search-review ()
@@ -13517,20 +13536,16 @@ This command will first prompt for the directory the file is in."
 
 (defun projectile-all-project-files ()
   "Get a list of all files in all projects."
-  (mapcan
-   (lambda (project)
-     (when (file-exists-p project)
-       (mapcar (lambda (file)
-                 (expand-file-name file project))
-               (projectile-project-files project))))
-   projectile-known-projects))
+  (projectile-project-group-files projectile-known-projects))
 
 ;;;###autoload
 (defun projectile-find-file-in-known-projects ()
-  "Jump to a file in any of the known projects."
+  "Jump to a file in any of the known projects.
+This is `projectile-find-file-in-projects' over every project you have
+ever visited."
   (interactive)
-  (find-file (projectile-completing-read "Find file in projects: " (projectile-all-project-files)
-                                         :caller 'projectile-read-file)))
+  (projectile-find-file-in-projects projectile-known-projects
+                                    "Find file in projects: "))
 
 (defun projectile-keep-project-p (project)
   "Determine whether we should cleanup (remove) PROJECT or not.
@@ -14587,6 +14602,135 @@ switch.  With a prefix ARG invokes `projectile-dispatch' instead."
      :action (lambda (project)
                (projectile-switch-project-by-name project arg))
      :category 'projectile-project)))
+
+
+;;; Commands over a group of projects
+;;
+;; Everything above works on the project you're in.  These two work on a set
+;; of projects handed to them, because those are the two questions a group
+;; actually raises: which of them was that file in, and which of them mention
+;; this string.
+;;
+;; They're plain functions taking the list, so a command for a new kind of
+;; group is a two-line wrapper.  The known-projects and sibling commands are
+;; exactly that, and so is anything you write yourself.
+
+(defun projectile--common-parent (directories)
+  "Return the innermost directory containing every one of DIRECTORIES.
+
+Nil when they share no ancestor at all: a group mixing local and remote
+\(TRAMP) projects has none, and neither do two remote projects on
+different hosts.  Nil for an empty DIRECTORIES too."
+  (when directories
+    (let ((parent (file-name-as-directory (expand-file-name (car directories)))))
+      (dolist (dir (cdr directories) parent)
+        (let ((other (file-name-as-directory (expand-file-name dir))))
+          (while (and parent (not (string-prefix-p parent other)))
+            ;; climb until PARENT contains OTHER too, giving up at the root
+            (let ((up (file-name-directory (directory-file-name parent))))
+              (setq parent (unless (equal up parent) up)))))))))
+
+(defun projectile--project-group (projects what)
+  "Return the members of PROJECTS that are still on disk.
+WHAT names the kind of group in the error signalled when none are."
+  (or (seq-filter #'projectile--directory-p projects)
+      (user-error "No %s to search" what)))
+
+(defun projectile-project-group-files (projects)
+  "Return every file in PROJECTS, as absolute paths.
+
+Projects that no longer exist are skipped rather than erroring: a group
+can name a directory that has since been moved away.  The result is
+de-duplicated, since two members of a group can nest."
+  (delete-dups
+   (mapcan
+    (lambda (project)
+      (mapcar (lambda (file) (expand-file-name file project))
+              (projectile-project-files project)))
+    (seq-filter #'projectile--directory-p projects))))
+
+;;;###autoload
+(defun projectile-find-file-in-projects (projects &optional prompt)
+  "Jump to a file in any of PROJECTS.
+PROMPT overrides the completion prompt."
+  (find-file (projectile-completing-read
+              (or prompt "Find file in projects: ")
+              (projectile-project-group-files
+               (projectile--project-group projects "projects"))
+              :caller 'projectile-read-file)))
+
+;;;###autoload
+(defun projectile-search-in-projects (projects &optional literal prompt)
+  "Search PROJECTS for a term and review the matches read-only.
+LITERAL non-nil searches for a literal string, otherwise the term is an
+Emacs regexp.  PROMPT overrides the label the term is read with.
+
+This is `projectile-search-review' widened to a group, and that command
+is the single-project case of it: matches from every project land in one
+`*projectile-search*' buffer, grouped by file and named relative to the
+innermost directory containing the group, so each one is labelled with
+the project it came from.  Everything that buffer does - filtering,
+re-search, the hand-off to the replace reviewer - then covers the whole
+group.
+
+Searching more than one project skips the ripgrep fast-path, which runs
+one `rg' over one directory tree.  Note also that a project's own
+dirconfig ignores are only applied while you are inside it -
+`projectile-project-files' resolves them against the current project
+rather than the one it was handed - so the other members of a group are
+filtered by the global ignore rules alone.  That is long-standing
+behaviour, shared with `projectile-find-file-in-known-projects'."
+  (let* ((projects (projectile--project-group projects "projects"))
+         (term (projectile--read-search-string-with-default
+                (or prompt (format "Search %d project%s%s for"
+                                   (length projects)
+                                   (if (cdr projects) "s" "")
+                                   (if literal "" " regexp")))))
+         (regexp (if literal (regexp-quote term) term))
+         (case-fold case-fold-search)
+         (candidates (projectile-replace--candidates
+                      term literal case-fold projects)))
+    (projectile-replace--open
+     #'projectile-search-mode projectile-search-buffer-name
+     (or (projectile--common-parent projects) "/")
+     term regexp nil literal case-fold candidates
+     (projectile-prepend-project-name (format "No matches for %s" term))
+     projectile-search-whole-word nil projects)))
+
+(defun projectile--sibling-group ()
+  "Return the projects to treat as a group with the current one.
+
+That is `projectile-sibling-projects', which includes the project you are
+in - unlike switching, working across a family of projects is something
+you want the project at hand to be part of - minus any member that has
+been moved away, so a prompt never counts projects it cannot search."
+  (let ((root (projectile-acquire-root)))
+    (or (seq-filter #'projectile--directory-p (projectile-sibling-projects root))
+        (user-error "No projects related to %s found - see `projectile-project-groups'"
+                    (projectile-project-name root)))))
+
+;;;###autoload
+(defun projectile-find-file-in-sibling-projects ()
+  "Jump to a file in the current project or any related to it.
+Related is what `projectile-switch-sibling-project' means by it."
+  (interactive)
+  (projectile-find-file-in-projects (projectile--sibling-group)
+                                    "Find file in sibling projects: "))
+
+;;;###autoload
+(defun projectile-search-in-sibling-projects (&optional regexp)
+  "Search the current project and the ones related to it, reviewing the matches.
+
+Related is what `projectile-switch-sibling-project' means by it.  With a
+prefix argument REGEXP the search term is an Emacs regexp rather than a
+literal string."
+  (interactive "P")
+  (let ((siblings (projectile--sibling-group)))
+    (projectile-search-in-projects
+     siblings (not regexp)
+     (format "Search %d sibling project%s%s for"
+             (length siblings) (if (cdr siblings) "s" "")
+             (if regexp " regexp" "")))))
 
 
 ;;; Project bookmarks
@@ -16338,6 +16482,7 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "m") #'projectile-dispatch)
     ;; projects related to this one, in other repositories
     (define-key map (kbd "n") #'projectile-switch-sibling-project)
+    (define-key map (kbd "N") #'projectile-find-file-in-sibling-projects)
     (define-key map (kbd "o") #'projectile-multi-occur)
     (define-key map (kbd "p") #'projectile-switch-project)
     (define-key map (kbd "q") #'projectile-switch-open-project)
@@ -16351,6 +16496,7 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "s x") #'projectile-find-references)
     (define-key map (kbd "s R") #'projectile-search-review)
     (define-key map (kbd "s X") #'projectile-search-regexp-review)
+    (define-key map (kbd "s n") #'projectile-search-in-sibling-projects)
     (define-key map (kbd "s t") #'projectile-todos)
     (define-key map (kbd "S") #'projectile-save-project-buffers)
     (define-key map (kbd "t") #'projectile-toggle-between-implementation-and-test)
@@ -16683,6 +16829,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("sa" "ag" projectile-dispatch-ag)
       ("sx" "references" projectile-find-references)
       ("sR" "search (review)" projectile-dispatch-search-review)
+      ("sn" "search siblings" projectile-search-in-sibling-projects)
       ("st" "todos" projectile-todos)
       ("o" "multi-occur" projectile-multi-occur)
       ("r" "replace" projectile-replace)
@@ -16693,6 +16840,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
       ("q" "switch open project" projectile-switch-open-project)
       ("W" "switch worktree" projectile-switch-worktree)
       ("n" "switch sibling project" projectile-switch-sibling-project)
+      ("N" "file in sibling projects" projectile-find-file-in-sibling-projects)
       ("A" "add known project" projectile-add-known-project)
       ("v" "vc" projectile-vc)
       ("P" "dashboard" projectile-dashboard)
@@ -16772,6 +16920,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
          ["Find file" projectile-find-file]
          ["Find file (all, ignoring rules)" projectile-find-file-all]
          ["Find file in known projects" projectile-find-file-in-known-projects]
+         ["Find file in sibling projects" projectile-find-file-in-sibling-projects]
          ["Find test file" projectile-find-test-file]
          ["Find directory" projectile-find-dir]
          ["Find file in directory" projectile-find-file-in-directory]
@@ -16822,6 +16971,7 @@ search/replace case-sensitive, `--word' makes it match whole words,
          ["Search with grep" projectile-grep]
          ["Search with ripgrep" projectile-ripgrep]
          ["Search with ag" projectile-ag]
+         ["Search in sibling projects" projectile-search-in-sibling-projects]
          ["Project TODOs (review)" projectile-todos]
          ["Replace in project" projectile-replace]
          ["Replace in project (review)" projectile-replace-review]

--- a/test/projectile-project-group-test.el
+++ b/test/projectile-project-group-test.el
@@ -1,0 +1,283 @@
+;;; projectile-project-group-test.el --- Tests for commands over a group of projects -*- lexical-binding: t -*-
+
+;; Copyright © 2011-2026 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for `projectile-find-file-in-projects' and
+;; `projectile-search-in-projects' - the two commands that take a list of
+;; projects rather than working on the one you're in - and for the
+;; known-projects and sibling commands built on them.
+
+;;; Code:
+
+(require 'projectile-test-helpers)
+
+(defmacro projectile-group-test--with-projects (&rest body)
+  "Evaluate BODY in a sandbox holding two sibling projects.
+
+Creates `group/alpha/' and `group/beta/', each a `.projectile' project
+with a file mentioning `needle', plus `group/alpha/skip.log' which
+alpha's dirconfig ignores.  BODY runs with `alpha' and `beta' bound to
+the two truename'd roots and `parent' to the directory holding them."
+  (declare (indent 0) (debug (&rest form)))
+  `(projectile-test-with-sandbox
+     (projectile-test-with-files
+         ("group/alpha/src/" "group/beta/lib/")
+       (with-temp-file "group/alpha/.projectile" (insert "-/skip.log\n"))
+       (with-temp-file "group/beta/.projectile")
+       (with-temp-file "group/alpha/src/a.txt" (insert "alpha needle here\n"))
+       (with-temp-file "group/alpha/skip.log" (insert "ignored needle\n"))
+       (with-temp-file "group/beta/lib/b.txt" (insert "beta needle there\n"))
+       (let* ((parent (file-truename (expand-file-name "group/")))
+              (alpha (file-name-as-directory (expand-file-name "alpha" parent)))
+              (beta (file-name-as-directory (expand-file-name "beta" parent)))
+              (projectile-indexing-method 'native)
+              (projectile-projects-cache (make-hash-table :test 'equal))
+              (projectile-projects-cache-time (make-hash-table :test 'equal))
+              (projectile-enable-caching nil)
+              (case-fold-search t))
+         (ignore parent alpha beta)
+         (unwind-protect
+             (progn ,@body)
+           (projectile-test-kill-project-buffers parent))))))
+
+(defun projectile-group-test--search (projects term)
+  "Run `projectile-search-in-projects' over PROJECTS for literal TERM."
+  (spy-on 'read-string :and-call-fake (lambda (&rest _) term))
+  (cl-letf (((symbol-function 'pop-to-buffer) #'ignore))
+    (projectile-search-in-projects projects t))
+  (get-buffer projectile-search-buffer-name))
+
+
+;;; The directory a group's file names are shown relative to
+
+(describe "projectile--common-parent"
+  (it "returns the project itself for a group of one"
+    (expect (projectile--common-parent '("/src/app/"))
+            :to-equal "/src/app/"))
+
+  (it "returns the directory holding siblings"
+    (expect (projectile--common-parent '("/src/app" "/src/app-docs"))
+            :to-equal "/src/"))
+
+  (it "returns the outer project when one contains the other"
+    (expect (projectile--common-parent '("/src/app" "/src/app/sub"))
+            :to-equal "/src/app/"))
+
+  (it "walks all the way up when the projects share only the root"
+    (expect (projectile--common-parent '("/src/app" "/opt/tool"))
+            :to-equal "/"))
+
+  (it "does not care which order the projects come in"
+    (expect (projectile--common-parent '("/a/b/c" "/a/x")) :to-equal "/a/")
+    (expect (projectile--common-parent '("/a/x" "/a/b/c")) :to-equal "/a/"))
+
+  (it "has no answer for an empty group or for unrelated remote projects"
+    (expect (projectile--common-parent nil) :to-be nil)
+    (expect (projectile--common-parent '("/ssh:h1:/a" "/ssh:h2:/a")) :to-be nil)))
+
+
+;;; Files across a group
+
+(describe "projectile-project-group-files"
+  (it "returns absolute files from every project in the group"
+    (projectile-group-test--with-projects
+      (let ((files (projectile-project-group-files (list alpha beta))))
+        (expect (seq-filter #'file-name-absolute-p files) :to-equal files)
+        (expect (sort (mapcar (lambda (f) (file-relative-name f parent)) files)
+                      #'string<)
+                :to-equal '("alpha/.projectile" "alpha/skip.log"
+                            "alpha/src/a.txt"
+                            "beta/.projectile" "beta/lib/b.txt")))))
+
+  (it "applies a member's own dirconfig ignores only while you are in it"
+    ;; Long-standing behaviour, not a property of grouping:
+    ;; `projectile-project-files' resolves dirconfig against the current
+    ;; project rather than the one it was handed, so alpha's `-/skip.log'
+    ;; only bites from inside alpha.  `projectile-find-file-in-known-projects'
+    ;; has always worked this way.  This spec pins it so a fix is a
+    ;; deliberate change rather than a surprise.
+    (projectile-group-test--with-projects
+      (let ((skipped (expand-file-name "skip.log" alpha)))
+        (expect (projectile-project-group-files (list alpha beta))
+                :to-contain skipped)
+        (let ((default-directory alpha))
+          (spy-on 'projectile-project-root :and-return-value alpha)
+          (expect (projectile-project-group-files (list alpha beta))
+                  :not :to-contain skipped)))))
+
+  (it "skips a project that has been moved away"
+    (projectile-group-test--with-projects
+      (expect (projectile-project-group-files
+               (list alpha (expand-file-name "gone/" parent)))
+              :to-equal (projectile-project-group-files (list alpha)))))
+
+  (it "lists a file once when two members of the group nest"
+    ;; A monorepo and a project inside it can both be known projects.  A
+    ;; file offered twice is merely untidy here, but the same duplication
+    ;; in the search candidates makes the replace reviewer apply every
+    ;; replacement twice and corrupt the file.
+    (projectile-group-test--with-projects
+      (let ((files (projectile-project-group-files (list parent alpha))))
+        (expect files :to-equal (delete-dups (copy-sequence files)))))))
+
+(describe "projectile-find-file-in-projects"
+  (it "opens a file chosen from any project in the group"
+    (projectile-group-test--with-projects
+      (let ((wanted (expand-file-name "lib/b.txt" beta)))
+        (spy-on 'projectile-completing-read :and-return-value wanted)
+        (projectile-find-file-in-projects (list alpha beta))
+        (expect (file-truename (buffer-file-name))
+                :to-equal (file-truename wanted))))))
+
+
+;;; Searching a group
+
+(describe "projectile-search-in-projects"
+  (it "gathers matches from every project into one buffer"
+    (projectile-group-test--with-projects
+      (projectile-test-use-plain-grep)
+      (let ((buf (projectile-group-test--search (list alpha beta) "needle")))
+        (expect (projectile-test-match-files buf)
+                :to-equal '("alpha/skip.log" "alpha/src/a.txt"
+                            "beta/lib/b.txt")))))
+
+  (it "names the matches relative to the directory holding the group"
+    (projectile-group-test--with-projects
+      (projectile-test-use-plain-grep)
+      (let ((buf (projectile-group-test--search (list alpha beta) "needle")))
+        (with-current-buffer buf
+          (expect (file-truename projectile-replace--root)
+                  :to-equal (file-truename parent))
+          ;; so each match is labelled with the project it came from
+          (expect (buffer-string) :to-match "alpha/src/a\\.txt")
+          (expect (buffer-string) :to-match "beta/lib/b\\.txt")))))
+
+  (it "records the group so a re-search covers it again"
+    (projectile-group-test--with-projects
+      (projectile-test-use-plain-grep)
+      (let ((buf (projectile-group-test--search (list alpha beta) "needle")))
+        (with-current-buffer buf
+          (expect (length projectile-replace--projects) :to-equal 2)
+          (let ((before (length projectile-replace--matches)))
+            (projectile-replace--regather)
+            (expect (length projectile-replace--matches) :to-equal before)
+            (expect (projectile-test-match-files buf)
+                    :to-equal '("alpha/skip.log" "alpha/src/a.txt"
+                                "beta/lib/b.txt")))))))
+
+  (it "scopes back to one project when the buffer is reused for a plain search"
+    (projectile-group-test--with-projects
+      (projectile-test-use-plain-grep)
+      (projectile-group-test--search (list alpha beta) "needle")
+      ;; an ordinary single-project search must not inherit the old group,
+      ;; or its re-search would silently widen back to it
+      (let ((default-directory alpha))
+        (spy-on 'projectile-project-root :and-return-value alpha)
+        (let ((buf (projectile-group-test--search (list alpha) "needle")))
+          (with-current-buffer buf
+            (expect (length projectile-replace--projects) :to-equal 1)
+            (projectile-replace--regather)
+            (expect (projectile-test-match-files buf)
+                    :to-equal '("src/a.txt")))))))
+
+  (it "scans a file once when two members of the group nest"
+    ;; The reason the de-duplication matters: `r' from this buffer hands
+    ;; the matches to the replace reviewer, which applies every match in a
+    ;; file in one pass - so a doubled match replaces the span the first
+    ;; copy just wrote.
+    (projectile-group-test--with-projects
+      (projectile-test-use-plain-grep)
+      (let* ((buf (projectile-group-test--search (list parent alpha) "needle"))
+             (files (with-current-buffer buf
+                      (mapcar #'projectile-replace--match-file
+                              projectile-replace--matches))))
+        (expect files :to-equal (delete-dups (copy-sequence files))))))
+
+  (it "survives a group member being moved away while the buffer is open"
+    (projectile-group-test--with-projects
+      (projectile-test-use-plain-grep)
+      (let ((buf (projectile-group-test--search (list alpha beta) "needle")))
+        (delete-directory beta t)
+        (with-current-buffer buf
+          ;; `g' must re-scan what is left, not abort on the missing member
+          (projectile-replace--regather)
+          (expect (projectile-test-match-files buf)
+                  :to-equal '("alpha/skip.log" "alpha/src/a.txt"))))))
+
+  (it "refuses an empty group instead of searching the whole filesystem"
+    (projectile-group-test--with-projects
+      (expect (projectile-search-in-projects nil t) :to-throw 'user-error)
+      (expect (projectile-search-in-projects
+               (list (expand-file-name "gone/" parent)) t)
+              :to-throw 'user-error))))
+
+
+;;; The commands built on the two above
+
+(describe "projectile-find-file-in-known-projects"
+  (it "offers the files of every known project"
+    (projectile-group-test--with-projects
+      (let ((projectile-known-projects (list alpha beta)))
+        (spy-on 'projectile-completing-read :and-return-value
+                (expand-file-name "src/a.txt" alpha))
+        (spy-on 'find-file)
+        (projectile-find-file-in-known-projects)
+        (expect (sort (mapcar (lambda (f) (file-relative-name f parent))
+                              (cadr (spy-calls-args-for 'projectile-completing-read 0)))
+                      #'string<)
+                :to-equal '("alpha/.projectile" "alpha/skip.log"
+                            "alpha/src/a.txt"
+                            "beta/.projectile" "beta/lib/b.txt"))))))
+
+(describe "projectile-find-file-in-sibling-projects"
+  (it "searches the current project and the ones related to it"
+    (projectile-group-test--with-projects
+      (spy-on 'projectile-sibling-projects :and-return-value (list alpha beta))
+      (spy-on 'projectile-completing-read :and-return-value
+              (expand-file-name "src/a.txt" alpha))
+      (spy-on 'find-file)
+      (projectile-find-file-in-sibling-projects)
+      (expect (length (cadr (spy-calls-args-for 'projectile-completing-read 0)))
+              :to-equal 5)))
+
+  (it "says so when the project has no siblings"
+    (projectile-group-test--with-projects
+      (spy-on 'projectile-sibling-projects :and-return-value nil)
+      (spy-on 'projectile-acquire-root :and-return-value alpha)
+      (expect (projectile-find-file-in-sibling-projects) :to-throw 'user-error))))
+
+(describe "projectile-search-in-sibling-projects"
+  (it "searches the current project and the ones related to it"
+    (projectile-group-test--with-projects
+      (projectile-test-use-plain-grep)
+      (spy-on 'projectile-sibling-projects :and-return-value (list alpha beta))
+      (spy-on 'read-string :and-call-fake (lambda (&rest _) "needle"))
+      (cl-letf (((symbol-function 'pop-to-buffer) #'ignore))
+        (projectile-search-in-sibling-projects))
+      (expect (projectile-test-match-files
+               (get-buffer projectile-search-buffer-name))
+              :to-equal '("alpha/skip.log" "alpha/src/a.txt"
+                          "beta/lib/b.txt")))))
+
+(provide 'projectile-project-group-test)
+
+;;; projectile-project-group-test.el ends here

--- a/test/projectile-search-review-test.el
+++ b/test/projectile-search-review-test.el
@@ -41,16 +41,6 @@ REGEXP-P selects `projectile-search-regexp-review'."
                             #'projectile-search-review)))
     (get-buffer projectile-search-buffer-name)))
 
-(defun projectile-search-review-test--files (buf)
-  "Return the sorted set of project-relative files with matches in BUF."
-  (with-current-buffer buf
-    (let ((root projectile-replace--root)
-          (files nil))
-      (dolist (m projectile-replace--matches)
-        (cl-pushnew (file-relative-name (projectile-replace--match-file m) root)
-                    files :test #'equal))
-      (sort files #'string<))))
-
 (describe "projectile-search-review (literal)"
   (it "finds every literal match grouped by file, read-only, no apply keys"
     (projectile-test-with-project
@@ -61,7 +51,7 @@ REGEXP-P selects `projectile-search-regexp-review'."
         (with-current-buffer buf
           (expect major-mode :to-equal 'projectile-search-mode)
           (expect (length projectile-replace--matches) :to-equal 3)
-          (expect (projectile-search-review-test--files buf)
+          (expect (projectile-test-match-files buf)
                   :to-equal '("a.txt" "lib/b.txt"))
           ;; the buffer is genuinely read-only
           (expect buffer-read-only :to-be-truthy)
@@ -91,7 +81,8 @@ REGEXP-P selects `projectile-search-regexp-review'."
 
 (describe "projectile-search-review prompt tool tag"
   (before-each
-    (spy-on 'projectile-acquire-root :and-return-value "/proj/")
+    ;; a real directory: the search refuses a project that is not on disk
+    (spy-on 'projectile-acquire-root :and-return-value temporary-file-directory)
     (spy-on 'projectile-replace--candidates :and-return-value nil)
     (spy-on 'projectile-replace--open))
 
@@ -578,7 +569,7 @@ REGEXP-P selects `projectile-search-regexp-review'."
         (projectile-search-review-test--wait buf)
         (with-current-buffer buf
           (expect projectile-replace--scanning :to-be nil)
-          (expect (projectile-search-review-test--files buf)
+          (expect (projectile-test-match-files buf)
                   :to-equal '("mb.txt" "plain.txt"))
           ;; character column 5 ("café " is 5 chars), NOT the byte offset 6
           (expect (projectile-test-find-match projectile-replace--matches "mb.txt")
@@ -616,7 +607,7 @@ REGEXP-P selects `projectile-search-regexp-review'."
         (with-current-buffer buf
           ;; the `-/vendor' dirconfig ignore must be honored by the rg path,
           ;; just as it is by the elisp path
-          (expect (projectile-search-review-test--files buf)
+          (expect (projectile-test-match-files buf)
                   :to-equal '("keep.txt"))
           (expect (cl-some (lambda (m)
                              (string-match-p

--- a/test/projectile-test-helpers.el
+++ b/test/projectile-test-helpers.el
@@ -295,6 +295,16 @@ regardless of the order they were collected in."
                 matches)
         (lambda (a b) (string< (format "%S" a) (format "%S" b)))))
 
+(defun projectile-test-match-files (buf)
+  "Return the sorted set of files with matches in BUF, relative to its root."
+  (with-current-buffer buf
+    (sort (seq-uniq
+           (mapcar (lambda (m)
+                     (file-relative-name (projectile-replace--match-file m)
+                                         projectile-replace--root))
+                   projectile-replace--matches))
+          #'string<)))
+
 ;;; Sandbox project helpers
 
 (defun projectile-test-project-root ()


### PR DESCRIPTION
Switching to a related project isn't the only thing a family of projects is good for - more often I want to find a file in one of them, or search all of them at once. `s-p n f` completes over the files of every related project, and `s-p n s` searches them and collects the matches in a single buffer, named so each match says which project it came from.

Underneath both are thin wrappers over `projectile-find-file-in-projects` and `projectile-search-in-projects`, which take any list of projects. `projectile-find-file-in-known-projects` and `projectile-search-review` are now the widest and narrowest cases of those same two functions, so a command for a group of your own is a two-line wrapper.

Heads up on one break: `s-p n` is now a prefix for the whole family rather than a command, so `projectile-switch-sibling-project` moves to `s-p n p`. The sub-keys mirror the project-wide ones a level down, the way `c m` does for subprojects.

Fixes #1752.