### PR TITLE
Let the mode-line prefix change after load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Bugs fixed
 
 - [#2162](https://github.com/bbatsov/projectile/pull/2162): Listing another project's files now applies that project's own ignore rules instead of the rules of whichever project you happen to be visiting. `projectile-find-file-in-known-projects` and the sibling commands used to filter every other project by the current one's dirconfig, and with caching on they stored that wrong list under the other project's key - so an ordinary `projectile-find-file` there kept offering ignored files, and with persistent caching it survived a restart.
+- [#2161](https://github.com/bbatsov/projectile/pull/2161): Customizing `projectile-mode-line-prefix` now reaches buffers whose lighter is never recomputed - every buffer when `projectile-dynamic-mode-line` is off, which is the case its docstring describes, and remote ones always. The prefix used to be frozen at whatever it was when Projectile loaded.
 - [#2157](https://github.com/bbatsov/projectile/pull/2157): `projectile-use-comint-mode` now covers the named tasks run by `projectile-run-task`, which were always given a read-only compilation buffer however it was set - so a task that needs to ask for a sudo password had nowhere to type one ([#2156](https://github.com/bbatsov/projectile/issues/2156)). Name `task` in the list, or set the option to `t`.
 
 ## 3.4.0 (2026-08-10)

--- a/projectile.el
+++ b/projectile.el
@@ -16457,14 +16457,35 @@ remote project, or under any other VCS, that section says so instead.
 
 ;;; Projectile Minor mode
 
+(defvar-local projectile--mode-line nil
+  "The mode-line lighter Projectile shows in this buffer.
+Seeded from `projectile-mode-line-prefix' and replaced by
+`projectile-update-mode-line' once the buffer's project is known.  A
+buffer that never gets that far keeps the prefix: that is every buffer
+when `projectile-dynamic-mode-line' is off, and remote ones always,
+since both update paths skip them to avoid a TRAMP round trip.")
+
 (defcustom projectile-mode-line-prefix
   " Projectile"
   "Mode line lighter prefix for Projectile.
 It's used by `projectile-default-mode-line'
 when using dynamic mode line lighter and is the only
-thing shown in the mode line otherwise."
+thing shown in the mode line otherwise.
+
+Change the value via Customize or `setopt' so it takes effect
+immediately; a plain `setq' only reaches buffers whose lighter is
+recomputed later, and none are when `projectile-dynamic-mode-line' is
+off."
   :group 'projectile
   :type 'string
+  :set (lambda (symbol value)
+         (set-default symbol value)
+         ;; The lighter is a variable, not a computation, so buffers that
+         ;; never recompute it - all of them with `projectile-dynamic-mode-line'
+         ;; off - would otherwise keep displaying whatever the prefix was
+         ;; when Projectile loaded.
+         (setq-default projectile--mode-line value)
+         (force-mode-line-update t))
   :package-version '(projectile . "0.12.0"))
 
 (defcustom projectile-show-menu t
@@ -16472,8 +16493,6 @@ thing shown in the mode line otherwise."
   :group 'projectile
   :type 'boolean
   :package-version '(projectile . "2.6.0"))
-
-(defvar-local projectile--mode-line projectile-mode-line-prefix)
 
 (defun projectile-default-mode-line ()
   "Report project name and type in the modeline."

--- a/test/projectile-core-test.el
+++ b/test/projectile-core-test.el
@@ -145,6 +145,25 @@
     (let ((projectile-mode-line-prefix " Pro"))
       (expect (projectile-default-mode-line) :to-equal " Pro[foo:bar]"))))
 
+(describe "projectile-mode-line-prefix"
+  ;; The minor-mode lighter is the variable `projectile--mode-line', not a
+  ;; computation, so a buffer that never recomputes it shows whatever the
+  ;; prefix was when Projectile loaded.  That is every buffer when
+  ;; `projectile-dynamic-mode-line' is off - precisely the configuration the
+  ;; option's docstring is about - so customizing it has to move the lighter
+  ;; too.
+  (after-each
+    (customize-set-variable 'projectile-mode-line-prefix " Projectile"))
+
+  (it "is what a buffer that never recomputes its lighter displays"
+    (with-temp-buffer
+      (expect projectile--mode-line :to-equal projectile-mode-line-prefix)))
+
+  (it "moves the lighter of such buffers when customized"
+    (customize-set-variable 'projectile-mode-line-prefix " Prj")
+    (with-temp-buffer
+      (expect projectile--mode-line :to-equal " Prj"))))
+
 (describe "projectile-purge-file-from-cache"
   (it "serializes the updated cache without the purged file"
     (let ((projectile-projects-cache (make-hash-table :test 'equal))


### PR DESCRIPTION
`projectile-mode-line-prefix` was effectively a no-op unless you set it before Projectile loaded. The lighter is the variable `projectile--mode-line`, seeded from the prefix once at load, and nothing moves it afterwards unless a buffer recomputes its lighter - which nothing does when `projectile-dynamic-mode-line` is off, and remote buffers never do either.

That's the exact configuration the option's docstring is about ("the only thing shown in the mode line otherwise"), so customizing it now moves the default lighter too.