### PR TITLE
Let every shell backend open in another window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New features
 
+- [#2180](https://github.com/bbatsov/projectile/pull/2180): Every shell backend can now open in another window (`s-p x 4 <key>`), not just vterm, eat and ghostel: `shell`, `eshell`, `ielm`, `term` and the backend-dispatching `projectile-run` gained `-other-window` commands.
 - [#2160](https://github.com/bbatsov/projectile/pull/2160): Add `projectile-find-file-in-sibling-projects` (`s-p n f`) and `projectile-search-in-sibling-projects` (`s-p n s`), which work across the family of related projects rather than just the one you're in.
   - Both are built on `projectile-find-file-in-projects` and `projectile-search-in-projects`, which take any list of projects, so a command for a group of your own is a two-line wrapper.
   - A group search puts every match in one `*projectile-search*` buffer, named relative to the directory containing the group, so each one is labelled with the project it came from.

--- a/doc/modules/ROOT/pages/cheatsheet.adoc
+++ b/doc/modules/ROOT/pages/cheatsheet.adoc
@@ -295,6 +295,9 @@ Here's a list of the interactive Emacs Lisp functions, provided by Projectile:
 | kbd:[s-p x G]
 | Start or visit a `ghostel` terminal for the project.
 
+| kbd:[s-p x 4 <key>]
+| Any of the above in another window, e.g. kbd:[s-p x 4 s] for a `shell`. Every backend supports this except `gdb`.
+
 | kbd:[s-p B s]
 | Set a bookmark at point, named after the current project.
 

--- a/projectile.el
+++ b/projectile.el
@@ -8844,40 +8844,59 @@ Projectile project too when `projectile-mode' is enabled."
 
 ;;;; Engines for the built-in shells (always available)
 
-(defun projectile--run-shell (new-process &optional _other-window)
+(defmacro projectile--displaying-in-other-window (other-window &rest body)
+  "Run BODY, popping whatever buffer it displays elsewhere when OTHER-WINDOW.
+
+The built-in shells (`shell', `eshell', `ielm') display their buffer
+themselves and have no `-other-window' flavour to call, the way `vterm'
+and `eat' do.  They all go through `display-buffer' though, and
+`display-buffer-overriding-action' outranks the action they pass, so
+binding it around the call is what redirects them."
+  (declare (indent 1) (debug t))
+  `(let ((display-buffer-overriding-action
+          (when ,other-window
+            '((display-buffer-pop-up-window) (inhibit-same-window . t)))))
+     ,@body))
+
+(defun projectile--run-shell (new-process &optional other-window)
   "Invoke `shell' in the project's root.
 NEW-PROCESS forces creation of a new process instead of reusing an
-existing buffer."
+existing buffer.  OTHER-WINDOW displays it in another window."
   (let ((project (projectile-acquire-root)))
     (projectile-with-default-dir project
-      (shell (projectile-generate-process-name "shell" new-process project)))))
+      (projectile--displaying-in-other-window other-window
+        (shell (projectile-generate-process-name "shell" new-process project))))))
 
-(defun projectile--run-eshell (new-process &optional _other-window)
+(defun projectile--run-eshell (new-process &optional other-window)
   "Invoke `eshell' in the project's root.
 NEW-PROCESS forces creation of a new process instead of reusing an
-existing buffer."
+existing buffer.  OTHER-WINDOW displays it in another window."
   (let ((project (projectile-acquire-root)))
     (projectile-with-default-dir project
       (let ((eshell-buffer-name (projectile-generate-process-name "eshell" new-process project)))
-        (eshell)))))
+        (projectile--displaying-in-other-window other-window
+          (eshell))))))
 
-(defun projectile--run-ielm (new-process &optional _other-window)
+(defun projectile--run-ielm (new-process &optional other-window)
   "Invoke `ielm' in the project's root.
 NEW-PROCESS forces creation of a new process instead of reusing an
-existing buffer."
+existing buffer.  OTHER-WINDOW displays it in another window."
   (let* ((project (projectile-acquire-root))
          (ielm-buffer-name (projectile-generate-process-name "ielm" new-process project)))
     (if (get-buffer ielm-buffer-name)
-        (switch-to-buffer ielm-buffer-name)
+        (if other-window
+            (switch-to-buffer-other-window ielm-buffer-name)
+          (switch-to-buffer ielm-buffer-name))
       (projectile-with-default-dir project
-        (ielm))
+        (projectile--displaying-in-other-window other-window
+          (ielm)))
       ;; ielm's buffer name is hardcoded, so we have to rename it after creation
       (rename-buffer ielm-buffer-name))))
 
-(defun projectile--run-term (new-process &optional _other-window)
+(defun projectile--run-term (new-process &optional other-window)
   "Invoke `term' in the project's root.
 NEW-PROCESS forces creation of a new process instead of reusing an
-existing buffer."
+existing buffer.  OTHER-WINDOW displays it in another window."
   (let* ((project (projectile-acquire-root))
          (buffer-name (projectile-generate-process-name "term" new-process project))
          (default-program (or explicit-shell-file-name
@@ -8891,7 +8910,9 @@ existing buffer."
           (set-buffer (term-ansi-make-term buffer-name program))
           (term-mode)
           (term-char-mode))))
-    (switch-to-buffer buffer-name)))
+    (if other-window
+        (switch-to-buffer-other-window buffer-name)
+      (switch-to-buffer buffer-name))))
 
 ;;;; Engines for the package-backed terminals
 
@@ -9021,12 +9042,27 @@ one."
   (interactive "P")
   (projectile--run projectile-shell-backend arg nil))
 
+;;;###autoload (autoload 'projectile-run-other-window "projectile" nil t)
+(projectile--define-display-variants projectile-run (&optional arg)
+  "Run a shell, REPL or terminal in the project root, in another %s.
+The backend is chosen the same way `projectile-run' chooses it.  With a
+prefix ARG, start a fresh process instead of reusing an existing one."
+  :places (window)
+  (projectile--run projectile-shell-backend arg t))
+
 ;;;###autoload
 (defun projectile-run-shell (&optional arg)
   "Invoke `shell' in the project's root (the shell `projectile-run' backend).
 Use a prefix argument ARG to indicate creation of a new process instead."
   (interactive "P")
   (projectile--run 'shell arg nil))
+
+;;;###autoload (autoload 'projectile-run-shell-other-window "projectile" nil t)
+(projectile--define-display-variants projectile-run-shell (&optional arg)
+  "Invoke `shell' in the project's root, displayed in another %s.
+Use a prefix argument ARG to indicate creation of a new process instead."
+  :places (window)
+  (projectile--run 'shell arg t))
 
 ;;;###autoload
 (defun projectile-run-eshell (&optional arg)
@@ -9035,6 +9071,13 @@ Use a prefix argument ARG to indicate creation of a new process instead."
   (interactive "P")
   (projectile--run 'eshell arg nil))
 
+;;;###autoload (autoload 'projectile-run-eshell-other-window "projectile" nil t)
+(projectile--define-display-variants projectile-run-eshell (&optional arg)
+  "Invoke `eshell' in the project's root, displayed in another %s.
+Use a prefix argument ARG to indicate creation of a new process instead."
+  :places (window)
+  (projectile--run 'eshell arg t))
+
 ;;;###autoload
 (defun projectile-run-ielm (&optional arg)
   "Invoke `ielm' in the project's root (the ielm `projectile-run' backend).
@@ -9042,12 +9085,26 @@ Use a prefix argument ARG to indicate creation of a new process instead."
   (interactive "P")
   (projectile--run 'ielm arg nil))
 
+;;;###autoload (autoload 'projectile-run-ielm-other-window "projectile" nil t)
+(projectile--define-display-variants projectile-run-ielm (&optional arg)
+  "Invoke `ielm' in the project's root, displayed in another %s.
+Use a prefix argument ARG to indicate creation of a new process instead."
+  :places (window)
+  (projectile--run 'ielm arg t))
+
 ;;;###autoload
 (defun projectile-run-term (&optional arg)
   "Invoke `term' in the project's root (the term `projectile-run' backend).
 Use a prefix argument ARG to indicate creation of a new process instead."
   (interactive "P")
   (projectile--run 'term arg nil))
+
+;;;###autoload (autoload 'projectile-run-term-other-window "projectile" nil t)
+(projectile--define-display-variants projectile-run-term (&optional arg)
+  "Invoke `term' in the project's root, displayed in another %s.
+Use a prefix argument ARG to indicate creation of a new process instead."
+  :places (window)
+  (projectile--run 'term arg t))
 
 ;;;###autoload
 (defun projectile-run-vterm (&optional arg)
@@ -17039,10 +17096,15 @@ Magit that don't trigger `find-file-hook'."
     (define-key map (kbd "c X") #'projectile-repeat-last-task)
     ;; integration with utilities
     (define-key map (kbd "x r") #'projectile-run)
+    (define-key map (kbd "x 4 r") #'projectile-run-other-window)
     (define-key map (kbd "x e") #'projectile-run-eshell)
+    (define-key map (kbd "x 4 e") #'projectile-run-eshell-other-window)
     (define-key map (kbd "x i") #'projectile-run-ielm)
+    (define-key map (kbd "x 4 i") #'projectile-run-ielm-other-window)
     (define-key map (kbd "x t") #'projectile-run-term)
+    (define-key map (kbd "x 4 t") #'projectile-run-term-other-window)
     (define-key map (kbd "x s") #'projectile-run-shell)
+    (define-key map (kbd "x 4 s") #'projectile-run-shell-other-window)
     (define-key map (kbd "x g") #'projectile-run-gdb)
     (define-key map (kbd "x v") #'projectile-run-vterm)
     (define-key map (kbd "x 4 v") #'projectile-run-vterm-other-window)

--- a/test/projectile-commands-test.el
+++ b/test/projectile-commands-test.el
@@ -624,12 +624,55 @@
     (expect (fboundp 'projectile-run-eat-other-frame) :to-be nil)
     (expect (fboundp 'projectile-run-ghostel-other-frame) :to-be nil))
 
+  (it "every shell backend has an other-window command that asks for one"
+    ;; The built-in shells used to ignore the flag, so only the three
+    ;; package-backed terminals had a variant at all.
+    (spy-on 'projectile--run)
+    (dolist (backend '(shell eshell ielm term vterm eat ghostel))
+      (let ((cmd (intern (format "projectile-run-%s-other-window" backend))))
+        (expect (commandp cmd) :to-be-truthy)
+        (funcall cmd)
+        (expect 'projectile--run :to-have-been-called-with backend nil t))))
+
+  (it "projectile-run itself gets one, dispatching through the configured backend"
+    (spy-on 'projectile--run)
+    (let ((projectile-shell-backend 'eshell))
+      (projectile-run-other-window)
+      (expect 'projectile--run :to-have-been-called-with 'eshell nil t)))
+
   (it "the generated variants are interactive and take the prefix argument"
     (expect (commandp #'projectile-find-file-other-window) :to-be-truthy)
     (expect (interactive-form 'projectile-find-file-other-frame)
             :to-equal '(interactive "P"))
     (expect (cadr (interactive-form 'projectile-switch-to-buffer-other-window))
             :to-be nil)))
+
+(describe "projectile--displaying-in-other-window"
+  ;; `shell', `eshell' and `ielm' display their own buffer and have no
+  ;; `-other-window' flavour to call, so the flag is honoured by overriding
+  ;; the display action they pass rather than by picking a different command.
+  (it "redirects a same-window pop into another window"
+    (let ((buf (get-buffer-create " *projectile-ow-probe*")))
+      (unwind-protect
+          (save-current-buffer
+            (save-window-excursion
+              (delete-other-windows)
+              (projectile--displaying-in-other-window t
+                (pop-to-buffer-same-window buf))
+              (expect (> (length (window-list)) 1) :to-be-truthy)
+              (expect (window-buffer) :to-be buf)))
+        (kill-buffer buf))))
+
+  (it "leaves the display alone when the flag is off"
+    (let ((buf (get-buffer-create " *projectile-ow-probe*")))
+      (unwind-protect
+          (save-current-buffer
+            (save-window-excursion
+              (delete-other-windows)
+              (projectile--displaying-in-other-window nil
+                (pop-to-buffer-same-window buf))
+              (expect (length (window-list)) :to-equal 1)))
+        (kill-buffer buf)))))
 
 (describe "projectile-other-window-command"
   ;; Tear down whatever the prefix command armed (the display override


### PR DESCRIPTION
Only vterm, eat and ghostel had an `-other-window` command, so the three third-party terminals were better served than the shells that ship with Emacs. The four built-in runners took the `OTHER-WINDOW` argument and ignored it, so there was nothing to build a variant on.

`term` just needed the branch on its final `switch-to-buffer`. `shell`, `eshell` and `ielm` display their own buffer and have no `-other-window` flavour to call, so they go through `display-buffer-overriding-action`, which outranks the action they pass. `projectile-run` gets a variant too, bound to `s-p x 4 r`.
