### PR TITLE
Take a monorepo's members from the workspace, not from a scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   - A group search puts every match in one `*projectile-search*` buffer, named relative to the directory containing the group, so each one is labelled with the project it came from.
 - [#2165](https://github.com/bbatsov/projectile/pull/2165): A subproject now has its own project type, so the `s-p c m` lifecycle commands build a monorepo member with the member's own toolchain - a Rust crate or Go module under a JavaScript repository runs `cargo test` or `go test` rather than the repository's `npm test`. New `projectile-subproject-type`.
   - A member identified by the same manifest as the repository keeps the repository's type: a pnpm or yarn workspace member holds only a `package.json` and would otherwise fall back to plain `npm`.
+- [#2166](https://github.com/bbatsov/projectile/pull/2166): Subprojects now come from the workspace's own member list when the repository declares one - pnpm, npm/yarn/bun, Cargo and `go.work` - instead of from scanning for manifests, so test fixtures and excluded crates stop showing up as subprojects. Babel's repository goes from 205 to its declared 162. New `projectile-subproject-functions`.
+  - Build tools that compute their members rather than declaring them (Gradle, Bazel) keep using the scan, which is why it remains the fallback.
 - [#2163](https://github.com/bbatsov/projectile/pull/2163): Add `projectile-switch-to-buffer-in-sibling-projects` (`s-p n b`), `projectile-multi-occur-in-sibling-projects` (`s-p n o`) and `projectile-todos-in-sibling-projects` (`s-p n t`), so buffers and annotations follow the same family as files and searches.
   - `projectile-switch-to-buffer-in-projects` joins the two existing generic commands, and `projectile-todos` now shares one implementation with its group form.
 

--- a/doc/modules/ROOT/pages/tasks.adoc
+++ b/doc/modules/ROOT/pages/tasks.adoc
@@ -233,17 +233,31 @@ finding files or searching covers all of it. But its parts usually have
 manifests of their own (a crate, a package, a Maven module), and building or
 testing the whole repository when you're working on one of them is wasteful.
 
-Projectile calls those parts *subprojects*: any directory below the project
-root that holds a project manifest. What counts as a manifest comes from
+Projectile calls those parts *subprojects*, and finds them in one of two
+ways - `projectile-subproject-functions` decides which, trying each in turn
+until one has an answer.
+
+*The workspace's own member list*, when the repository declares one in a form
+Projectile can read: pnpm (`pnpm-workspace.yaml`), npm, yarn and bun
+(`workspaces` in `package.json`), Cargo (`[workspace] members`, minus
+`exclude`) and Go (`go.work`). This is the better answer where it exists,
+because a workspace knows which of its directories are members and which are
+not - a test fixture that happens to carry a `package.json`, a scaffolding
+template, a fuzzing crate kept out of the build. In Babel's repository that is
+the difference between 162 members and 205 directories holding a manifest.
+
+*A scan for manifests*, otherwise. What counts as a manifest comes from
 `projectile-subproject-markers`, which by default is derived from the
 registered project types, so every type Projectile knows about - including the
-ones you register yourself - is recognized inside a monorepo. A polyglot
-repository works out of the box: a `Cargo.toml` under a `package.json` project
-is still a subproject.
+ones you register yourself - is recognized. The scan reads the project's own
+file listing, so the xref:ignoring.adoc[ignore rules] apply and a vendored
+dependency's manifest doesn't count.
 
-`projectile-project-subprojects` returns them, scanning the project's own file
-listing (so the xref:ignoring.adoc[ignore rules] apply, and a vendored
-dependency's manifest doesn't count as a subproject).
+The scan is the fallback rather than a legacy path, because some build tools
+compute their member list instead of declaring it: Gradle assembles it in a
+Kotlin or Groovy program and Bazel in Starlark, and neither can be read
+without running the tool. A polyglot repository works either way: a
+`Cargo.toml` under a `package.json` project is still a subproject.
 
 * `projectile-find-file-in-subproject` (kbd:[s-p c m f]) prompts for a
   subproject and then completes over just its files.

--- a/projectile.el
+++ b/projectile.el
@@ -12269,18 +12269,163 @@ See `projectile-subproject-markers'."
               (push file markers))))
         markers)))
 
-(defun projectile-project-subprojects (&optional project-root)
-  "Return the subprojects of the project at PROJECT-ROOT.
+(defcustom projectile-subproject-functions
+  '(projectile-subprojects-from-manifest
+    projectile-subprojects-from-scan)
+  "Functions consulted by `projectile-project-subprojects'.
 
-A subproject is a directory below the root that holds a project manifest
-of its own (see `projectile-subproject-markers').  The result is a sorted
-list of directory names relative to the root, each ending in a slash.
+Each is called with a project root and should return the project's
+subprojects as directory names relative to it, each ending in a slash.
+They are tried in order and the first non-empty answer wins - so the
+list runs from the most authoritative source to the most general, the
+way `projectile-project-root-functions' does.
 
-The project's own file listing is what gets scanned, so the ignore rules
-apply as usual - the manifest of a vendored dependency doesn't turn it
-into a subproject."
-  (let* ((root (or project-root (projectile-acquire-root)))
-         (markers (projectile--subproject-markers))
+The default asks the workspace manifest first and falls back to scanning
+for manifests.  Put `projectile-subprojects-from-scan' first to always
+scan, or add your own function for a workspace format Projectile cannot
+read."
+  :group 'projectile
+  :type '(repeat function)
+  :package-version '(projectile . "3.5.0"))
+
+(defun projectile--expand-member-globs (root patterns)
+  "Expand PATTERNS relative to ROOT into a list of relative directory names.
+PATTERNS are workspace member globs (`packages/*', `crates/core').  Only
+existing directories survive, and each comes back with a trailing slash.
+Negated patterns - pnpm allows a leading `!' - are dropped rather than
+subtracted, which can only leave the answer too generous, never too
+narrow."
+  (let ((default-directory root)
+        (dirs nil))
+    (dolist (pattern patterns)
+      (unless (string-prefix-p "!" pattern)
+        ;; Two arguments only: the third is REGEXP, not a dotfile flag, and
+        ;; passing it makes a glob be read as a regular expression.
+        (dolist (hit (file-expand-wildcards (directory-file-name pattern)))
+          (when (file-directory-p (expand-file-name hit root))
+            (push (file-name-as-directory hit) dirs)))))
+    (sort (delete-dups dirs) #'string<)))
+
+(defun projectile--workspace-member-patterns (root)
+  "Return ROOT's declared workspace member patterns, or nil.
+Reads the manifest of the workspace formats Projectile can parse
+statically - pnpm, npm/yarn/bun, Cargo and Go - and returns the raw
+globs.  Formats whose member list is computed rather than declared
+\(Gradle builds it in a Kotlin or Groovy program, Bazel in Starlark) have
+no answer here and fall through to scanning."
+  (let ((pnpm (expand-file-name "pnpm-workspace.yaml" root))
+        (npm (expand-file-name "package.json" root))
+        (cargo (expand-file-name "Cargo.toml" root))
+        (gowork (expand-file-name "go.work" root)))
+    (cond
+     ((file-readable-p pnpm) (projectile--pnpm-workspace-patterns pnpm))
+     ((file-readable-p npm) (projectile--npm-workspace-patterns npm))
+     ((file-readable-p cargo) (projectile--cargo-workspace-patterns cargo))
+     ((file-readable-p gowork) (projectile--go-work-patterns gowork)))))
+
+(defun projectile--file-contents (file)
+  "Return the contents of FILE as a string."
+  (with-temp-buffer
+    (insert-file-contents file)
+    (buffer-string)))
+
+(defun projectile--pnpm-workspace-patterns (file)
+  "Return the `packages:' entries of the pnpm workspace manifest FILE.
+A deliberately small YAML reader: it takes the list items under the
+top-level `packages:' key and stops at the next top-level key, which is
+all this file shape needs (`catalog:' and friends live alongside it)."
+  (let ((lines (split-string (projectile--file-contents file) "\n"))
+        (in-packages nil)
+        (patterns nil))
+    (dolist (line lines)
+      (cond
+       ((string-match "\\`packages:[[:space:]]*\\'" line)
+        (setq in-packages t))
+       ;; any other unindented, non-comment line ends the block
+       ((and in-packages (string-match-p "\\`[^[:space:]#-]" line))
+        (setq in-packages nil))
+       ((and in-packages
+             (string-match "\\`[[:space:]]*-[[:space:]]*['\"]?\\([^'\"#]+?\\)['\"]?[[:space:]]*\\'" line))
+        (push (match-string 1 line) patterns))))
+    (nreverse patterns)))
+
+(defun projectile--npm-workspace-patterns (file)
+  "Return the `workspaces' globs declared by the package.json at FILE.
+Both the plain array form and the `{\"packages\": [...]}' form yarn uses
+are understood."
+  (when (fboundp 'json-parse-string)
+    (let* ((json (ignore-errors
+                   (json-parse-string (projectile--file-contents file)
+                                      :object-type 'alist
+                                      :array-type 'list)))
+           (workspaces (alist-get 'workspaces json)))
+      (cond
+       ((and (listp workspaces) (stringp (car workspaces))) workspaces)
+       ((listp workspaces) (alist-get 'packages workspaces))))))
+
+(defun projectile--toml-string-array (text key)
+  "Return the strings of the TOML array assigned to KEY in TEXT, or nil.
+Comments are stripped first, so the `# Internal' notes Cargo manifests
+carry inside their member list don't end up in the result."
+  (when (string-match (concat "^[[:space:]]*" (regexp-quote key)
+                              "[[:space:]]*=[[:space:]]*\\[\\(\\(?:.\\|\n\\)*?\\)\\]")
+                      text)
+    (let ((body (replace-regexp-in-string "#[^\n]*" "" (match-string 1 text)))
+          (out nil)
+          (start 0))
+      (while (string-match "\"\\([^\"]*\\)\"" body start)
+        (push (match-string 1 body) out)
+        (setq start (match-end 0)))
+      (nreverse out))))
+
+(defun projectile--cargo-workspace-patterns (file)
+  "Return the `[workspace]' members declared by the Cargo manifest at FILE.
+`exclude' entries are removed, so a fuzzing crate the workspace keeps out
+of the build is not reported as a member."
+  (let* ((text (projectile--file-contents file))
+         (members (projectile--toml-string-array text "members"))
+         (excluded (projectile--toml-string-array text "exclude")))
+    (seq-remove (lambda (m) (member m excluded)) members)))
+
+(defun projectile--go-work-patterns (file)
+  "Return the module directories a Go workspace file FILE puts to use.
+Both the parenthesised `use (...)' block and single-line `use ./dir' are
+understood."
+  (let ((text (projectile--file-contents file))
+        (out nil))
+    (when (string-match "use[[:space:]]*(\\([^)]*\\))" text)
+      (dolist (line (split-string (match-string 1 text) "\n" t))
+        (let ((entry (string-trim (replace-regexp-in-string "//.*" "" line))))
+          (unless (string-empty-p entry) (push entry out)))))
+    (let ((start 0))
+      (while (string-match "^[[:space:]]*use[[:space:]]+\\([^(\n]+\\)$" text start)
+        (push (string-trim (match-string 1 text)) out)
+        (setq start (match-end 0))))
+    (nreverse out)))
+
+(defun projectile-subprojects-from-manifest (root)
+  "Return the subprojects ROOT's workspace manifest declares, or nil.
+
+The member list a workspace declares is the workspace's own answer to
+what its parts are, so it is preferred over looking for manifests: it
+leaves out the ones that are deliberately not members - test fixtures
+carrying a package.json, a scaffolding template, an excluded fuzzing
+crate - which scanning cannot tell apart from the real thing."
+  (when-let* ((patterns (projectile--workspace-member-patterns root)))
+    (projectile--expand-member-globs root patterns)))
+
+(defun projectile-subprojects-from-scan (root)
+  "Return the directories below ROOT that hold a project manifest.
+
+What counts as a manifest comes from `projectile-subproject-markers'.
+The file listing of ROOT is what gets scanned, so the ignore rules apply
+as usual - the manifest of a vendored dependency does not turn it into a
+subproject.
+
+This finds every manifest there is, which is the right answer when
+nothing declares the members and too generous when something does; see
+`projectile-subprojects-from-manifest'."
+  (let* ((markers (projectile--subproject-markers))
          (marker-set (make-hash-table :test 'equal))
          (dirs (make-hash-table :test 'equal)))
     (dolist (marker markers)
@@ -12295,6 +12440,19 @@ into a subproject."
         (when-let* ((dir (file-name-directory file)))
           (puthash dir t dirs))))
     (sort (hash-table-keys dirs) #'string<)))
+
+(defun projectile-project-subprojects (&optional project-root)
+  "Return the subprojects of the project at PROJECT-ROOT.
+
+A subproject is a part of a monorepo that has a project of its own - a
+crate, a package, a module.  The result is a sorted list of directory
+names relative to the root, each ending in a slash.
+
+Where the list comes from is `projectile-subproject-functions': by
+default the workspace manifest if there is one Projectile can read, and
+otherwise a scan for manifests."
+  (let ((root (or project-root (projectile-acquire-root))))
+    (run-hook-with-args-until-success 'projectile-subproject-functions root)))
 
 (defun projectile-subproject-type (&optional subproject-root)
   "Return the project type of the subproject at SUBPROJECT-ROOT.

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -821,6 +821,77 @@
     (let ((projectile-subproject-markers '("Cargo.toml")))
       (expect (projectile-project-subprojects "/proj/") :to-equal '("crates/parser/")))))
 
+(describe "projectile-subprojects-from-manifest"
+  (it "reads the members a pnpm workspace declares"
+    (projectile-test-with-sandbox
+      (projectile-test-with-files
+          ("repo/packages/core/" "repo/packages/runtime/" "repo/tools/scratch/")
+        (with-temp-file "repo/pnpm-workspace.yaml"
+          (insert "packages:\n  - 'packages/*'\n\ncatalog:\n  vite: ^8.0.0\n"))
+        (let ((repo (file-truename (expand-file-name "repo/"))))
+          ;; `tools/scratch/' is not a member, and the `catalog:' key that
+          ;; follows the list must not be read as one either
+          (expect (projectile-subprojects-from-manifest repo)
+                  :to-equal '("packages/core/" "packages/runtime/"))))))
+
+  (it "reads the workspaces a package.json declares, globs and literals alike"
+    (projectile-test-with-sandbox
+      (projectile-test-with-files
+          ("repo/packages/a/" "repo/packages/b/" "repo/benchmark/" "repo/other/")
+        (with-temp-file "repo/package.json"
+          (insert "{\"workspaces\": [\"packages/*\", \"benchmark\"]}"))
+        (let ((repo (file-truename (expand-file-name "repo/"))))
+          (expect (projectile-subprojects-from-manifest repo)
+                  :to-equal '("benchmark/" "packages/a/" "packages/b/"))))))
+
+  (it "drops the crates a Cargo workspace excludes"
+    (projectile-test-with-sandbox
+      (projectile-test-with-files
+          ("repo/core/" "repo/util/" "repo/fuzz/")
+        (with-temp-file "repo/Cargo.toml"
+          (insert "[workspace]\nmembers = [\n  \"core\",\n  # internal\n  \"util\",\n]\n"
+                  "exclude = [\"fuzz\"]\n"))
+        (let ((repo (file-truename (expand-file-name "repo/"))))
+          ;; the comment inside the array is not a member, and `fuzz' is
+          ;; deliberately kept out of the workspace
+          (expect (projectile-subprojects-from-manifest repo)
+                  :to-equal '("core/" "util/"))))))
+
+  (it "has no answer when the members are not declared statically"
+    ;; Gradle builds its module list in a Kotlin program and Bazel in
+    ;; Starlark; neither can be read without running the tool, so the scan
+    ;; has to stay the fallback.
+    (projectile-test-with-sandbox
+      (projectile-test-with-files
+          ("repo/settings.gradle.kts" "repo/documentation/build.gradle.kts")
+        (let ((repo (file-truename (expand-file-name "repo/"))))
+          (expect (projectile-subprojects-from-manifest repo) :to-be nil))))))
+
+(describe "projectile-project-subprojects"
+  (it "prefers the declared members over a scan for manifests"
+    (projectile-test-with-sandbox
+      (projectile-test-with-files
+          ("repo/.projectile" "repo/packages/a/package.json"
+           "repo/test/fixtures/broken/package.json")
+        (with-temp-file "repo/package.json"
+          (insert "{\"workspaces\": [\"packages/*\"]}"))
+        (let ((repo (file-truename (expand-file-name "repo/"))))
+          (spy-on 'projectile-project-root :and-return-value repo)
+          ;; the fixture carries a package.json but is not a member
+          (expect (projectile-project-subprojects repo)
+                  :to-equal '("packages/a/"))
+          (expect (projectile-subprojects-from-scan repo)
+                  :to-contain "test/fixtures/broken/")))))
+
+  (it "falls back to scanning when nothing declares the members"
+    (projectile-test-with-sandbox
+      (projectile-test-with-files
+          ("repo/.projectile" "repo/settings.gradle.kts"
+           "repo/mod/pom.xml")
+        (let ((repo (file-truename (expand-file-name "repo/"))))
+          (spy-on 'projectile-project-root :and-return-value repo)
+          (expect (projectile-project-subprojects repo) :to-equal '("mod/")))))))
+
 (describe "projectile-find-file-in-subproject"
   (it "completes over just the chosen subproject's files, from the project's listing"
     (spy-on 'projectile-acquire-root :and-return-value "/proj/")

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -875,7 +875,11 @@
            "repo/test/fixtures/broken/package.json")
         (with-temp-file "repo/package.json"
           (insert "{\"workspaces\": [\"packages/*\"]}"))
-        (let ((repo (file-truename (expand-file-name "repo/"))))
+        (let ((repo (file-truename (expand-file-name "repo/")))
+              (projectile-indexing-method 'native)
+              (projectile-projects-cache (make-hash-table :test 'equal))
+              (projectile-projects-cache-time (make-hash-table :test 'equal))
+              (projectile-enable-caching nil))
           (spy-on 'projectile-project-root :and-return-value repo)
           ;; the fixture carries a package.json but is not a member
           (expect (projectile-project-subprojects repo)
@@ -888,7 +892,11 @@
       (projectile-test-with-files
           ("repo/.projectile" "repo/settings.gradle.kts"
            "repo/mod/pom.xml")
-        (let ((repo (file-truename (expand-file-name "repo/"))))
+        (let ((repo (file-truename (expand-file-name "repo/")))
+              (projectile-indexing-method 'native)
+              (projectile-projects-cache (make-hash-table :test 'equal))
+              (projectile-projects-cache-time (make-hash-table :test 'equal))
+              (projectile-enable-caching nil))
           (spy-on 'projectile-project-root :and-return-value repo)
           (expect (projectile-project-subprojects repo) :to-equal '("mod/")))))))
 


### PR DESCRIPTION
Scanning for manifests finds every one there is, which is more than a workspace has members. Babel declares 162 packages but holds 205 directories with a `package.json` - the surplus is test fixtures. Tokio's fuzzing crates are excluded from its workspace on purpose and got reported anyway.

Where a repository declares its members in a form readable without running the build tool - pnpm, npm/yarn/bun, Cargo, `go.work` - that list is used instead. Against the real repos the result matches each tool's own answer exactly: babel 162, vue 17, tokio 10.

The scan stays as the fallback rather than being retired. Gradle assembles its module list in a Kotlin program and Bazel in Starlark, so neither can be parsed statically - junit-framework is the case in point, with no declared list and 21 subprojects found by scanning. `projectile-subproject-functions` is the seam, tried in order until one answers.