### PR TITLE
Save sessions automatically by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Changes
 
+- [#2179](https://github.com/bbatsov/projectile/pull/2179): `projectile-session-autosave` now defaults to `t`. `projectile-session-restore-on-switch` reads what autosave writes, so with the save off by default `projectile-session-mode` restored layouts it had never recorded and did nothing until you saved one by hand.
 - [#2160](https://github.com/bbatsov/projectile/pull/2160): `projectile-switch-sibling-project` moved from `s-p n` to `s-p n p`. `s-p n` is now the prefix for every command that works across related projects, with each key mirroring the project-wide one a level down, the way `c m` does for subprojects.
 - [#2168](https://github.com/bbatsov/projectile/pull/2168): Search results are redrawn at most every `projectile-search-render-interval` while streaming, instead of on every chunk. The buffer is redrawn from scratch, so drawing per chunk cost roughly chunks times matches - two thirds of a sibling-group search went on redrawing. A search across 18 projects drops from 0.32s to 0.18s, and across 122 from 4.8s to 2.8s.
 - [#2164](https://github.com/bbatsov/projectile/pull/2164): A search across several projects now uses ripgrep, one run per project, instead of falling back to the Emacs Lisp scanner. The candidate file list is also only computed when something is going to scan it, so the ripgrep path no longer pays for a directory walk it never reads.

--- a/doc/modules/ROOT/pages/sessions.adoc
+++ b/doc/modules/ROOT/pages/sessions.adoc
@@ -90,14 +90,17 @@ With `projectile-session-restore-on-switch` (on by default), switching to a
 project that has no open tab but does have a saved session restores that
 session instead of running `projectile-session-default-action`.
 
-Set `projectile-session-autosave` to save automatically: the outgoing
-project's session is saved when you switch away from it, and every open
-project's session is saved when Emacs exits. Layouts with no serializable
-buffer are skipped.
+`projectile-session-autosave` (on by default) does the saving for you: the
+outgoing project's session is saved when you switch away from it, and every
+open project's session is saved when Emacs exits. Layouts with no
+serializable buffer are skipped. It's what gives
+`projectile-session-restore-on-switch` something to restore, so turn it off
+only if you'd rather pick which layouts are worth keeping and save those
+yourself.
 
 [source,elisp]
 ----
-(setq projectile-session-autosave t)
+(setq projectile-session-autosave nil)
 ----
 
 === Restoring every session at once

--- a/projectile.el
+++ b/projectile.el
@@ -17783,14 +17783,19 @@ mode *after* Emacs has finished starting never triggers a restore."
   :type 'boolean
   :package-version '(projectile . "3.2.0"))
 
-(defcustom projectile-session-autosave nil
+(defcustom projectile-session-autosave t
   "Whether `projectile-session-mode' saves sessions automatically.
-When non-nil, the outgoing project's session is saved when you switch
-away from it, and every open project's session is saved when Emacs exits.
-Degenerate layouts with no serializable buffer are skipped."
+When non-nil (the default), the outgoing project's session is saved when
+you switch away from it, and every open project's session is saved when
+Emacs exits.  Degenerate layouts with no serializable buffer are skipped.
+
+Sessions are what `projectile-session-restore-on-switch' reads, so with
+this off the mode restores layouts it never records: nothing comes back
+until you save one yourself with `projectile-session-save'.  Turn it off
+if you would rather decide which layouts are worth keeping."
   :group 'projectile
   :type 'boolean
-  :package-version '(projectile . "3.2.0"))
+  :package-version '(projectile . "3.5.0"))
 
 (defcustom projectile-session-buffer-serializers
   '((dired-mode

--- a/test/projectile-session-test.el
+++ b/test/projectile-session-test.el
@@ -704,6 +704,15 @@ everything that runs afterwards - see `dev/buffer-leaks.el'."
                                  projectile-before-switch-project-hook)))
               :to-equal 1)))
 
+  (it "ships defaults that record the sessions they restore"
+    ;; `projectile-session-restore-on-switch' reads what autosave writes.
+    ;; Shipping the restore on and the save off left the mode restoring
+    ;; layouts it had never recorded, so it did nothing until you saved
+    ;; one by hand.
+    (expect (or (not (default-value 'projectile-session-restore-on-switch))
+                (default-value 'projectile-session-autosave))
+            :to-be-truthy))
+
   (it "autosaves the outgoing project only when enabled"
     (let ((projectile-session-autosave nil))
       (spy-on 'projectile-session-save)


### PR DESCRIPTION
`projectile-session-restore-on-switch` has always been on, and it reads what autosave writes. With autosave defaulting to nil, enabling `projectile-session-mode` gave you a mode that restores layouts it never records, so nothing came back until you ran `projectile-session-save` by hand.

Enabling the mode is already an opt-in to session management, so let it manage sessions. Restoring at startup stays off by default, since that rebuilds everything at launch rather than when you ask for a project.
