### PR TITLE
List ignored files for Sapling and Bazaar too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New features
 
+- [#2181](https://github.com/bbatsov/projectile/pull/2181): Sapling and Bazaar projects can now list their own ignored files, via the new `projectile-sapling-ignored-command` and `projectile-bzr-ignored-command`.
 - [#2180](https://github.com/bbatsov/projectile/pull/2180): Every shell backend can now open in another window (`s-p x 4 <key>`), not just vterm, eat and ghostel: `shell`, `eshell`, `ielm`, `term` and the backend-dispatching `projectile-run` gained `-other-window` commands.
 - [#2160](https://github.com/bbatsov/projectile/pull/2160): Add `projectile-find-file-in-sibling-projects` (`s-p n f`) and `projectile-search-in-sibling-projects` (`s-p n s`), which work across the family of related projects rather than just the one you're in.
   - Both are built on `projectile-find-file-in-projects` and `projectile-search-in-projects`, which take any list of projects, so a command for a group of your own is a two-line wrapper.

--- a/doc/modules/ROOT/pages/configuration_index.adoc
+++ b/doc/modules/ROOT/pages/configuration_index.adoc
@@ -47,6 +47,9 @@ and the other reference pages.
 | `projectile-bzr-command`
 | Command used by projectile to get the files in a bazaar project.
 
+| `projectile-bzr-ignored-command`
+| Command used by projectile to get the ignored files in a bazaar project.
+
 | `projectile-cache-file`
 | The name of Projectile’s cache.
 
@@ -271,6 +274,9 @@ and the other reference pages.
 
 | `projectile-sapling-command`
 | Command used by projectile to get the files in a Sapling project.
+
+| `projectile-sapling-ignored-command`
+| Command used by projectile to get the ignored files in a Sapling project.
 
 | `projectile-search-async`
 | Whether the reviewable search/replace commands scan asynchronously.

--- a/projectile.el
+++ b/projectile.el
@@ -1442,6 +1442,14 @@ back to running it as a shell command."
   :type 'string
   :package-version '(projectile . "2.9.0"))
 
+(defcustom projectile-sapling-ignored-command "sl status -in0 ."
+  "Command used by projectile to get the ignored files in a Sapling project.
+Sapling is a Mercurial fork and kept `status' flags, so this mirrors
+`projectile-hg-ignored-command'."
+  :group 'projectile
+  :type 'string
+  :package-version '(projectile . "3.5.0"))
+
 (defcustom projectile-fossil-command (concat "fossil ls | "
                                              (when (eq system-type 'windows-nt)
                                                "dos2unix | ")
@@ -1456,6 +1464,13 @@ back to running it as a shell command."
   :group 'projectile
   :type 'string
   :package-version '(projectile . "0.9.0"))
+
+(defcustom projectile-bzr-ignored-command "bzr ls -R --ignored -0"
+  "Command used by projectile to get the ignored files in a bazaar project.
+`--ignored' in place of the `--versioned' of `projectile-bzr-command'."
+  :group 'projectile
+  :type 'string
+  :package-version '(projectile . "3.5.0"))
 
 (defcustom projectile-darcs-command "darcs show files -0 ."
   "Command used by projectile to get the files in a darcs project."
@@ -3658,6 +3673,8 @@ sub-modules there)."
   (pcase vcs
     ('git projectile-git-ignored-command)
     ('hg projectile-hg-ignored-command)
+    ('sapling projectile-sapling-ignored-command)
+    ('bzr projectile-bzr-ignored-command)
     ('svn projectile-svn-ignored-command)
     (_ nil)))
 

--- a/test/projectile-ignore-test.el
+++ b/test/projectile-ignore-test.el
@@ -712,4 +712,23 @@
       (expect (string-match-p re "vendor/z.js") :to-be-truthy)
       (expect (string-match-p re "src/main.c") :not :to-be-truthy))))
 
+(describe "projectile-get-ext-ignored-command"
+  (it "knows the VCSes that can list their own ignored files"
+    (expect (projectile-get-ext-ignored-command 'git)
+            :to-equal projectile-git-ignored-command)
+    (expect (projectile-get-ext-ignored-command 'hg)
+            :to-equal projectile-hg-ignored-command)
+    (expect (projectile-get-ext-ignored-command 'sapling)
+            :to-equal projectile-sapling-ignored-command)
+    (expect (projectile-get-ext-ignored-command 'bzr)
+            :to-equal projectile-bzr-ignored-command)
+    (expect (projectile-get-ext-ignored-command 'svn)
+            :to-equal projectile-svn-ignored-command))
+
+  (it "returns nil for the ones with no way to list them"
+    ;; jj, fossil, darcs and pijul have no equivalent of `hg status -i',
+    ;; so the caller filters in Emacs Lisp instead.
+    (dolist (vcs '(jj fossil darcs pijul none))
+      (expect (projectile-get-ext-ignored-command vcs) :to-be nil))))
+
 ;;; projectile-ignore-test.el ends here


### PR DESCRIPTION
Projectile knows how to list the files of nine VCSes but could only ask three of them for their ignored files, so under hybrid indexing a Sapling or Bazaar project fell back to filtering in Emacs Lisp.

Both recipes are a one-flag change from that VCS's existing Projectile command: Sapling is a Mercurial fork that kept the `status` flags, and `bzr ls` takes `--ignored` where the file listing passes `--versioned`. jj, fossil, darcs and pijul still return nil, since none has an equivalent of `hg status -i`.

Worth flagging: neither `sl` nor `bzr` is installed here or in CI, so the recipes are reasoned from each VCS's existing Projectile command rather than exercised. The dispatch is covered by specs; the command strings themselves aren't.
