### PR TITLE
Throttle the redraw while search results stream in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Changes
 
 - [#2160](https://github.com/bbatsov/projectile/pull/2160): `projectile-switch-sibling-project` moved from `s-p n` to `s-p n p`. `s-p n` is now the prefix for every command that works across related projects, with each key mirroring the project-wide one a level down, the way `c m` does for subprojects.
+- [#2168](https://github.com/bbatsov/projectile/pull/2168): Search results are redrawn at most every `projectile-search-render-interval` while streaming, instead of on every chunk. The buffer is redrawn from scratch, so drawing per chunk cost roughly chunks times matches - two thirds of a sibling-group search went on redrawing. A search across 18 projects drops from 0.32s to 0.18s, and across 122 from 4.8s to 2.8s.
 - [#2164](https://github.com/bbatsov/projectile/pull/2164): A search across several projects now uses ripgrep, one run per project, instead of falling back to the Emacs Lisp scanner. The candidate file list is also only computed when something is going to scan it, so the ripgrep path no longer pays for a directory walk it never reads.
 
 ### Bugs fixed

--- a/doc/modules/ROOT/pages/configuration_index.adoc
+++ b/doc/modules/ROOT/pages/configuration_index.adoc
@@ -281,6 +281,9 @@ and the other reference pages.
 | `projectile-search-max-matches`
 | Upper bound on how many matches a review buffer collects.
 
+| `projectile-search-render-interval`
+| Seconds to leave between redraws while search results stream in.
+
 | `projectile-search-scan-chunk-size`
 | Number of candidate files scanned per async chunk before yielding.
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -318,6 +318,13 @@ new scan (kbd:[g], kbd:[c], kbd:[x]) first cancels any in-flight one. Set
 `projectile-search-async` to nil to force the old synchronous single-pass
 scan instead; batch (`noninteractive`) runs always scan synchronously.
 
+The buffer is redrawn from scratch each time, so a redraw costs time in
+proportion to the matches found so far - which is why redrawing is throttled
+to `projectile-search-render-interval` (a tenth of a second by default) while
+results stream in rather than happening on every chunk. The redraw that
+settles a finished scan is unconditional, so throttling only ever delays an
+intermediate state. Set the option to nil to redraw on every chunk.
+
 kbd:[!] applies the enabled matches with no external dependency. If you'd
 rather edit the results as text, kbd:[e] exports the enabled matches (the
 same set kbd:[!] would act on) to a `+*projectile-grep*+` buffer in `grep-mode`,

--- a/projectile.el
+++ b/projectile.el
@@ -9454,6 +9454,26 @@ often; smaller values keep Emacs more responsive."
   enabled)    ; non-nil when the match will be applied
 
 ;; Buffer-local state of a `*projectile-replace*' buffer.
+(defcustom projectile-search-render-interval 0.1
+  "Seconds to leave between redraws while search results stream in.
+
+The results buffer is redrawn from scratch, so a redraw costs time
+proportional to the matches found so far - about 1 ms at a hundred
+matches and 70 ms at five thousand.  Redrawing on every chunk therefore
+costs roughly the number of chunks times the number of matches, which on
+a large search is most of the run rather than a detail of it.
+
+The redraw at the end of a scan is unconditional, so this only delays
+intermediate states.  Set it to nil to redraw on every chunk."
+  :group 'projectile
+  :type '(choice (const :tag "Redraw on every chunk" nil)
+                 (number :tag "Seconds between redraws"))
+  :package-version '(projectile . "3.5.0"))
+
+(defvar-local projectile-replace--last-render 0.0
+  "When this results buffer was last redrawn, as a `float-time'.
+Zero in a freshly seeded buffer, so the first chunk always draws.")
+
 (defvar-local projectile-replace--root nil
   "Directory the current results buffer's file names are shown relative to.
 For an ordinary search that is the project root; for a search over a
@@ -9774,7 +9794,7 @@ killed BUFFER (leaving no work behind) and against \\`C-g' during a chunk
                       (run-with-timer 0 nil
                                       #'projectile-replace--scan-step
                                       buffer remaining regexp budget on-done generation))
-                (funcall projectile-replace--render-function))
+                (projectile-replace--render-progress))
             ;; finished (or budget-truncated): settle and hand off
             (with-current-buffer buffer
               (setq projectile-replace--scanning nil
@@ -10781,7 +10801,7 @@ finish the scan."
           (when new
             (setq projectile-replace--matches
                   (append projectile-replace--matches new)))
-          (funcall projectile-replace--render-function)
+          (projectile-replace--render-progress)
           projectile-replace--truncated)))))
 
 (defun projectile-search--rg-finish (buffer on-done)
@@ -10926,6 +10946,18 @@ might take either path therefore pass a function, so the walk - which
 shells out per project - is paid for only when something is going to scan
 its result."
   (if (functionp candidates) (funcall candidates) candidates))
+
+(defun projectile-replace--render-progress ()
+  "Redraw the current results buffer, subject to throttling.
+Redraws no more often than `projectile-search-render-interval'.  For use
+while a scan is streaming; the redraw that settles a finished scan is
+unconditional, so a skipped intermediate draw is never the last word."
+  (let ((now (float-time)))
+    (when (or (null projectile-search-render-interval)
+              (>= (- now projectile-replace--last-render)
+                  projectile-search-render-interval))
+      (setq projectile-replace--last-render now)
+      (funcall projectile-replace--render-function))))
 
 (defun projectile-replace--start (buffer candidates regexp on-done)
   "Fill BUFFER's match list by scanning CANDIDATES for REGEXP.

--- a/test/projectile-search-review-test.el
+++ b/test/projectile-search-review-test.el
@@ -555,6 +555,59 @@ REGEXP-P selects `projectile-search-regexp-review'."
         (expect 'projectile-search--gather-rg :not :to-have-been-called)
         (expect 'projectile-replace--gather-async :to-have-been-called)))))
 
+(describe "projectile-replace--render-progress"
+  ;; The results buffer is redrawn from scratch, so a redraw costs time
+  ;; proportional to the matches found so far; drawing on every chunk of a
+  ;; streaming scan is most of the run on a large search.
+  (before-each
+    (set-buffer (get-buffer-create projectile-search-buffer-name))
+    (projectile-replace--seed (current-buffer) #'projectile-search-mode
+                              default-directory "foo" "foo" nil t t)
+    (spy-on 'projectile-search--render))
+
+  (it "draws the first time, since a fresh buffer has never been drawn"
+    (let ((projectile-search-render-interval 3600))
+      (projectile-replace--render-progress)
+      (expect 'projectile-search--render :to-have-been-called-times 1)))
+
+  (it "suppresses a redraw that comes too soon after the last"
+    (let ((projectile-search-render-interval 3600))
+      (projectile-replace--render-progress)
+      (projectile-replace--render-progress)
+      (projectile-replace--render-progress)
+      (expect 'projectile-search--render :to-have-been-called-times 1)))
+
+  (it "draws again once the interval has passed"
+    (let ((projectile-search-render-interval 0.05))
+      (projectile-replace--render-progress)
+      ;; rather than sleeping, age the buffer's last-draw stamp
+      (setq projectile-replace--last-render (- (float-time) 10))
+      (projectile-replace--render-progress)
+      (expect 'projectile-search--render :to-have-been-called-times 2)))
+
+  (it "draws on every call when the interval is nil"
+    (let ((projectile-search-render-interval nil))
+      (dotimes (_ 5) (projectile-replace--render-progress))
+      (expect 'projectile-search--render :to-have-been-called-times 5))))
+
+(describe "streaming redraw throttling"
+  (it "always redraws when a scan finishes, however long the interval"
+    (assume (executable-find "rg") "ripgrep is not installed")
+    (projectile-test-with-project
+        (("a.txt" . "foo bar\n"))
+      (let* ((projectile-search-render-interval 3600)
+             (buf (get-buffer-create projectile-search-buffer-name)))
+        (projectile-replace--seed buf #'projectile-search-mode
+                                  default-directory "foo" "foo" nil t t)
+        (projectile-search--gather-rg buf "foo" nil)
+        (projectile-search-review-test--wait buf)
+        (with-current-buffer buf
+          ;; the redraw that settles a finished scan is unconditional, so a
+          ;; long interval cannot leave the buffer showing an empty result
+          (expect projectile-replace--scanning :to-be nil)
+          (expect (buffer-string) :to-match "a\\.txt")
+          (expect (buffer-string) :to-match "foo bar"))))))
+
 (describe "projectile-search-review ripgrep end-to-end"
   (it "finds matches with a correct character column on a multibyte line"
     (assume (executable-find "rg") "ripgrep is not installed")


### PR DESCRIPTION
The results buffer is redrawn from scratch, so one redraw costs time in proportion to the matches found so far - roughly 1 ms at a hundred matches, 70 ms at five thousand. Both engines redrew on every chunk, making the total about chunks times matches.

Measured here: a literal search over an 18-project sibling group spent **0.21s of its 0.32s** redrawing, across 54 draws; over 122 projects, **2.15s of 4.80s** across 293. With a tenth-of-a-second floor between draws those become 0.18s / 4 draws and 2.84s / 19 - same 1262 and 5000 matches.

The redraw that settles a finished scan stays unconditional, so throttling only ever delays an intermediate state. `projectile-search-render-interval` set to nil restores drawing on every chunk.