### PR TITLE
Give a monorepo member its own project type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - [#2160](https://github.com/bbatsov/projectile/pull/2160): Add `projectile-find-file-in-sibling-projects` (`s-p n f`) and `projectile-search-in-sibling-projects` (`s-p n s`), which work across the family of related projects rather than just the one you're in.
   - Both are built on `projectile-find-file-in-projects` and `projectile-search-in-projects`, which take any list of projects, so a command for a group of your own is a two-line wrapper.
   - A group search puts every match in one `*projectile-search*` buffer, named relative to the directory containing the group, so each one is labelled with the project it came from.
+- [#2165](https://github.com/bbatsov/projectile/pull/2165): A subproject now has its own project type, so the `s-p c m` lifecycle commands build a monorepo member with the member's own toolchain - a Rust crate or Go module under a JavaScript repository runs `cargo test` or `go test` rather than the repository's `npm test`. New `projectile-subproject-type`.
+  - A member identified by the same manifest as the repository keeps the repository's type: a pnpm or yarn workspace member holds only a `package.json` and would otherwise fall back to plain `npm`.
 - [#2163](https://github.com/bbatsov/projectile/pull/2163): Add `projectile-switch-to-buffer-in-sibling-projects` (`s-p n b`), `projectile-multi-occur-in-sibling-projects` (`s-p n o`) and `projectile-todos-in-sibling-projects` (`s-p n t`), so buffers and annotations follow the same family as files and searches.
   - `projectile-switch-to-buffer-in-projects` joins the two existing generic commands, and `projectile-todos` now shares one implementation with its group form.
 

--- a/doc/modules/ROOT/pages/tasks.adoc
+++ b/doc/modules/ROOT/pages/tasks.adoc
@@ -254,9 +254,7 @@ image::projectile-find-file-in-subproject.png[The subproject prompt, listing the
   `-compile-` (kbd:[s-p c m c]), `-test-` (kbd:[s-p c m t]), `-install-`
   (kbd:[s-p c m i]), `-package-` (kbd:[s-p c m p]) and `-run-`
   (kbd:[s-p c m r]). They run in the *nearest* subproject - the one containing
-  the file you're visiting - rather than at the project root. The command
-  itself is the project's, only the directory changes, which is what
-  workspace-aware tools like Cargo, npm and Maven need to scope their work.
+  the file you're visiting - rather than at the project root.
 
 The prompt tells you where the command will run (`Test command in
 services/api/:`), so a subproject build is never mistaken for a whole-project
@@ -266,6 +264,39 @@ the subproject: in a Meson monorepo kbd:[s-p c m c] runs ninja in
 
 If there's no manifest between the current file and the project root, those
 commands say so rather than silently building the whole repository.
+
+=== Which command a subproject runs
+
+A subproject gets its *own* project type, so a Rust crate under a JavaScript
+repository is built with Cargo rather than with the repository's npm. Type
+detection is rooted at the member, which is what
+`projectile-subproject-type` reports.
+
+There is one deliberate exception. A member of a JavaScript workspace holds
+nothing but a `package.json`, so on its own it reads as a plain `node`
+project - and running `npm test` inside a pnpm or yarn workspace is worse
+than what the repository would have run. When the member and the repository
+are identified by the same manifest, the repository's type is the more
+specific reading and it wins. In practice: a pnpm workspace keeps running
+`pnpm test` in its packages, while a `Cargo.toml` or `go.mod` under that same
+repository switches to `cargo` or `go`.
+
+The usual overrides still come first, so a member that needs something else
+can say so in its own `.dir-locals.el`:
+
+[source,elisp]
+----
+;;; packages/legacy/.dir-locals.el
+((nil . ((projectile-project-test-cmd . "make check"))))
+----
+
+TIP: If you would rather each member be a project in its own right - its own
+find-file, its own switch target - add its manifest to
+`projectile-project-root-files-bottom-up`. That is the trade the other way:
+the members get everything a project has, and the repository stops being one,
+so finding a file across the whole monorepo is no longer possible. Emacs's
+built-in `project.el` offers the same choice through
+`project-vc-extra-root-markers`.
 
 == Running the test at point
 

--- a/projectile.el
+++ b/projectile.el
@@ -1139,7 +1139,11 @@ or used as a hash key regardless of how each reference was spelled."
   (file-truename (file-name-as-directory path)))
 
 (projectile-define-project-cache projectile-project-type-cache
-  "A hashmap used to cache project type to speed up related operations.")
+  "A hashmap used to cache project type to speed up related operations.
+Keyed by project root, and also by subproject root for the types
+`projectile-subproject-type' detects - hence `:prefix-keyed', so
+invalidating a repository drops its members' entries along with its own."
+  :prefix-keyed t)
 
 (projectile-define-project-cache projectile-project-vcs-cache
   "Cache of `projectile-project-vcs' results keyed by directory.
@@ -3022,9 +3026,25 @@ topmost sequence of matched directories.  Nil otherwise."
                  (not (projectile-file-exists-p (projectile-expand-file-name-wildcard f (projectile-parent dir)))))))))
    (or list projectile-project-root-files-top-down-recurring)))
 
+(defvar projectile--root-override nil
+  "Directory `projectile-project-root' answers with while this is non-nil.
+
+Bound while detecting a subproject's type (see
+`projectile-subproject-type').  Eleven of the registered project types -
+`go', `make', `terraform', `xcode' and the rest - identify themselves
+with a predicate rather than a list of marker file names, and those
+predicates resolve their paths through `projectile-expand-root', which
+walks up to the enclosing project.  Inside a monorepo that walk lands on
+the repository, so a Go module in a subdirectory would be asked whether
+the *repository* has a `go.mod'.  Pinning the root for the duration of
+the detection asks the question about the member instead.")
+
 (defun projectile-project-root (&optional dir)
   "Return the root directory of the project containing DIR, or nil.
 If DIR is not supplied it defaults to `default-directory'.
+
+While `projectile--root-override' is non-nil that directory is returned
+instead, whatever DIR is.
 
 Each function in `projectile-project-root-functions' is tried in order;
 the first non-nil result wins.  Results - including failures - are
@@ -3041,7 +3061,8 @@ Special cases:
   ;; `default-directory' can be nil in some buffers; short-circuit to nil so
   ;; callers get "no project" instead of a `(wrong-type-argument stringp nil)'
   ;; from `file-remote-p' and friends below (#1829).
-  (when-let* ((dir (or dir default-directory)))
+  (or projectile--root-override
+      (when-let* ((dir (or dir default-directory)))
     ;; Back out of any archives, the project will live on the outside and
     ;; searching them is slow.
     (when (and (fboundp 'tramp-archive-file-name-p)
@@ -3105,7 +3126,7 @@ Special cases:
        ;; conventional means, and we assume the failure isn't transient
        ;; / network related, so cache the failure
        (puthash (cons 'none dir) 'none projectile-project-root-cache))))
-      (unless (eq result 'none) result))))
+      (unless (eq result 'none) result)))))
 
 (defun projectile-ensure-project (dir)
   "Ensure that DIR is non-nil.
@@ -12275,6 +12296,48 @@ into a subproject."
           (puthash dir t dirs))))
     (sort (hash-table-keys dirs) #'string<)))
 
+(defun projectile-subproject-type (&optional subproject-root)
+  "Return the project type of the subproject at SUBPROJECT-ROOT.
+
+Detection is rooted at the subproject instead of at the repository, so a
+crate inside a JavaScript monorepo comes back as `rust-cargo' rather than
+as one more `node' directory.  SUBPROJECT-ROOT defaults to the subproject
+containing the current file (see `projectile-subproject-root').
+
+This is what separates a subproject from a plain subdirectory: the
+repository stays the project - find-file, search and switching are still
+repository-wide - while the lifecycle commands under the `c m' prefix run
+the member's own build.  Promoting members to projects
+outright (by adding their manifests to
+`projectile-project-root-files-bottom-up') is the other way to get their
+commands right, at the cost of the repository no longer being a project."
+  (let* ((root (or subproject-root (projectile-subproject-root)))
+         ;; Resolve the repository's own type first, before the override is
+         ;; in force.
+         (repo-type (projectile-project-type))
+         (detected (let ((projectile--root-override root))
+                     (or (gethash root projectile-project-type-cache)
+                         (projectile-detect-project-type root root)))))
+    ;; A member of a JavaScript workspace holds a `package.json' and nothing
+    ;; else, so on its own it looks like a plain `node' project - and running
+    ;; `npm test' inside a pnpm or yarn workspace is worse than what the
+    ;; repository would have run.  The repository's type is the more specific
+    ;; one whenever both are identified by the same manifest, so keep it and
+    ;; only switch when the member is genuinely a different toolchain.
+    (if (projectile--same-manifest-type-p detected repo-type)
+        repo-type
+      detected)))
+
+(defun projectile--same-manifest-type-p (a b)
+  "Return non-nil when project types A and B are declared by the same manifest.
+Both `node' and `pnpm' are identified by `package.json', for instance, so
+one is a less specific reading of the other rather than a different kind
+of project."
+  (and a b
+       (let ((fa (projectile-project-type-attribute a 'project-file))
+             (fb (projectile-project-type-attribute b 'project-file)))
+         (and fa fb (equal fa fb)))))
+
 (defun projectile-subproject-root (&optional dir)
   "Find the root of the nearest subproject containing DIR.
 Walk up from DIR (the current file's directory by default) looking for
@@ -12722,7 +12785,14 @@ with a prefix ARG."
 SHOW-PROMPT is as in `projectile--run-lifecycle-phase', which does the
 actual work - the subproject is just the directory the phase resolves
 its compilation directory against."
-  (projectile--run-lifecycle-phase phase show-prompt (projectile-subproject-root)))
+  (let* ((subproject (projectile-subproject-root))
+         ;; `projectile--phase-command' falls back to the default command
+         ;; for `(projectile-project-type)'; bind it to the member's own
+         ;; type so a Rust crate in a JavaScript repo runs `cargo test'
+         ;; rather than the repository's `npm test'.  The dir-local
+         ;; override and the per-directory command cache still win over it.
+         (projectile-project-type (projectile-subproject-type subproject)))
+    (projectile--run-lifecycle-phase phase show-prompt subproject)))
 
 (defmacro projectile--define-subproject-commands (&rest phases)
   "Define a subproject variant of the lifecycle command of each of PHASES.

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -863,6 +863,48 @@
     (expect (projectile-compilation-dir "/proj/sub/") :to-equal "/proj/sub/")
     (expect (projectile-compilation-dir) :to-equal "/proj/")))
 
+(describe "projectile-subproject-type"
+  (it "gives a member of a different toolchain its own type"
+    ;; A Rust crate inside a JavaScript monorepo is a Rust crate.  Before
+    ;; this, every member inherited the repository's type, so `c m t' in the
+    ;; crate ran the repository's `npm test'.
+    (projectile-test-with-sandbox
+      (projectile-test-with-files
+          ("repo/.projectile" "repo/package.json"
+           "repo/crates/engine/Cargo.toml")
+        (let* ((repo (file-truename (expand-file-name "repo/")))
+               (member (expand-file-name "crates/engine/" repo)))
+          (let ((default-directory member))
+            (expect (projectile-subproject-type member) :to-equal 'rust-cargo))))))
+
+  (it "keeps the repository's type when the member is the same kind of project"
+    ;; A pnpm workspace member holds only a `package.json', so on its own it
+    ;; reads as plain `node' - and `npm test' inside a pnpm workspace is
+    ;; worse than what the repository would have run.
+    (projectile-test-with-sandbox
+      (projectile-test-with-files
+          ("repo/.projectile" "repo/package.json" "repo/pnpm-lock.yaml"
+           "repo/packages/core/package.json")
+        (let* ((repo (file-truename (expand-file-name "repo/")))
+               (member (expand-file-name "packages/core/" repo)))
+          (let ((default-directory member))
+            (expect (projectile-project-type repo) :to-equal 'pnpm)
+            (expect (projectile-subproject-type member) :to-equal 'pnpm))))))
+
+  (it "detects a member whose type identifies itself with a predicate"
+    ;; `go', `make', `terraform' and eight other types use a function marker
+    ;; instead of a list of file names, and those predicates resolve paths
+    ;; through `projectile-expand-root', which walks up to the repository.
+    ;; Without pinning the root the member would be asked whether the *repo*
+    ;; has a go.mod.
+    (projectile-test-with-sandbox
+      (projectile-test-with-files
+          ("repo/.projectile" "repo/package.json" "repo/services/api/go.mod")
+        (let* ((repo (file-truename (expand-file-name "repo/")))
+               (member (expand-file-name "services/api/" repo)))
+          (let ((default-directory member))
+            (expect (projectile-subproject-type member) :to-equal 'go)))))))
+
 (describe "the subproject lifecycle commands"
   (before-each
     (spy-on 'projectile-acquire-root :and-return-value "/proj/")


### PR DESCRIPTION
The `c m` lifecycle commands changed directory but kept the repository's command, so a Rust crate under a JavaScript repo ran `npm test` in the crate. Detection is now rooted at the member, reported by the new `projectile-subproject-type`.

Two things were in the way. Eleven project types - `go`, `make`, `terraform`, `xcode` among them - identify themselves with a predicate rather than a list of file names, and those predicates resolve paths through `projectile-expand-root`, which walks up; asked about a Go module in a subdirectory they went looking for the *repository's* `go.mod`. So the root is pinned for the duration of detection.

The other way round, detection at a member is sometimes worse than what the repo knew: a pnpm or yarn workspace member holds nothing but a `package.json`, reads as plain `node`, and would run `npm test` inside a pnpm workspace. Where member and repository are identified by the same manifest, the repository's type is the more specific reading and wins; a different manifest means a different toolchain and the member wins.

Checked against real repos - vue (pnpm), babel (yarn), tokio (cargo) - plus a polyglot fixture. The workspaces keep their package manager; the crate gets `cargo test` and the Go module `go test ./...`.